### PR TITLE
[KIECLOUD-6] set operator-sdk version to v0.0.6 for vendoring & stability

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -257,8 +257,7 @@
   revision = "072d1972d82ada59b68aed5e7c6ba93685edeb78"
 
 [[projects]]
-  branch = "master"
-  digest = "1:228bc59ce8dbf731012a1109c35db77dd0937fe1662b69153dfd2b40bb5c8a0b"
+  digest = "1:13c65466cd36dc25b8af03a7199879c304629545f19134425125fdef11b334f7"
   name = "github.com/operator-framework/operator-sdk"
   packages = [
     "pkg/k8sclient",
@@ -268,7 +267,8 @@
     "version",
   ]
   pruneopts = ""
-  revision = "9f22ed0a32e2c3209bf927428499014ed527e7d6"
+  revision = "cb89692cdd145f084798749c16baaf44a6e62cac"
+  version = "v0.0.6"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -13,8 +13,8 @@
 [[constraint]]
   name = "github.com/operator-framework/operator-sdk"
   # The version rule is used for a specific release and the master branch for in between releases.
-  branch = "master"
-  # version = "=v0.0.5"
+  # branch = "master"
+  version = "=v0.0.6"
 
 [[constraint]]
   name = "github.com/gobuffalo/packr"

--- a/cmd/rhpam-operator/main.go
+++ b/cmd/rhpam-operator/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"runtime"
+	"time"
 
 	"github.com/kiegroup/kie-cloud-operator/internal/app/handler"
 	"github.com/operator-framework/operator-sdk/pkg/sdk"
@@ -27,8 +28,8 @@ func main() {
 	if err != nil {
 		logrus.Fatalf("Failed to get watch namespace: %v", err)
 	}
-	resyncPeriod := 5
-	logrus.Infof("Watching %s of type %s in project %s, every %d seconds", resource, kind, namespace, resyncPeriod)
+	resyncPeriod := time.Duration(5) * time.Second
+	logrus.Infof("Watching %s of type %s in project %s, every %d seconds", resource, kind, namespace, (resyncPeriod / time.Second))
 	sdk.Watch(resource, kind, namespace, resyncPeriod)
 	sdk.Handle(handler.NewHandler())
 	sdk.Run(context.TODO())

--- a/deploy/trial-environment.yaml
+++ b/deploy/trial-environment.yaml
@@ -1,7 +1,7 @@
-apiVersion: "rhpam.redhat.com/v1alpha1"
-kind: "App"
+apiVersion: rhpam.redhat.com/v1alpha1
+kind: App
 metadata:
-  name: "trial-env"
+  name: trial-env
 spec:
   environment: trial-ephemeral
   console:


### PR DESCRIPTION
[KIECLOUD-6] Set operator-sdk version to v0.0.6 for vendoring & stability

Signed-off-by: tchughesiv <tchughesiv@gmail.com>