### PR TITLE
[KIECLOUD-17] fmt & generate automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,3 @@ In a project:
 # Clean up in the project:
 
     oc delete -f deploy/trial-environment.yaml
-    oc delete all --all

--- a/internal/app/handler/handler_test.go
+++ b/internal/app/handler/handler_test.go
@@ -5,8 +5,8 @@ import (
 	"github.com/openshift/api/apps/v1"
 	"github.com/operator-framework/operator-sdk/pkg/sdk"
 	"github.com/stretchr/testify/assert"
-	"reflect"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -76,7 +76,7 @@ func TestUnknownResourceTypeHandling(t *testing.T) {
 func TestTrialEnvironmentObjects(t *testing.T) {
 	cr := &v1.App{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:       "test-ns",
+			Namespace: "test-ns",
 		},
 		Spec: v1.AppSpec{
 			Environment: "trial-ephemeral",

--- a/internal/pkg/defaults/.packr/packr.go
+++ b/internal/pkg/defaults/.packr/packr.go
@@ -13,7 +13,7 @@ func main() {
 	b := builder.New(context.Background(), os.Args[1])
 	// b.Compress = true
 
-	fmt.Println("Generating Packr boxes")
+	fmt.Println("Generating packr boxes")
 
 	err := b.Run()
 	if err != nil {

--- a/internal/pkg/defaults/defaults.go
+++ b/internal/pkg/defaults/defaults.go
@@ -3,9 +3,9 @@ package defaults
 //go:generate sh -c "CGO_ENABLED=0 go run .packr/packr.go $PWD"
 
 import (
-	"github.com/kiegroup/kie-cloud-operator/pkg/apis/kiegroup/v1"
 	"github.com/ghodss/yaml"
 	"github.com/gobuffalo/packr"
+	"github.com/kiegroup/kie-cloud-operator/pkg/apis/kiegroup/v1"
 )
 
 func GetTrialEnvironment() v1.Environment {

--- a/internal/pkg/defaults/defaults_test.go
+++ b/internal/pkg/defaults/defaults_test.go
@@ -9,7 +9,7 @@ import (
 func TestLoadTrialEnvironment(t *testing.T) {
 	defer func() {
 		err := recover()
-		if (err != nil) {
+		if err != nil {
 			logrus.Error(err.(error))
 		}
 	}()

--- a/internal/pkg/kieserver/objects.go
+++ b/internal/pkg/kieserver/objects.go
@@ -1,11 +1,11 @@
 package kieserver
 
 import (
+	"github.com/imdario/mergo"
 	"github.com/kiegroup/kie-cloud-operator/internal/constants"
 	"github.com/kiegroup/kie-cloud-operator/internal/pkg/defaults"
 	"github.com/kiegroup/kie-cloud-operator/internal/pkg/shared"
 	opv1 "github.com/kiegroup/kie-cloud-operator/pkg/apis/kiegroup/v1"
-	"github.com/imdario/mergo"
 	"github.com/openshift/api/apps/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -16,10 +16,10 @@ func GetKieServer(cr *opv1.App) []runtime.Object {
 	_, serviceName, labels := shared.GetCommonLabels(cr, constants.KieServerServicePrefix)
 	image := shared.GetImage(cr.Spec.Server.Image, "rhpam70-kieserver-openshift")
 	resourceReqs := map[string]map[corev1.ResourceName]string{"Limits": {corev1.ResourceMemory: "220Mi"}, "Requests": {corev1.ResourceMemory: "220Mi"}}
-	livenessProbeInts := map[string]int{"InitialDelaySeconds": 180, "TimeoutSeconds": 2, "PeriodSeconds": 15,}
-	livenessProbeScript := map[string]string{"username": "adminUser", "password": "RedHat", "url": "http://localhost:8080/services/rest/server/healthcheck",}
-	readinessProbeInts := map[string]int{"InitialDelaySeconds": 60, "TimeoutSeconds": 2, "PeriodSeconds": 30, "FailureThreshold": 6,}
-	readinessProbeScript := map[string]string{"username": "adminUser", "password": "RedHat", "url": "http://localhost:8080/services/rest/server/readycheck",}
+	livenessProbeInts := map[string]int{"InitialDelaySeconds": 180, "TimeoutSeconds": 2, "PeriodSeconds": 15}
+	livenessProbeScript := map[string]string{"username": "adminUser", "password": "RedHat", "url": "http://localhost:8080/services/rest/server/healthcheck"}
+	readinessProbeInts := map[string]int{"InitialDelaySeconds": 60, "TimeoutSeconds": 2, "PeriodSeconds": 30, "FailureThreshold": 6}
+	readinessProbeScript := map[string]string{"username": "adminUser", "password": "RedHat", "url": "http://localhost:8080/services/rest/server/readycheck"}
 
 	dc := v1.DeploymentConfig{
 		TypeMeta:   shared.GetDeploymentTypeMeta(),

--- a/internal/pkg/rhpamcentr/objects.go
+++ b/internal/pkg/rhpamcentr/objects.go
@@ -1,11 +1,11 @@
 package rhpamcentr
 
 import (
+	"github.com/imdario/mergo"
 	"github.com/kiegroup/kie-cloud-operator/internal/constants"
 	"github.com/kiegroup/kie-cloud-operator/internal/pkg/defaults"
 	"github.com/kiegroup/kie-cloud-operator/internal/pkg/shared"
 	opv1 "github.com/kiegroup/kie-cloud-operator/pkg/apis/kiegroup/v1"
-	"github.com/imdario/mergo"
 	"github.com/openshift/api/apps/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/internal/pkg/shared/utils.go
+++ b/internal/pkg/shared/utils.go
@@ -1,8 +1,8 @@
 package shared
 
 import (
-	"github.com/kiegroup/kie-cloud-operator/pkg/apis/kiegroup/v1"
 	"github.com/imdario/mergo"
+	"github.com/kiegroup/kie-cloud-operator/pkg/apis/kiegroup/v1"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 )

--- a/tmp/build/build.sh
+++ b/tmp/build/build.sh
@@ -15,5 +15,6 @@ PROJECT_NAME="kie-cloud-operator"
 REPO_PATH="github.com/kiegroup/kie-cloud-operator"
 BUILD_PATH="${REPO_PATH}/cmd/${PROJECT_NAME}"
 echo "Building "${PROJECT_NAME}"..."
-go generate $REPO_PATH/internal/pkg/defaults
+go generate ${REPO_PATH}/...
+go fmt ${REPO_PATH}/...
 GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o ${BIN_DIR}/${PROJECT_NAME} $BUILD_PATH


### PR DESCRIPTION
[KIECLOUD-17] Standardize go format and generate

Automate `go fmt` & `go generate` for the code base at build time. Ensures differing formatting from IDE's aren't included in commit's.

Added commands to `tmp/build/build.sh` file which is executed during an `operator-sdk build quay.io/kiegroup/kie-cloud-operator`

Signed-off-by: tchughesiv <tchughesiv@gmail.com>