### PR TITLE
[KIECLOUD-47] First few steps towards a comprehensive merge framework

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -848,6 +848,7 @@
     "github.com/operator-framework/operator-sdk/pkg/k8sutil",
     "github.com/operator-framework/operator-sdk/version",
     "github.com/pavel-v-chernykh/keystore-go",
+    "github.com/pkg/errors",
     "github.com/sirupsen/logrus",
     "github.com/stretchr/testify/assert",
     "k8s.io/api/core/v1",

--- a/config/common/server.yaml
+++ b/config/common/server.yaml
@@ -1,0 +1,267 @@
+{{ range $index, $Map := .ServerCount }}
+persistentVolumeClaims:
+  - metadata:
+      name: "{{.ApplicationName}}-postgresql-claim-{{$index}}"
+      labels:
+        app: "{{.ApplicationName}}"
+        service: "{{.ApplicationName}}-postgresql-{{$index}}"
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: "1Gi"
+## PostgreSQL persistent volume claim END
+## KIE server deployment config BEGIN
+deploymentConfigs:
+  - metadata:
+      name: "{{.ApplicationName}}-kieserver-{{$index}}"
+      labels:
+        app: "{{.ApplicationName}}"
+    spec:
+      strategy:
+        type: Recreate
+      triggers:
+        - type: ImageChange
+          imageChangeParams:
+            automatic: true
+            containerNames:
+              - "{{.ApplicationName}}-kieserver"
+            from:
+              kind: ImageStreamTag
+              namespace: "openshift"
+              name: "rhpam{{.Version}}-kieserver-openshift:{{.ImageTag}}"
+        - type: ConfigChange
+      replicas: 3
+      selector:
+        deploymentConfig: "{{.ApplicationName}}-kieserver-{{$index}}"
+      template:
+        metadata:
+          name: "{{.ApplicationName}}-kieserverblh-{{$index}}"
+          labels:
+            deploymentConfig: "{{.ApplicationName}}-kieserver-{{$index}}"
+            app: "{{.ApplicationName}}"
+            service: "{{.ApplicationName}}-kieserver-{{$index}}"
+        spec:
+          serviceAccountName: "{{.ApplicationName}}-rhpamsvc"
+          terminationGracePeriodSeconds: 60
+          containers:
+            - name: "{{.ApplicationName}}-kieserver"
+              image: "rhpam{{.Version}}-kieserver-openshift"
+              imagePullPolicy: Always
+              resources:
+                requests:
+                  memory: 512Mi
+                limits:
+                  memory: 1Gi
+              volumeMounts:
+                - name: kieserver-keystore-volume
+                  mountPath: "/etc/kieserver-secret-volume"
+                  readOnly: true
+              livenessProbe:
+                exec:
+                  command:
+                    - "/bin/bash"
+                    - "-c"
+                    - curl --fail --silent -u adminUser:"$KIE_ADMIN_PWD" http://localhost:8080/services/rest/server/healthcheck
+                initialDelaySeconds: 180
+                timeoutSeconds: 2
+                periodSeconds: 15
+                failureThreshold: 3
+              readinessProbe:
+                exec:
+                  command:
+                    - "/bin/bash"
+                    - "-c"
+                    - curl --fail --silent -u adminUser:"$KIE_ADMIN_PWD" http://localhost:8080/services/rest/server/readycheck
+                initialDelaySeconds: 60
+                timeoutSeconds: 2
+                periodSeconds: 30
+                failureThreshold: 6
+              ports:
+                - name: jolokia
+                  containerPort: 8778
+                  protocol: TCP
+                - name: http
+                  containerPort: 8080
+                  protocol: TCP
+                - name: https
+                  containerPort: 8443
+                  protocol: TCP
+              env:
+              - name: KIE_ADMIN_USER
+                value: adminUser
+              - name: KIE_ADMIN_PWD
+                value: "{{.AdminPassword}}"
+              - name: KIE_SERVER_CONTROLLER_USER
+                value: controllerUser
+              - name: KIE_SERVER_CONTROLLER_PWD
+                value: "{{.ControllerPassword}}"
+              - name: KIE_SERVER_USER
+                value: executionUser
+              - name: KIE_SERVER_PWD
+                value: "{{.ServerPassword}}"
+              - name: DROOLS_SERVER_FILTER_CLASSES
+                value: "true"
+              - name: RHPAMCENTR_MAVEN_REPO_PATH
+                value: /maven2/
+              - name: KIE_SERVER_CONTROLLER_SERVICE
+                value: "{{.ApplicationName}}-rhpamcentr"
+              - name: KIE_MBEANS
+                value: enabled
+              - name: MAVEN_REPOS
+                value: RHPAMCENTR,EXTERNAL
+              - name: SSO_OPENIDCONNECT_DEPLOYMENTS
+                value: ROOT.war
+              - name: KIE_SERVER_BYPASS_AUTH_USER
+                value: "false"
+              - name: KIE_SERVER_CONTROLLER_PROTOCOL
+                value: ws
+          volumes:
+            - name: kieserver-keystore-volume
+              secret:
+                secretName: "{{.ApplicationName}}-kieserver-{{$index}}-app-secret"
+  ## KIE server deployment config END
+  ## PostgreSQL deployment config BEGIN
+  - metadata:
+      name: "{{.ApplicationName}}-postgresql-{{$index}}"
+      labels:
+        app: "{{.ApplicationName}}"
+        service: "{{.ApplicationName}}-postgresql-{{$index}}"
+    spec:
+      strategy:
+        type: Recreate
+      triggers:
+        - type: ImageChange
+          imageChangeParams:
+            automatic: true
+            containerNames:
+              - "{{.ApplicationName}}-postgresql"
+            from:
+              kind: ImageStreamTag
+              namespace: "openshift"
+              name: "postgresql:9.6"
+        - type: ConfigChange
+      replicas: 1
+      selector:
+        deploymentConfig: "{{.ApplicationName}}-postgresql-{{$index}}"
+      template:
+        metadata:
+          name: "{{.ApplicationName}}-postgresql-{{$index}}"
+          labels:
+            deploymentConfig: "{{.ApplicationName}}-postgresql-{{$index}}"
+            app: "{{.ApplicationName}}"
+            service: "{{.ApplicationName}}-postgresql-{{$index}}"
+        spec:
+          terminationGracePeriodSeconds: 60
+          containers:
+            - name: "{{.ApplicationName}}-postgresql"
+              image: postgresql
+              imagePullPolicy: Always
+              livenessProbe:
+                exec:
+                  command:
+                    - "/usr/libexec/check-container"
+                    - "--live"
+                initialDelaySeconds: 120
+                timeoutSeconds: 10
+              readinessProbe:
+                exec:
+                  command:
+                    - "/usr/libexec/check-container"
+                initialDelaySeconds: 5
+                timeoutSeconds: 1
+              ports:
+                - containerPort: 5432
+                  protocol: TCP
+              volumeMounts:
+                - mountPath: "/var/lib/pgsql/data"
+                  name: "{{.ApplicationName}}-postgresql-pvol"
+              env:
+                - name: POSTGRESQL_USER
+                  value: "rhpam"
+                - name: POSTGRESQL_PASSWORD
+                  value: "{{.AdminPassword}}"
+                - name: POSTGRESQL_DATABASE
+                  value: "rhpam7"
+                - name: POSTGRESQL_MAX_PREPARED_TRANSACTIONS
+                  value: "100"
+          volumes:
+            - name: "{{.ApplicationName}}-postgresql-pvol"
+              persistentVolumeClaim:
+                claimName: "{{.ApplicationName}}-postgresql-claim-{{$index}}"
+## PostgreSQL deployment config END
+## KIE server services BEGIN
+services:
+  - spec:
+      ports:
+        - name: http
+          port: 8080
+          targetPort: 8080
+        - name: https
+          port: 8443
+          targetPort: 8443
+      selector:
+        deploymentConfig: "{{.ApplicationName}}-kieserver-{{$index}}"
+    metadata:
+      name: "{{.ApplicationName}}-kieserver-{{$index}}"
+      labels:
+        app: "{{.ApplicationName}}"
+        service: "{{.ApplicationName}}-kieserver-{{$index}}"
+      annotations:
+        description: All the KIE server web server's ports. (KIE server)
+  - spec:
+      clusterIP: "None"
+      ports:
+        - name: "ping"
+          port: 8888
+          targetPort: 8888
+      selector:
+        deploymentConfig: "{{.ApplicationName}}-kieserver-{{$index}}"
+    metadata:
+      name: "{{.ApplicationName}}-kieserver-{{$index}}-ping"
+      labels:
+        app: "{{.ApplicationName}}"
+        service: "{{.ApplicationName}}-kieserver-{{$index}}"
+      annotations:
+        service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+        description: "The JGroups ping port for clustering."
+  ## KIE server services END
+  ## PostgreSQL service BEGIN
+  - metadata:
+      annotations:
+        description: The database server's port.
+      labels:
+        application: prod
+        service: "{{.ApplicationName}}-postgresql-{{$index}}"
+      name: "{{.ApplicationName}}-postgresql-{{$index}}"
+    spec:
+      ports:
+        - port: 5432
+          targetPort: 5432
+      selector:
+        deploymentConfig: "{{.ApplicationName}}-postgresql-{{$index}}"
+## PostgreSQL service END
+## KIE server routes BEGIN
+routes:
+  - id: "{{.ApplicationName}}-kieserver-{{$index}}-https"
+    metadata:
+      name: "{{.ApplicationName}}-kieserver-{{$index}}"
+      labels:
+        app: "{{.ApplicationName}}"
+        service: "{{.ApplicationName}}-kieserver-{{$index}}"
+      annotations:
+        description: Route for KIE server's https service.
+    spec:
+      host: ""
+      to:
+        name: "{{.ApplicationName}}-kieserver-{{$index}}"
+      port:
+        targetPort: https
+      tls:
+        insecureEdgeTerminationPolicy: Redirect
+        termination: passthrough
+## KIE server routes END
+{{end}}
+## RANGE ends
+## KIE Servers END

--- a/config/envs/production-lite.yaml
+++ b/config/envs/production-lite.yaml
@@ -1,0 +1,714 @@
+console:
+  serviceAccounts:
+  - metadata:
+      name: "{{.ApplicationName}}-rhpamsvc"
+      labels:
+        application: "{{.ApplicationName}}"
+  rolebindings:
+  - metadata:
+      name: "{{.ApplicationName}}-rhpamsvc-view"
+    subjects:
+    - kind: ServiceAccount
+      name: "{{.ApplicationName}}-rhpamsvc"
+    roleRef:
+      kind: Role
+      name: view
+
+  deploymentConfigs:
+  - metadata:
+      name: "{{.ApplicationName}}-rhpamcentr"
+      labels:
+        app: "{{.ApplicationName}}"
+        service: "{{.ApplicationName}}-rhpamcentr"
+      annotations:
+        template.alpha.openshift.io/wait-for-ready: "true"
+    spec:
+      strategy:
+        type: Recreate
+      triggers:
+      - type: ImageChange
+        imageChangeParams:
+          automatic: true
+          containerNames:
+          - "{{.ApplicationName}}-rhpamcentr"
+          from:
+            kind: ImageStreamTag
+            namespace: "openshift"
+            name: "rhpam{{.Version}}-businesscentral-monitoring-openshift:{{.ImageTag}}"
+      - type: ConfigChange
+  ## Replicas for Business Central Monitoring
+      replicas: 3
+      selector:
+        deploymentConfig: "{{.ApplicationName}}-rhpamcentr"
+      template:
+        metadata:
+          name: "{{.ApplicationName}}-rhpamcentr"
+          labels:
+            deploymentConfig: "{{.ApplicationName}}-rhpamcentr"
+            app: "{{.ApplicationName}}"
+            service: "{{.ApplicationName}}-rhpamcentr"
+        spec:
+          terminationGracePeriodSeconds: 60
+          containers:
+          - name: "{{.ApplicationName}}-rhpamcentr"
+            image: rhpam{{.Version}}-businesscentral-monitoring-openshift
+            imagePullPolicy: Always
+            resources:
+              requests:
+                memory: 768Mi
+              limits:
+                memory: 1Gi
+            volumeMounts:
+            - name: businesscentral-keystore-volume
+              mountPath: "/etc/businesscentral-secret-volume"
+              readOnly: true
+            - name: "{{.ApplicationName}}-rhpamcentr-pvol"
+              mountPath: "/opt/eap/standalone/data/kie"
+            livenessProbe:
+              exec:
+                command:
+                - "/bin/bash"
+                - "-c"
+                - curl --fail --silent -u adminUser:"$KIE_ADMIN_PWD" http://localhost:8080/kie-wb.jsp
+              initialDelaySeconds: 180
+              timeoutSeconds: 2
+              periodSeconds: 15
+            readinessProbe:
+              exec:
+                command:
+                - "/bin/bash"
+                - "-c"
+                - curl --fail --silent -u adminUser:"$KIE_ADMIN_PWD" http://localhost:8080/kie-wb.jsp
+              initialDelaySeconds: 60
+              timeoutSeconds: 2
+              periodSeconds: 30
+              failureThreshold: 6
+            ports:
+            - name: jolokia
+              containerPort: 8778
+              protocol: TCP
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: https
+              containerPort: 8443
+              protocol: TCP
+            - name: ping
+              containerPort: 8888
+              protocol: TCP
+            env:
+            - name: MAVEN_REPO_ID
+              value: ""
+            - name: MAVEN_REPO_URL
+              value: ""
+            - name: MAVEN_REPO_USERNAME
+              value: ""
+            - name: MAVEN_REPO_PASSWORD
+              value: ""
+            - name: KIE_SERVER_CONTROLLER_TOKEN
+              value: ""
+            - name: HTTPS_KEYSTORE_DIR
+              value: "/etc/businesscentral-secret-volume"
+            - name: HTTPS_KEYSTORE
+              value: "keystore.jks"
+            - name: HTTPS_NAME
+              value: "jboss"
+            - name: HTTPS_PASSWORD
+              value: "{{.KeyStorePassword}}"
+            - name: JGROUPS_PING_PROTOCOL
+              value: "openshift.DNS_PING"
+            - name: OPENSHIFT_DNS_PING_SERVICE_NAME
+              value: "{{.ApplicationName}}-rhpamcentr-ping"
+            - name: OPENSHIFT_DNS_PING_SERVICE_PORT
+              value: "8888"
+            - name: SSO_URL
+              value: ""
+            - name: SSO_OPENIDCONNECT_DEPLOYMENTS
+              value: "ROOT.war"
+            - name: SSO_REALM
+              value: ""
+            - name: SSO_SECRET
+              value: ""
+            - name: SSO_CLIENT
+              value: ""
+            - name: SSO_USERNAME
+              value: ""
+            - name: SSO_PASSWORD
+              value: ""
+            - name: SSO_DISABLE_SSL_CERTIFICATE_VALIDATION
+              value: "false"
+            - name: SSO_PRINCIPAL_ATTRIBUTE
+              value: "preferred_username"
+            - name: HOSTNAME_HTTP
+              value: ""
+            - name: HOSTNAME_HTTPS
+              value: ""
+            - name: AUTH_LDAP_URL
+              value: ""
+            - name: AUTH_LDAP_BIND_DN
+              value: ""
+            - name: AUTH_LDAP_BIND_CREDENTIAL
+              value: ""
+            - name: AUTH_LDAP_JAAS_SECURITY_DOMAIN
+              value: ""
+            - name: AUTH_LDAP_BASE_CTX_DN
+              value: ""
+            - name: AUTH_LDAP_BASE_FILTER
+              value: ""
+            - name: AUTH_LDAP_SEARCH_SCOPE
+              value: ""
+            - name: AUTH_LDAP_SEARCH_TIME_LIMIT
+              value: ""
+            - name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
+              value: ""
+            - name: AUTH_LDAP_PARSE_USERNAME
+              value: ""
+            - name: AUTH_LDAP_USERNAME_BEGIN_STRING
+              value: ""
+            - name: AUTH_LDAP_USERNAME_END_STRING
+              value: ""
+            - name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
+              value: ""
+            - name: AUTH_LDAP_ROLES_CTX_DN
+              value: ""
+            - name: AUTH_LDAP_ROLE_FILTER
+              value: ""
+            - name: AUTH_LDAP_ROLE_RECURSION
+              value: ""
+            - name: AUTH_LDAP_DEFAULT_ROLE
+              value: ""
+            - name: AUTH_LDAP_ROLE_NAME_ATTRIBUTE_ID
+              value: ""
+            - name: AUTH_LDAP_PARSE_ROLE_NAME_FROM_DN
+              value: ""
+            - name: AUTH_LDAP_ROLE_ATTRIBUTE_IS_DN
+              value: ""
+            - name: AUTH_LDAP_REFERRAL_USER_ATTRIBUTE_ID_TO_CHECK
+              value: ""
+          volumes:
+          - name: businesscentral-keystore-volume
+            secret:
+              secretName: "{{.ApplicationName}}-businesscentral-app-secret"
+          - name: "{{.ApplicationName}}-rhpamcentr-pvol"
+            persistentVolumeClaim:
+              claimName: "{{.ApplicationName}}-rhpamcentr-claim"
+  services:
+  - spec:
+      ports:
+      - name: http
+        port: 8080
+        targetPort: 8080
+      - name: https
+        port: 8443
+        targetPort: 8443
+      selector:
+        deploymentConfig: "{{.ApplicationName}}-rhpamcentr"
+    metadata:
+      name: "{{.ApplicationName}}-rhpamcentr"
+      labels:
+        app: "{{.ApplicationName}}"
+        service: "{{.ApplicationName}}-rhpamcentr"
+      annotations:
+        description: All the Business Central Monitoring web server's ports.
+  - spec:
+      clusterIP: "None"
+      ports:
+      - name: "ping"
+        port: 8888
+        targetPort: 8888
+      selector:
+        deploymentConfig: "{{.ApplicationName}}-rhpamcentr"
+    metadata:
+      name: "{{.ApplicationName}}-rhpamcentr-ping"
+      labels:
+        app: "{{.ApplicationName}}"
+        service: "{{.ApplicationName}}-rhpamcentr"
+      annotations:
+        service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+        description: "The JGroups ping port for clustering."
+  routes:
+  - id: "{{.ApplicationName}}-rhpamcentr-https"
+    metadata:
+      name: "{{.ApplicationName}}-rhpamcentr"
+      labels:
+        app: "{{.ApplicationName}}"
+        service: "{{.ApplicationName}}-rhpamcentr"
+      annotations:
+        description: Route for Business Central Monitoring's https service.
+        haproxy.router.openshift.io/timeout: 60s
+    spec:
+      host: ""
+      to:
+        name: "{{.ApplicationName}}-rhpamcentr"
+      port:
+        targetPort: https
+      tls:
+        insecureEdgeTerminationPolicy: Redirect
+        termination: passthrough
+  persistentVolumeClaims:
+  - metadata:
+      name: "{{.ApplicationName}}-rhpamcentr-claim"
+      labels:
+        app: "{{.ApplicationName}}"
+        service: "{{.ApplicationName}}-rhpamcentr"
+    spec:
+      accessModes:
+      - ReadWriteMany
+      resources:
+        requests:
+          storage: "64Mi"
+
+## KIE smartrouter BEGIN
+others:
+- persistentVolumeClaims:
+  - metadata:
+      name: "{{.ApplicationName}}-smartrouter-claim"
+      labels:
+        app: "{{.ApplicationName}}"
+        service: "{{.ApplicationName}}-smartrouter"
+    spec:
+      accessModes:
+      - ReadWriteMany
+      resources:
+        requests:
+          storage: "64Mi"
+  deploymentConfigs:
+  - metadata:
+      name: "{{.ApplicationName}}-smartrouter"
+      labels:
+        app: "{{.ApplicationName}}"
+        service: "{{.ApplicationName}}-smartrouter"
+    spec:
+      strategy:
+        type: Recreate
+      triggers:
+      - type: ImageChange
+        imageChangeParams:
+          automatic: true
+          containerNames:
+          - "{{.ApplicationName}}-smartrouter"
+          from:
+            kind: ImageStreamTag
+            namespace: "openshift"
+            name: "rhpam{{.Version}}-smartrouter-openshift:{{.ImageTag}}"
+      - type: ConfigChange
+      replicas: 2
+      selector:
+        deploymentConfig: "{{.ApplicationName}}-smartrouter"
+      template:
+        metadata:
+          name: "{{.ApplicationName}}-smartrouter"
+          labels:
+            app: "{{.ApplicationName}}"
+            deploymentConfig: "{{.ApplicationName}}-smartrouter"
+            service: "{{.ApplicationName}}-smartrouter"
+        spec:
+          terminationGracePeriodSeconds: 60
+          containers:
+          - name: "{{.ApplicationName}}-smartrouter"
+            image: rhpam{{.Version}}-smartrouter-openshift
+            imagePullPolicy: Always
+            resources:
+              requests:
+                memory: "512Mi"
+              limits:
+                memory: "512Mi"
+            ports:
+            - name: http
+              containerPort: 9000
+              protocol: TCP
+            env:
+            - name: KIE_SERVER_ROUTER_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: KIE_SERVER_ROUTER_PORT
+              value: "9000"
+            - name: KIE_SERVER_ROUTER_URL_EXTERNAL
+              value: ""
+            - name: KIE_SERVER_ROUTER_ID
+              value: "kie-server-router"
+            - name: KIE_SERVER_ROUTER_NAME
+              value: "KIE Server Router"
+            - name: KIE_SERVER_ROUTER_PROTOCOL
+              value: ""
+            - name: KIE_SERVER_CONTROLLER_USER
+              value: controllerUser
+            - name: KIE_SERVER_CONTROLLER_PWD
+              value: "{{.ControllerPassword}}"
+            - name: KIE_SERVER_CONTROLLER_TOKEN
+              value: ""
+            - name: KIE_SERVER_CONTROLLER_SERVICE
+              value: "{{.ApplicationName}}-rhpamcentr"
+            - name: KIE_SERVER_CONTROLLER_PROTOCOL
+              value: "http"
+            - name: KIE_SERVER_ROUTER_REPO
+              value: "/opt/rhpam-smartrouter/data"
+            - name: KIE_SERVER_ROUTER_CONFIG_WATCHER_ENABLED
+              value: "true"
+            volumeMounts:
+            - name: "{{.ApplicationName}}-smartrouter"
+              mountPath: "/opt/rhpam-smartrouter/data"
+          volumes:
+          - name: "{{.ApplicationName}}-smartrouter"
+            persistentVolumeClaim:
+              claimName: "{{.ApplicationName}}-smartrouter-claim"
+  services:
+  - spec:
+      ports:
+      - port: 9000
+        targetPort: 9000
+      selector:
+        deploymentConfig: "{{.ApplicationName}}-smartrouter"
+    metadata:
+      name: "{{.ApplicationName}}-smartrouter"
+      labels:
+        app: "{{.ApplicationName}}"
+        service: "{{.ApplicationName}}-smartrouter"
+      annotations:
+        description: The smart router server http port.
+  routes:
+  - id: "{{.ApplicationName}}-smartrouter-https"
+    metadata:
+      name: "{{.ApplicationName}}-smartrouter"
+      labels:
+        app: "{{.ApplicationName}}"
+        service: "{{.ApplicationName}}-smartrouter"
+      annotations:
+        description: Route for Smart Router's http service.
+    spec:
+      host: ""
+      to:
+        name: "{{.ApplicationName}}-smartrouter"
+      tls:
+        insecureEdgeTerminationPolicy: Redirect
+        termination: passthrough
+## KIE smartrouter END
+
+## KIE Servers BEGIN
+servers:
+## RANGE BEGINS
+{{ range $index, $Map := .ServerCount }}
+  ## PostgreSQL persistent volume claim BEGIN
+- persistentVolumeClaims:
+  - metadata:
+      name: "{{.ApplicationName}}-postgresql-claim-{{$index}}"
+      labels:
+        app: "{{.ApplicationName}}"
+        service: "{{.ApplicationName}}-postgresql-{{$index}}"
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: "1Gi"
+  ## PostgreSQL persistent volume claim END
+  ## KIE server deployment config BEGIN
+  deploymentConfigs:
+  - metadata:
+      name: "{{.ApplicationName}}-kieserver-{{$index}}"
+      labels:
+        app: "{{.ApplicationName}}"
+        service: "{{.ApplicationName}}-kieserver-{{$index}}"
+    spec:
+      replicas: 3
+      template:
+        metadata:
+          name: "{{.ApplicationName}}-kieserver-{{$index}}"
+          labels:
+            deploymentConfig: "{{.ApplicationName}}-kieserver-{{$index}}"
+            app: "{{.ApplicationName}}"
+            service: "{{.ApplicationName}}-kieserver-{{$index}}"
+        spec:
+          serviceAccountName: "{{.ApplicationName}}-rhpamsvc"
+          terminationGracePeriodSeconds: 60
+          containers:
+          - name: "{{.ApplicationName}}-kieserver"
+            image: "rhpam{{.Version}}-kieserver-openshift"
+            imagePullPolicy: Always
+            resources:
+              requests:
+                memory: 512Mi
+              limits:
+                memory: 1Gi
+            ports:
+            - name: ping
+              containerPort: 8888
+              protocol: TCP
+            env:
+            - name: KIE_SERVER_CONTROLLER_TOKEN
+              value: ""
+            - name: KIE_SERVER_ID
+              value: "{{.ApplicationName}}-kieserver-{{$index}}"
+            - name: KIE_SERVER_ROUTE_NAME
+              value: "{{.ApplicationName}}-kieserver-{{$index}}"
+            - name: KIE_SERVER_USE_SECURE_ROUTE_NAME
+              value: "false"
+            - name: KIE_SERVER_CONTAINER_DEPLOYMENT
+              value: ""
+            - name: EXTERNAL_MAVEN_REPO_ID
+              value: ""
+            - name: EXTERNAL_MAVEN_REPO_URL
+              value: ""
+            - name: EXTERNAL_MAVEN_REPO_USERNAME
+              value: ""
+            - name: EXTERNAL_MAVEN_REPO_PASSWORD
+              value: ""
+            - name: KIE_SERVER_ROUTER_SERVICE
+              value: "{{.ApplicationName}}-smartrouter"
+            - name: KIE_SERVER_ROUTER_PORT
+              value: "9000"
+            - name: KIE_SERVER_ROUTER_PROTOCOL
+              value: ""
+            - name: KIE_SERVER_PERSISTENCE_DS
+              value: "java:/jboss/datasources/rhpam"
+            - name: DATASOURCES
+              value: "RHPAM"
+            - name: RHPAM_JNDI
+              value: "java:/jboss/datasources/rhpam"
+            - name: RHPAM_JTA
+              value: "true"
+  ## PostgreSQL driver settings BEGIN
+            - name: RHPAM_DATABASE
+              value: "rhpam7"
+            - name: RHPAM_DRIVER
+              value: "postgresql"
+            - name: KIE_SERVER_PERSISTENCE_DIALECT
+              value: "org.hibernate.dialect.PostgreSQLDialect"
+            - name: RHPAM_USERNAME
+              value: "rhpam"
+            - name: RHPAM_PASSWORD
+              value: "{{.AdminPassword}}"
+            - name: RHPAM_SERVICE_HOST
+              value: "{{.ApplicationName}}-postgresql-{{$index}}"
+            - name: RHPAM_SERVICE_PORT
+              value: "5432"
+            - name: TIMER_SERVICE_DATA_STORE
+              value: "{{.ApplicationName}}-postgresql-{{$index}}"
+  ## PostgreSQL driver settings END
+            - name: TIMER_SERVICE_DATA_STORE_REFRESH_INTERVAL
+              value: "30000"
+            - name: HTTPS_KEYSTORE_DIR
+              value: "/etc/kieserver-secret-volume"
+            - name: HTTPS_KEYSTORE
+              value: "keystore.jks"
+            - name: HTTPS_NAME
+              value: "jboss"
+            - name: HTTPS_PASSWORD
+              value: "{{.KeyStorePassword}}"
+            - name: JGROUPS_PING_PROTOCOL
+              value: "openshift.DNS_PING"
+            - name: OPENSHIFT_DNS_PING_SERVICE_NAME
+              value: "{{.ApplicationName}}-kieserver-{{$index}}-ping"
+            - name: OPENSHIFT_DNS_PING_SERVICE_PORT
+              value: "8888"
+            - name: SSO_URL
+              value: ""
+            - name: SSO_REALM
+              value: ""
+            - name: SSO_SECRET
+              value: ""
+            - name: SSO_CLIENT
+              value: ""
+            - name: SSO_USERNAME
+              value: ""
+            - name: SSO_PASSWORD
+              value: ""
+            - name: SSO_DISABLE_SSL_CERTIFICATE_VALIDATION
+              value: "false"
+            - name: SSO_PRINCIPAL_ATTRIBUTE
+              value: "preferred_username"
+            - name: HOSTNAME_HTTP
+              value: ""
+            - name: HOSTNAME_HTTPS
+              value: ""
+            - name: AUTH_LDAP_URL
+              value: ""
+            - name: AUTH_LDAP_BIND_DN
+              value: ""
+            - name: AUTH_LDAP_BIND_CREDENTIAL
+              value: ""
+            - name: AUTH_LDAP_JAAS_SECURITY_DOMAIN
+              value: ""
+            - name: AUTH_LDAP_BASE_CTX_DN
+              value: ""
+            - name: AUTH_LDAP_BASE_FILTER
+              value: ""
+            - name: AUTH_LDAP_SEARCH_SCOPE
+              value: ""
+            - name: AUTH_LDAP_SEARCH_TIME_LIMIT
+              value: ""
+            - name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
+              value: ""
+            - name: AUTH_LDAP_PARSE_USERNAME
+              value: ""
+            - name: AUTH_LDAP_USERNAME_BEGIN_STRING
+              value: ""
+            - name: AUTH_LDAP_USERNAME_END_STRING
+              value: ""
+            - name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
+              value: ""
+            - name: AUTH_LDAP_ROLES_CTX_DN
+              value: ""
+            - name: AUTH_LDAP_ROLE_FILTER
+              value: ""
+            - name: AUTH_LDAP_ROLE_RECURSION
+              value: ""
+            - name: AUTH_LDAP_DEFAULT_ROLE
+              value: ""
+            - name: AUTH_LDAP_ROLE_NAME_ATTRIBUTE_ID
+              value: ""
+            - name: AUTH_LDAP_PARSE_ROLE_NAME_FROM_DN
+              value: ""
+            - name: AUTH_LDAP_ROLE_ATTRIBUTE_IS_DN
+              value: ""
+            - name: AUTH_LDAP_REFERRAL_USER_ATTRIBUTE_ID_TO_CHECK
+              value: ""
+          volumes:
+          - name: kieserver-keystore-volume
+            secret:
+              secretName: "{{.ApplicationName}}-kieserver-{{$index}}-app-secret"
+  ## KIE server deployment config END
+  ## PostgreSQL deployment config BEGIN
+  - metadata:
+      name: "{{.ApplicationName}}-postgresql-{{$index}}"
+      labels:
+        app: "{{.ApplicationName}}"
+        service: "{{.ApplicationName}}-postgresql-{{$index}}"
+    spec:
+      strategy:
+        type: Recreate
+      triggers:
+      - type: ImageChange
+        imageChangeParams:
+          automatic: true
+          containerNames:
+          - "{{.ApplicationName}}-postgresql"
+          from:
+            kind: ImageStreamTag
+            namespace: "openshift"
+            name: "postgresql:9.6"
+      - type: ConfigChange
+      replicas: 1
+      selector:
+        deploymentConfig: "{{.ApplicationName}}-postgresql-{{$index}}"
+      template:
+        metadata:
+          name: "{{.ApplicationName}}-postgresql-{{$index}}"
+          labels:
+            deploymentConfig: "{{.ApplicationName}}-postgresql-{{$index}}"
+            app: "{{.ApplicationName}}"
+            service: "{{.ApplicationName}}-postgresql-{{$index}}"
+        spec:
+          terminationGracePeriodSeconds: 60
+          containers:
+          - name: "{{.ApplicationName}}-postgresql"
+            image: postgresql
+            imagePullPolicy: Always
+            livenessProbe:
+              exec:
+                command:
+                - "/usr/libexec/check-container"
+                - "--live"
+              initialDelaySeconds: 120
+              timeoutSeconds: 10
+            readinessProbe:
+              exec:
+                command:
+                - "/usr/libexec/check-container"
+              initialDelaySeconds: 5
+              timeoutSeconds: 1
+            ports:
+            - containerPort: 5432
+              protocol: TCP
+            volumeMounts:
+            - mountPath: "/var/lib/pgsql/data"
+              name: "{{.ApplicationName}}-postgresql-pvol"
+            env:
+            - name: POSTGRESQL_USER
+              value: "rhpam"
+            - name: POSTGRESQL_PASSWORD
+              value: "{{.AdminPassword}}"
+            - name: POSTGRESQL_DATABASE
+              value: "rhpam7"
+            - name: POSTGRESQL_MAX_PREPARED_TRANSACTIONS
+              value: "100"
+          volumes:
+          - name: "{{.ApplicationName}}-postgresql-pvol"
+            persistentVolumeClaim:
+              claimName: "{{.ApplicationName}}-postgresql-claim-{{$index}}"
+  ## PostgreSQL deployment config END
+  ## KIE server services BEGIN
+  services:
+  - spec:
+      ports:
+      - name: http
+        port: 8080
+        targetPort: 8080
+      - name: https
+        port: 8443
+        targetPort: 8443
+      selector:
+        deploymentConfig: "{{.ApplicationName}}-kieserver-{{$index}}"
+    metadata:
+      name: "{{.ApplicationName}}-kieserver-{{$index}}"
+      labels:
+        app: "{{.ApplicationName}}"
+        service: "{{.ApplicationName}}-kieserver-{{$index}}"
+      annotations:
+        description: All the KIE server web server's ports. (KIE server)
+  - spec:
+      clusterIP: "None"
+      ports:
+      - name: "ping"
+        port: 8888
+        targetPort: 8888
+      selector:
+        deploymentConfig: "{{.ApplicationName}}-kieserver-{{$index}}"
+    metadata:
+      name: "{{.ApplicationName}}-kieserver-{{$index}}-ping"
+      labels:
+        app: "{{.ApplicationName}}"
+        service: "{{.ApplicationName}}-kieserver-{{$index}}"
+      annotations:
+        service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+        description: "The JGroups ping port for clustering."
+  ## KIE server services END
+  ## PostgreSQL service BEGIN
+  - metadata:
+      annotations:
+        description: The database server's port.
+      labels:
+        application: prod
+        service: "{{.ApplicationName}}-postgresql-{{$index}}"
+      name: "{{.ApplicationName}}-postgresql-{{$index}}"
+    spec:
+      ports:
+      - port: 5432
+        targetPort: 5432
+      selector:
+        deploymentConfig: "{{.ApplicationName}}-postgresql-{{$index}}"
+  ## PostgreSQL service END
+  ## KIE server routes BEGIN
+  routes:
+  - id: "{{.ApplicationName}}-kieserver-{{$index}}-https"
+    metadata:
+      name: "{{.ApplicationName}}-kieserver-{{$index}}"
+      labels:
+        app: "{{.ApplicationName}}"
+        service: "{{.ApplicationName}}-kieserver-{{$index}}"
+      annotations:
+        description: Route for KIE server's https service.
+    spec:
+      host: ""
+      to:
+        name: "{{.ApplicationName}}-kieserver-{{$index}}"
+      port:
+        targetPort: https
+      tls:
+        insecureEdgeTerminationPolicy: Redirect
+        termination: passthrough
+  ## KIE server routes END
+{{end}}
+## RANGE ends
+## KIE Servers END

--- a/pkg/controller/kieapp/defaults/merge.go
+++ b/pkg/controller/kieapp/defaults/merge.go
@@ -1,0 +1,397 @@
+package defaults
+
+import (
+	"github.com/imdario/mergo"
+	"github.com/kiegroup/kie-cloud-operator/pkg/apis/app/v1"
+	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/shared"
+	appsv1 "github.com/openshift/api/apps/v1"
+	routev1 "github.com/openshift/api/route/v1"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
+)
+
+func merge(baseline *v1.CustomObject, overwrite *v1.CustomObject) {
+	baseline.PersistentVolumeClaims = mergePersistentVolumeClaims(baseline.PersistentVolumeClaims, overwrite.PersistentVolumeClaims)
+	baseline.ServiceAccounts = mergeServiceAccounts(baseline.ServiceAccounts, overwrite.ServiceAccounts)
+	baseline.Secrets = mergeSecrets(baseline.Secrets, overwrite.Secrets)
+	baseline.RoleBindings = mergeRoleBindings(baseline.RoleBindings, overwrite.RoleBindings)
+	baseline.DeploymentConfigs = mergeDeploymentConfigs(baseline.DeploymentConfigs, overwrite.DeploymentConfigs)
+	baseline.Services = mergeServices(baseline.Services, overwrite.Services)
+	baseline.Routes = mergeRoutes(baseline.Routes, overwrite.Routes)
+}
+
+func mergePersistentVolumeClaims(baseline []corev1.PersistentVolumeClaim, overwrite []corev1.PersistentVolumeClaim) []corev1.PersistentVolumeClaim {
+	if len(overwrite) == 0 {
+		return baseline
+	} else if len(baseline) == 0 {
+		return overwrite
+	} else {
+		baselineRefs := getPersistentVolumeClaimReferenceSlice(baseline)
+		overwriteRefs := getPersistentVolumeClaimReferenceSlice(overwrite)
+		slice := make([]corev1.PersistentVolumeClaim, combinedSize(baselineRefs, overwriteRefs))
+		err := mergeObjects(baselineRefs, overwriteRefs, slice)
+		if err != nil {
+			logrus.Errorf("%v", err)
+			return nil
+		}
+		return slice
+	}
+}
+
+func getPersistentVolumeClaimReferenceSlice(objects []corev1.PersistentVolumeClaim) []v1.OpenShiftObject {
+	slice := make([]v1.OpenShiftObject, len(objects))
+	for index := range objects {
+		slice[index] = &objects[index]
+	}
+	return slice
+}
+
+func mergeServiceAccounts(baseline []corev1.ServiceAccount, overwrite []corev1.ServiceAccount) []corev1.ServiceAccount {
+	if len(overwrite) == 0 {
+		return baseline
+	} else if len(baseline) == 0 {
+		return overwrite
+	} else {
+		baselineRefs := getServiceAccountReferenceSlice(baseline)
+		overwriteRefs := getServiceAccountReferenceSlice(overwrite)
+		slice := make([]corev1.ServiceAccount, combinedSize(baselineRefs, overwriteRefs))
+		err := mergeObjects(baselineRefs, overwriteRefs, slice)
+		if err != nil {
+			logrus.Errorf("%v", err)
+			return nil
+		}
+		return slice
+	}
+}
+
+func getServiceAccountReferenceSlice(objects []corev1.ServiceAccount) []v1.OpenShiftObject {
+	slice := make([]v1.OpenShiftObject, len(objects))
+	for index := range objects {
+		slice[index] = &objects[index]
+	}
+	return slice
+}
+
+func mergeSecrets(baseline []corev1.Secret, overwrite []corev1.Secret) []corev1.Secret {
+	if len(overwrite) == 0 {
+		return baseline
+	} else if len(baseline) == 0 {
+		return overwrite
+	} else {
+		baselineRefs := getSecretReferenceSlice(baseline)
+		overwriteRefs := getSecretReferenceSlice(overwrite)
+		slice := make([]corev1.Secret, combinedSize(baselineRefs, overwriteRefs))
+		err := mergeObjects(baselineRefs, overwriteRefs, slice)
+		if err != nil {
+			logrus.Errorf("%v", err)
+			return nil
+		}
+		return slice
+	}
+}
+
+func getSecretReferenceSlice(objects []corev1.Secret) []v1.OpenShiftObject {
+	slice := make([]v1.OpenShiftObject, len(objects))
+	for index := range objects {
+		slice[index] = &objects[index]
+	}
+	return slice
+}
+
+func mergeRoleBindings(baseline []rbacv1.RoleBinding, overwrite []rbacv1.RoleBinding) []rbacv1.RoleBinding {
+	if len(overwrite) == 0 {
+		return baseline
+	} else if len(baseline) == 0 {
+		return overwrite
+	} else {
+		baselineRefs := getRoleBindingReferenceSlice(baseline)
+		overwriteRefs := getRoleBindingReferenceSlice(overwrite)
+		slice := make([]rbacv1.RoleBinding, combinedSize(baselineRefs, overwriteRefs))
+		err := mergeObjects(baselineRefs, overwriteRefs, slice)
+		if err != nil {
+			logrus.Errorf("%v", err)
+			return nil
+		}
+		return slice
+	}
+}
+
+func getRoleBindingReferenceSlice(objects []rbacv1.RoleBinding) []v1.OpenShiftObject {
+	slice := make([]v1.OpenShiftObject, len(objects))
+	for index := range objects {
+		slice[index] = &objects[index]
+	}
+	return slice
+}
+
+func mergeDeploymentConfigs(baseline []appsv1.DeploymentConfig, overwrite []appsv1.DeploymentConfig) []appsv1.DeploymentConfig {
+	if len(overwrite) == 0 {
+		return baseline
+	} else if len(baseline) == 0 {
+		return overwrite
+	} else {
+		baselineRefs := getDeploymentConfigReferenceSlice(baseline)
+		overwriteRefs := getDeploymentConfigReferenceSlice(overwrite)
+		for overwriteIndex := range overwrite {
+			overwriteItem := overwrite[overwriteIndex]
+			baselineIndex, _ := findOpenShiftObject(&overwriteItem, baselineRefs)
+			if baselineIndex >= 0 {
+				baselineItem := baseline[baselineIndex]
+				err := mergeLabels(&overwriteItem.ObjectMeta, &baselineItem.ObjectMeta) //reverse merge to maintain changes
+				if err != nil {
+					logrus.Errorf("%v", err)
+					return nil
+				}
+				err = mergo.Merge(&overwriteItem.ObjectMeta, baselineItem.ObjectMeta)
+				if err != nil {
+					logrus.Errorf("%v", err)
+					return nil
+				}
+				mergedSpec, err := mergeSpec(baselineItem.Spec, overwriteItem.Spec)
+				if err != nil {
+					logrus.Errorf("%v", err)
+					return nil
+				}
+				overwriteItem.Spec = mergedSpec
+			}
+		}
+		slice := make([]appsv1.DeploymentConfig, combinedSize(baselineRefs, overwriteRefs))
+		err := mergeObjects(baselineRefs, overwriteRefs, slice)
+		if err != nil {
+			logrus.Errorf("%v", err)
+			return nil
+		}
+		return slice
+	}
+}
+
+func mergeLabels(baseline metav1.Object, overwrite metav1.Object) error {
+	mergedLabels := baseline.GetLabels()
+	err := mergo.Merge(&mergedLabels, overwrite.GetLabels(), mergo.WithOverride)
+	if err != nil {
+		return err
+	}
+	baseline.SetLabels(mergedLabels)
+	return nil
+}
+
+func mergeSpec(baseline appsv1.DeploymentConfigSpec, overwrite appsv1.DeploymentConfigSpec) (appsv1.DeploymentConfigSpec, error) {
+	mergedTemplate, err := mergeTemplate(baseline.Template, overwrite.Template)
+	if err != nil {
+		return appsv1.DeploymentConfigSpec{}, err
+	}
+	overwrite.Template = mergedTemplate
+
+	err = mergo.Merge(&baseline, overwrite, mergo.WithOverride)
+	if err != nil {
+		return appsv1.DeploymentConfigSpec{}, nil
+	}
+	return baseline, nil
+}
+
+func mergeTemplate(baseline *corev1.PodTemplateSpec, overwrite *corev1.PodTemplateSpec) (*corev1.PodTemplateSpec, error) {
+	err := mergeLabels(overwrite, baseline)
+	if err != nil {
+		return nil, err
+	}
+	mergedPodSpec, err := mergePodSpecs(baseline.Spec, overwrite.Spec)
+	if err != nil {
+		return nil, err
+	}
+	overwrite.Spec = mergedPodSpec
+
+	err = mergo.Merge(baseline, *overwrite, mergo.WithOverride)
+	if err != nil {
+		return nil, err
+	}
+	return baseline, nil
+}
+
+func mergePodSpecs(baseline corev1.PodSpec, overwrite corev1.PodSpec) (corev1.PodSpec, error) {
+	mergedContainers, err := mergeContainers(baseline.Containers, overwrite.Containers)
+	if err != nil {
+		return corev1.PodSpec{}, err
+	}
+	overwrite.Containers = mergedContainers
+
+	err = mergo.Merge(&baseline, overwrite, mergo.WithOverride)
+	if err != nil {
+		return corev1.PodSpec{}, err
+	}
+	return baseline, nil
+}
+
+func mergeContainers(baseline []corev1.Container, overwrite []corev1.Container) ([]corev1.Container, error) {
+	if len(overwrite) == 0 {
+		return baseline, nil
+	} else if len(baseline) == 0 {
+		return overwrite, nil
+	} else if len(baseline) > 1 || len(overwrite) > 1 {
+		err := errors.New("Merge algorithm does not yet support multiple containers within a deployment")
+		return nil, err
+	}
+	overwrite[0].Env = shared.EnvOverride(baseline[0].Env, overwrite[0].Env)
+	mergedPorts, err := mergePorts(baseline[0].Ports, overwrite[0].Ports)
+	if err != nil {
+		return nil, err
+	}
+	overwrite[0].Ports = mergedPorts
+
+	err = mergo.Merge(&baseline[0], overwrite[0], mergo.WithOverride)
+	if err != nil {
+		return nil, err
+	}
+	return baseline, nil
+}
+
+func mergePorts(baseline []corev1.ContainerPort, overwrite []corev1.ContainerPort) ([]corev1.ContainerPort, error) {
+	var slice []corev1.ContainerPort
+	for index := range baseline {
+		found := findContainerPort(baseline[index], overwrite)
+		if found != (corev1.ContainerPort{}) {
+			err := mergo.Merge(&baseline[index], found, mergo.WithOverride)
+			if err != nil {
+				return nil, err
+			}
+		}
+		slice = append(slice, baseline[index])
+	}
+	for index := range overwrite {
+		found := findContainerPort(overwrite[index], baseline)
+		if found == (corev1.ContainerPort{}) {
+			slice = append(slice, overwrite[index])
+		}
+	}
+	return slice, nil
+}
+
+func findContainerPort(port corev1.ContainerPort, ports []corev1.ContainerPort) corev1.ContainerPort {
+	for index := range ports {
+		if port.Name == ports[index].Name {
+			return ports[index]
+		}
+	}
+	return corev1.ContainerPort{}
+}
+
+func getDeploymentConfigReferenceSlice(objects []appsv1.DeploymentConfig) []v1.OpenShiftObject {
+	slice := make([]v1.OpenShiftObject, len(objects))
+	for index := range objects {
+		slice[index] = &objects[index]
+	}
+	return slice
+}
+
+func mergeServices(baseline []corev1.Service, overwrite []corev1.Service) []corev1.Service {
+	if len(overwrite) == 0 {
+		return baseline
+	} else if len(baseline) == 0 {
+		return overwrite
+	} else {
+		baselineRefs := getServiceReferenceSlice(baseline)
+		overwriteRefs := getServiceReferenceSlice(overwrite)
+		slice := make([]corev1.Service, combinedSize(baselineRefs, overwriteRefs))
+		err := mergeObjects(baselineRefs, overwriteRefs, slice)
+		if err != nil {
+			logrus.Errorf("%v", err)
+			return nil
+		}
+		return slice
+	}
+}
+func getServiceReferenceSlice(objects []corev1.Service) []v1.OpenShiftObject {
+	slice := make([]v1.OpenShiftObject, len(objects))
+	for index := range objects {
+		slice[index] = &objects[index]
+	}
+	return slice
+}
+
+func mergeRoutes(baseline []routev1.Route, overwrite []routev1.Route) []routev1.Route {
+	if len(overwrite) == 0 {
+		return baseline
+	} else if len(baseline) == 0 {
+		return overwrite
+	} else {
+		baselineRefs := getRouteReferenceSlice(baseline)
+		overwriteRefs := getRouteReferenceSlice(overwrite)
+		slice := make([]routev1.Route, combinedSize(baselineRefs, overwriteRefs))
+		err := mergeObjects(baselineRefs, overwriteRefs, slice)
+		if err != nil {
+			logrus.Errorf("%v", err)
+			return nil
+		}
+		return slice
+	}
+}
+
+func getRouteReferenceSlice(objects []routev1.Route) []v1.OpenShiftObject {
+	slice := make([]v1.OpenShiftObject, len(objects))
+	for index := range objects {
+		slice[index] = &objects[index]
+	}
+	return slice
+}
+
+func combinedSize(baseline []v1.OpenShiftObject, overwrite []v1.OpenShiftObject) int {
+	count := 0
+	for _, object := range overwrite {
+		_, found := findOpenShiftObject(object, baseline)
+		if found == nil && object.GetAnnotations()["delete"] != "true" {
+			//unique item with no counterpart in baseline, count it
+			count++
+		} else if found != nil && object.GetAnnotations()["delete"] == "true" {
+			///Deletes the counterpart in baseline, deduct 1 since the counterpart is being counted below
+			count--
+		}
+	}
+	count += len(baseline)
+	return count
+}
+
+func mergeObjects(baseline []v1.OpenShiftObject, overwrite []v1.OpenShiftObject, objectSlice interface{}) error {
+	slice := reflect.ValueOf(objectSlice)
+	sliceIndex := 0
+	for _, object := range baseline {
+		_, found := findOpenShiftObject(object, overwrite)
+		if found == nil {
+			slice.Index(sliceIndex).Set(reflect.ValueOf(object).Elem())
+			sliceIndex++
+			logrus.Debugf("Not found, added %s to beginning of slice\n", object)
+		} else if found.GetAnnotations()["delete"] != "true" {
+			err := mergo.Merge(object, found, mergo.WithOverride)
+			if err != nil {
+				return err
+			}
+			slice.Index(sliceIndex).Set(reflect.ValueOf(object).Elem())
+			sliceIndex++
+			if found.GetAnnotations() == nil {
+				annotations := make(map[string]string)
+				found.SetAnnotations(annotations)
+			}
+		}
+	}
+	for _, object := range overwrite {
+		if object.GetAnnotations()["delete"] != "true" {
+			_, found := findOpenShiftObject(object, baseline)
+			if found == nil {
+				slice.Index(sliceIndex).Set(reflect.ValueOf(object).Elem())
+				sliceIndex++
+			}
+		}
+	}
+	return nil
+}
+
+func findOpenShiftObject(object v1.OpenShiftObject, slice []v1.OpenShiftObject) (int, v1.OpenShiftObject) {
+	for index, candidate := range slice {
+		if candidate.GetName() == object.GetName() {
+			return index, candidate
+		}
+	}
+	return -1, nil
+}

--- a/pkg/controller/kieapp/defaults/merge_test.go
+++ b/pkg/controller/kieapp/defaults/merge_test.go
@@ -1,0 +1,169 @@
+package defaults
+
+import (
+	"github.com/ghodss/yaml"
+	"github.com/sirupsen/logrus"
+	"testing"
+
+	"github.com/kiegroup/kie-cloud-operator/pkg/apis/app/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestMergeServices(t *testing.T) {
+	baseline, err := getConsole("trial", "test")
+	assert.Nil(t, err)
+	overwrite := baseline.DeepCopy()
+
+	service1 := baseline.Services[0]
+	service1.Labels["source"] = "baseline"
+	service1.Labels["baseline"] = "true"
+	service2 := service1.DeepCopy()
+	service2.Name = service1.Name + "-2"
+	service4 := service1.DeepCopy()
+	service4.Name = service1.Name + "-4"
+	baseline.Services = append(baseline.Services, *service2)
+	baseline.Services = append(baseline.Services, *service4)
+
+	service1b := overwrite.Services[0]
+	service1b.Labels["source"] = "overwrite"
+	service1b.Labels["overwrite"] = "true"
+	service3 := service1b.DeepCopy()
+	service3.Name = service1b.Name + "-3"
+	service5 := service1b.DeepCopy()
+	service5.Name = service1b.Name + "-4"
+	annotations := service5.Annotations
+	if annotations == nil {
+		annotations = make(map[string]string)
+		service5.Annotations = annotations
+	}
+	service5.Annotations["delete"] = "true"
+	overwrite.Services = append(overwrite.Services, *service3)
+	overwrite.Services = append(overwrite.Services, *service5)
+
+	merge(&baseline, overwrite)
+	assert.Equal(t, 3, len(baseline.Services), "Expected 3 services")
+	finalService1 := baseline.Services[0]
+	finalService2 := baseline.Services[1]
+	finalService3 := baseline.Services[2]
+	assert.Equal(t, "true", finalService1.Labels["baseline"], "Expected the baseline label to be set")
+	assert.Equal(t, "true", finalService1.Labels["overwrite"], "Expected the overwrite label to also be set as part of the merge")
+	assert.Equal(t, "overwrite", finalService1.Labels["source"], "Expected the source label to have been overwritten by merge")
+	assert.Equal(t, "true", finalService2.Labels["baseline"], "Expected the baseline label to be set")
+	assert.Equal(t, "baseline", finalService2.Labels["source"], "Expected the source label to be baseline")
+	assert.Equal(t, "true", finalService3.Labels["overwrite"], "Expected the baseline label to be set")
+	assert.Equal(t, "true", finalService3.Labels["overwrite"], "Expected the overwrite label to be set")
+	assert.Equal(t, "overwrite", finalService3.Labels["source"], "Expected the source label to be overwrite")
+	assert.Equal(t, "test-rhpamcentr-2", finalService2.Name, "Second service name should end with -2")
+	assert.Equal(t, "test-rhpamcentr-2", finalService2.Name, "Second service name should end with -3")
+}
+
+func TestMergeRoutes(t *testing.T) {
+	baseline, err := getConsole("trial", "test")
+	assert.Nil(t, err)
+	overwrite := baseline.DeepCopy()
+
+	route1 := baseline.Routes[0]
+	route1.Labels["source"] = "baseline"
+	route1.Labels["baseline"] = "true"
+	route2 := route1.DeepCopy()
+	route2.Name = route1.Name + "-2"
+	route4 := route1.DeepCopy()
+	route4.Name = route1.Name + "-4"
+	baseline.Routes = append(baseline.Routes, *route2)
+	baseline.Routes = append(baseline.Routes, *route4)
+
+	route1b := overwrite.Routes[0]
+	route1b.Labels["source"] = "overwrite"
+	route1b.Labels["overwrite"] = "true"
+	route3 := route1b.DeepCopy()
+	route3.Name = route1b.Name + "-3"
+	route5 := route1b.DeepCopy()
+	route5.Name = route1b.Name + "-4"
+	annotations := route5.Annotations
+	if annotations == nil {
+		annotations = make(map[string]string)
+		route5.Annotations = annotations
+	}
+	route5.Annotations["delete"] = "true"
+	overwrite.Routes = append(overwrite.Routes, *route3)
+	overwrite.Routes = append(overwrite.Routes, *route5)
+
+	merge(&baseline, overwrite)
+	assert.Equal(t, 3, len(baseline.Routes), "Expected 3 routes")
+	finalRoute1 := baseline.Routes[0]
+	finalRoute2 := baseline.Routes[1]
+	finalRoute3 := baseline.Routes[2]
+	assert.Equal(t, "true", finalRoute1.Labels["baseline"], "Expected the baseline label to be set")
+	assert.Equal(t, "true", finalRoute1.Labels["overwrite"], "Expected the overwrite label to also be set as part of the merge")
+	assert.Equal(t, "overwrite", finalRoute1.Labels["source"], "Expected the source label to have been overwritten by merge")
+	assert.Equal(t, "true", finalRoute2.Labels["baseline"], "Expected the baseline label to be set")
+	assert.Equal(t, "baseline", finalRoute2.Labels["source"], "Expected the source label to be baseline")
+	assert.Equal(t, "true", finalRoute3.Labels["overwrite"], "Expected the baseline label to be set")
+	assert.Equal(t, "true", finalRoute3.Labels["overwrite"], "Expected the overwrite label to be set")
+	assert.Equal(t, "overwrite", finalRoute3.Labels["source"], "Expected the source label to be overwrite")
+	assert.Equal(t, "test-rhpamcentr-2", finalRoute2.Name, "Second route name should end with -2")
+	assert.Equal(t, "test-rhpamcentr-2", finalRoute2.Name, "Second route name should end with -3")
+}
+
+func getConsole(environment string, name string) (v1.CustomObject, error) {
+	cr := &v1.KieApp{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "test-ns",
+		},
+		Spec: v1.KieAppSpec{
+			Environment: environment,
+		},
+	}
+
+	env, _, err := GetEnvironment(cr)
+	if err != nil {
+		return v1.CustomObject{}, err
+	}
+	return env.Console, nil
+}
+
+func TestMergeServerDeploymentConfigs(t *testing.T) {
+	var prodEnv v1.Environment
+	err := getParsedTemplate("envs/production-lite.yaml", "prod", &prodEnv)
+	assert.Nil(t, err, "Error: %v", err)
+
+	var servers v1.CustomObject
+	err = getParsedTemplate("common/server.yaml", "prod", &servers)
+	assert.Nil(t, err, "Error: %v", err)
+
+	baseEnvCount := len(servers.DeploymentConfigs[0].Spec.Template.Spec.Containers[0].Env)
+	prodEnvCount := len(prodEnv.Servers[0].DeploymentConfigs[0].Spec.Template.Spec.Containers[0].Env)
+
+	mergedDCs := mergeDeploymentConfigs(servers.DeploymentConfigs, prodEnv.Servers[0].DeploymentConfigs)
+
+	assert.NotNil(t, mergedDCs, "Must have encountered an error, merged DCs should not be null")
+	assert.Len(t, mergedDCs, 2, "Expect 2 deployment descriptors but got %v", len(mergedDCs))
+
+	mergedEnvCount := len(mergedDCs[0].Spec.Template.Spec.Containers[0].Env)
+	assert.True(t, mergedEnvCount > baseEnvCount, "Merged DC should have a higher number of environment variables than the base server")
+	assert.True(t, mergedEnvCount > prodEnvCount, "Merged DC should have a higher number of environment variables than the server")
+
+	assert.Len(t, mergedDCs[0].Spec.Template.Spec.Containers[0].Ports, 4, "Expecting 4 ports")
+}
+
+func getParsedTemplate(filename string, name string, object interface{}) error {
+	cr := &v1.KieApp{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "test-ns",
+		},
+	}
+	envTemplate := getEnvTemplate(cr)
+
+	yamlBytes, err := loadYaml((filename), envTemplate)
+	if err != nil {
+		return err
+	}
+	err = yaml.Unmarshal(yamlBytes, object)
+	if err != nil {
+		logrus.Error(err)
+	}
+	return nil
+}


### PR DESCRIPTION
The provided merge.go is not 100% complete, but goes a long way towards merging OpenShift objects. The production-lite.yaml starts validating this approach by taking out just a small subset of its content and moving them to server.yaml, with merge_test.go validating the result.

The defaults.go class has undergone minimal refactor to allow the use of envTemplate logic without breaking current usage.

Signed-off-by: Babak Mozaffari <bmozaffa@redhat.com>