### PR TITLE
[KIECLOUD-65] Allow unit testing for environment processing

### DIFF
--- a/pkg/apis/app/v1/kieapp_types.go
+++ b/pkg/apis/app/v1/kieapp_types.go
@@ -7,6 +7,8 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -100,6 +102,13 @@ type Template struct {
 	ControllerPassword string `json:"controllerPassword,omitempty"`
 	ServerPassword     string `json:"serverPassword,omitempty"`
 	MavenPassword      string `json:"mavenPassword,omitempty"`
+}
+
+type PlatformService interface {
+	GetClient() client.Client
+	GetRouteHost(route routev1.Route, cr *KieApp) string
+	UpdateObj(obj runtime.Object) (reconcile.Result, error)
+	CreateCustomObjects(object CustomObject, cr *KieApp) (reconcile.Result, error)
 }
 
 func init() {

--- a/pkg/controller/kieapp/kieapp_controller_test.go
+++ b/pkg/controller/kieapp/kieapp_controller_test.go
@@ -2,6 +2,7 @@ package kieapp
 
 import (
 	"fmt"
+	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/test"
 	"regexp"
 	"strings"
 	"testing"
@@ -131,4 +132,22 @@ func TestTrialServerEnv(t *testing.T) {
 		Value: "RedHat",
 	})
 	assert.Contains(t, env.Servers[cr.Spec.KieDeployments-1].DeploymentConfigs[0].Spec.Template.Spec.Containers[0].Env, commonAddition, "Environment additions not functional")
+}
+
+func TestGenerateSecret(t *testing.T) {
+	cr := &v1.KieApp{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: v1.KieAppSpec{
+			Environment: "trial",
+		},
+	}
+	env, err := defaults.GetEnvironment(cr, fake.NewFakeClient())
+	assert.Nil(t, err, "Error getting a new environment")
+	assert.Len(t, env.Console.Secrets, 0, "No secret is available when reading the trial workbench from yaml files")
+
+	env, _, err = NewEnv(test.MockPlatformService{}, cr)
+	assert.Nil(t, err, "Error creating a new environment")
+	assert.Len(t, env.Console.Secrets, 1, "One secret should be generated for the trial workbench")
 }

--- a/pkg/controller/kieapp/test/mock_service.go
+++ b/pkg/controller/kieapp/test/mock_service.go
@@ -1,0 +1,31 @@
+package test
+
+import (
+	"github.com/kiegroup/kie-cloud-operator/pkg/apis/app/v1"
+	routev1 "github.com/openshift/api/route/v1"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type MockPlatformService struct{}
+
+func (MockPlatformService) GetClient() client.Client {
+	return fake.NewFakeClient()
+}
+
+func (MockPlatformService) GetRouteHost(route routev1.Route, cr *v1.KieApp) string {
+	return "www.example.com"
+}
+
+func (MockPlatformService) UpdateObj(obj runtime.Object) (reconcile.Result, error) {
+	logrus.Debugf("Mock service will do no-op in lieu of updating %v", obj)
+	return reconcile.Result{}, nil
+}
+
+func (MockPlatformService) CreateCustomObjects(object v1.CustomObject, cr *v1.KieApp) (reconcile.Result, error) {
+	logrus.Debugf("Mock service will do no-op in lieu of creating %v with CR %v", object, cr)
+	return reconcile.Result{}, nil
+}


### PR DESCRIPTION
Allow unit testing to extend beyond reading environments from files.

The new PlatformService represents some of the actions not available outside of Kubernetes, that are now mocked up by the test.MockPlatformService for use in unit tests

Signed-off-by: Babak Mozaffari <bmozaffa@redhat.com>