### PR TITLE
[KIECLOUD-78] Change most log lines for SugaredLogger format

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -39,14 +39,14 @@ func main() {
 
 	namespace, err := k8sutil.GetWatchNamespace()
 	if err != nil {
-		log.Error(err, "failed to get watch namespace")
+		log.Error("Failed to get watch namespace. ", err)
 		os.Exit(1)
 	}
 
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()
 	if err != nil {
-		log.Error(err, "Error while getting config")
+		log.Error("Error while getting config. ", err)
 		os.Exit(1)
 	}
 
@@ -56,7 +56,7 @@ func main() {
 	r := ready.NewFileReady()
 	err = r.Set()
 	if err != nil {
-		log.Error(err, "Error on NewFileReady()")
+		log.Error("Error on NewFileReady(). ", err)
 		os.Exit(1)
 	}
 	defer r.Unset()
@@ -65,7 +65,7 @@ func main() {
 	syncPeriod := time.Duration(2) * time.Hour
 	mgr, err := manager.New(cfg, manager.Options{Namespace: namespace, SyncPeriod: &syncPeriod})
 	if err != nil {
-		log.Error(err, "Error getting Manager")
+		log.Error("Error getting Manager. ", err)
 		os.Exit(1)
 	}
 
@@ -73,13 +73,13 @@ func main() {
 
 	// Setup Scheme for all resources
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
-		log.Error(err, "Error on AddToScheme")
+		log.Error("Error on AddToScheme. ", err)
 		os.Exit(1)
 	}
 
 	// Setup all Controllers
 	if err := controller.AddToManager(mgr); err != nil {
-		log.Error(err, "Error adding controllers to Manager")
+		log.Error("Error adding controllers to Manager. ", err)
 		os.Exit(1)
 	}
 
@@ -87,7 +87,7 @@ func main() {
 
 	// Start the Cmd
 	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
-		log.Error(err, "manager exited non-zero")
+		log.Error("Manager exited non-zero. ", err)
 		os.Exit(1)
 	}
 }

--- a/pkg/controller/kieapp/defaults/defaults.go
+++ b/pkg/controller/kieapp/defaults/defaults.go
@@ -126,13 +126,13 @@ func parseTemplate(e v1.EnvTemplate, objYaml string) []byte {
 
 	tmpl, err := template.New(e.ApplicationName).Parse(objYaml)
 	if err != nil {
-		log.Error(err, "Error creating new Go template")
+		log.Error("Error creating new Go template. ", err)
 	}
 
 	// template replacement
 	err = tmpl.Execute(&b, e)
 	if err != nil {
-		log.Error(err, "Error applying Go template")
+		log.Error("Error applying Go template. ", err)
 	}
 
 	return b.Bytes()
@@ -155,7 +155,7 @@ func ConfigMapsFromFile(namespace string) []corev1.ConfigMap {
 	for _, filename := range box.List() {
 		s, err := box.FindString(filename)
 		if err != nil {
-			log.Error(err, "Error finding file with packr")
+			log.Error("Error finding file with packr. ", err)
 		}
 		cmData := map[string]string{}
 		cmName, file := convertToConfigMapName(filename)

--- a/pkg/controller/kieapp/defaults/defaults_test.go
+++ b/pkg/controller/kieapp/defaults/defaults_test.go
@@ -16,7 +16,7 @@ func TestLoadUnknownEnvironment(t *testing.T) {
 	defer func() {
 		err := recover()
 		if err != nil {
-			log.Error(err.(error), "")
+			log.Error(err)
 		}
 	}()
 
@@ -63,7 +63,7 @@ func TestMultipleServerDeployment(t *testing.T) {
 	defer func() {
 		err := recover()
 		if err != nil {
-			log.Error(err.(error), "")
+			log.Error(err)
 		}
 	}()
 

--- a/pkg/controller/kieapp/defaults/merge.go
+++ b/pkg/controller/kieapp/defaults/merge.go
@@ -59,7 +59,7 @@ func mergePersistentVolumeClaims(baseline []corev1.PersistentVolumeClaim, overwr
 		slice := make([]corev1.PersistentVolumeClaim, combinedSize(baselineRefs, overwriteRefs))
 		err := mergeObjects(baselineRefs, overwriteRefs, slice)
 		if err != nil {
-			log.Error(err, "Error merging objects")
+			log.Error("Error merging objects. ", err)
 			return nil
 		}
 		return slice
@@ -85,7 +85,7 @@ func mergeServiceAccounts(baseline []corev1.ServiceAccount, overwrite []corev1.S
 		slice := make([]corev1.ServiceAccount, combinedSize(baselineRefs, overwriteRefs))
 		err := mergeObjects(baselineRefs, overwriteRefs, slice)
 		if err != nil {
-			log.Error(err, "Error merging objects")
+			log.Error("Error merging objects. ", err)
 			return nil
 		}
 		return slice
@@ -111,7 +111,7 @@ func mergeSecrets(baseline []corev1.Secret, overwrite []corev1.Secret) []corev1.
 		slice := make([]corev1.Secret, combinedSize(baselineRefs, overwriteRefs))
 		err := mergeObjects(baselineRefs, overwriteRefs, slice)
 		if err != nil {
-			log.Error(err, "Error merging objects")
+			log.Error("Error merging objects. ", err)
 			return nil
 		}
 		return slice
@@ -137,7 +137,7 @@ func mergeRoles(baseline []rbacv1.Role, overwrite []rbacv1.Role) []rbacv1.Role {
 		slice := make([]rbacv1.Role, combinedSize(baselineRefs, overwriteRefs))
 		err := mergeObjects(baselineRefs, overwriteRefs, slice)
 		if err != nil {
-			log.Error(err, "Error merging objects")
+			log.Error("Error merging objects. ", err)
 			return nil
 		}
 		return slice
@@ -155,7 +155,7 @@ func mergeRoleBindings(baseline []rbacv1.RoleBinding, overwrite []rbacv1.RoleBin
 		slice := make([]rbacv1.RoleBinding, combinedSize(baselineRefs, overwriteRefs))
 		err := mergeObjects(baselineRefs, overwriteRefs, slice)
 		if err != nil {
-			log.Error(err, "Error merging objects")
+			log.Error("Error merging objects. ", err)
 			return nil
 		}
 		return slice
@@ -194,12 +194,12 @@ func mergeDeploymentConfigs(baseline []appsv1.DeploymentConfig, overwrite []apps
 			baselineItem := baseline[baselineIndex]
 			err := mergo.Merge(&overwriteItem.ObjectMeta, baselineItem.ObjectMeta)
 			if err != nil {
-				log.Error(err, "Error merging interfaces")
+				log.Error("Error merging interfaces. ", err)
 				return nil
 			}
 			mergedSpec, err := mergeSpec(baselineItem.Spec, overwriteItem.Spec)
 			if err != nil {
-				log.Error(err, "Error merging DeploymentConfig Specs")
+				log.Error("Error merging DeploymentConfig Specs. ", err)
 				return nil
 			}
 			overwriteItem.Spec = mergedSpec
@@ -208,7 +208,7 @@ func mergeDeploymentConfigs(baseline []appsv1.DeploymentConfig, overwrite []apps
 	slice := make([]appsv1.DeploymentConfig, combinedSize(baselineRefs, overwriteRefs))
 	err := mergeObjects(baselineRefs, overwriteRefs, slice)
 	if err != nil {
-		log.Error(err, "Error merging objects")
+		log.Error("Error merging objects. ", err)
 		return nil
 	}
 	return slice
@@ -241,7 +241,7 @@ func mergeTemplate(baseline *corev1.PodTemplateSpec, overwrite *corev1.PodTempla
 	}
 	err := mergo.Merge(&overwrite.ObjectMeta, baseline.ObjectMeta)
 	if err != nil {
-		log.Error(err, "Error merging interfaces")
+		log.Error("Error merging interfaces. ", err)
 		return nil, nil
 	}
 	mergedPodSpec, err := mergePodSpecs(baseline.Spec, overwrite.Spec)
@@ -492,7 +492,7 @@ func mergeServices(baseline []corev1.Service, overwrite []corev1.Service) []core
 				baselineItem := baseline[baselineIndex]
 				err := mergo.Merge(&overwriteItem.ObjectMeta, baselineItem.ObjectMeta)
 				if err != nil {
-					log.Error(err, "Error merging interfaces")
+					log.Error("Error merging interfaces. ", err)
 					return nil
 				}
 				overwriteItem.Spec.Ports = mergeServicePorts(baselineItem.Spec.Ports, overwriteItem.Spec.Ports)
@@ -501,7 +501,7 @@ func mergeServices(baseline []corev1.Service, overwrite []corev1.Service) []core
 		slice := make([]corev1.Service, combinedSize(baselineRefs, overwriteRefs))
 		err := mergeObjects(baselineRefs, overwriteRefs, slice)
 		if err != nil {
-			log.Error(err, "Error merging objects")
+			log.Error("Error merging objects. ", err)
 			return nil
 		}
 		return slice
@@ -561,7 +561,7 @@ func mergeRoutes(baseline []routev1.Route, overwrite []routev1.Route) []routev1.
 		slice := make([]routev1.Route, combinedSize(baselineRefs, overwriteRefs))
 		err := mergeObjects(baselineRefs, overwriteRefs, slice)
 		if err != nil {
-			log.Error(err, "Error merging objects")
+			log.Error("Error merging objects. ", err)
 			return nil
 		}
 		return slice

--- a/pkg/controller/kieapp/defaults/merge_test.go
+++ b/pkg/controller/kieapp/defaults/merge_test.go
@@ -363,7 +363,7 @@ func getParsedTemplate(filename string, name string, object interface{}) error {
 	}
 	err = yaml.Unmarshal(yamlBytes, object)
 	if err != nil {
-		log.Error(err, "Error unmarshalling yaml")
+		log.Error("Error unmarshalling yaml. ", err)
 	}
 	return nil
 }

--- a/pkg/controller/kieapp/kieapp_controller_test.go
+++ b/pkg/controller/kieapp/kieapp_controller_test.go
@@ -34,7 +34,7 @@ func TestUnknownEnvironmentObjects(t *testing.T) {
 	env = ConsolidateObjects(env, cr)
 	assert.NotNil(t, err)
 
-	log.Debug(fmt.Sprintf("Testing with environment %v", cr.Spec.Environment))
+	log.Debug("Testing with environment ", cr.Spec.Environment)
 	assert.Equal(t, v1.Environment{}, env, "Env object should be empty")
 }
 
@@ -67,7 +67,7 @@ func TestTrialConsoleEnv(t *testing.T) {
 
 	env, err := defaults.GetEnvironment(cr, fake.NewFakeClient())
 	if !assert.Nil(t, err, "error should be nil") {
-		log.Error(err, "Error getting environment")
+		log.Error("Error getting environment. ", err)
 	}
 	env = ConsolidateObjects(env, cr)
 
@@ -116,7 +116,7 @@ func TestTrialServerEnv(t *testing.T) {
 
 	env, err := defaults.GetEnvironment(cr, fake.NewFakeClient())
 	if !assert.Nil(t, err, "error should be nil") {
-		log.Error(err, "Error getting environment")
+		log.Error("Error getting environment. ", err)
 	}
 	env.Servers[cr.Spec.KieDeployments-1].DeploymentConfigs[0].Spec.Template.Spec.Containers[0].Env = append(env.Servers[cr.Spec.KieDeployments-1].DeploymentConfigs[0].Spec.Template.Spec.Containers[0].Env, commonAddition)
 	env = ConsolidateObjects(env, cr)
@@ -150,7 +150,7 @@ func TestRhpamRegistry(t *testing.T) {
 	}
 	_, err := defaults.GetEnvironment(cr, fake.NewFakeClient())
 	if !assert.Nil(t, err, "error should be nil") {
-		log.Error(err, "Error getting environment")
+		log.Error("Error getting environment. ", err)
 	}
 	assert.Equal(t, registry1, cr.Spec.RhpamRegistry.Registry)
 	assert.Equal(t, true, cr.Spec.RhpamRegistry.Insecure)
@@ -169,7 +169,7 @@ func TestRhpamRegistry(t *testing.T) {
 	}
 	_, err = defaults.GetEnvironment(cr2, fake.NewFakeClient())
 	if !assert.Nil(t, err, "error should be nil") {
-		log.Error(err, "Error getting environment")
+		log.Error("Error getting environment. ", err)
 	}
 	assert.Equal(t, registry2, cr2.Spec.RhpamRegistry.Registry)
 	assert.Equal(t, false, cr2.Spec.RhpamRegistry.Insecure)

--- a/pkg/controller/kieapp/kieserver/objects.go
+++ b/pkg/controller/kieapp/kieserver/objects.go
@@ -16,7 +16,7 @@ func ConstructObject(object v1.CustomObject, cr *v1.KieApp) v1.CustomObject {
 
 			err := mergo.Merge(&c.Resources, cr.Spec.Objects.Server.Resources, mergo.WithOverride)
 			if err != nil {
-				log.Error(err, "Error merging interfaces")
+				log.Error("Error merging interfaces. ", err)
 			}
 			dc.Spec.Template.Spec.Containers[containerIndex] = c
 		}

--- a/pkg/controller/kieapp/rhpamcentr/objects.go
+++ b/pkg/controller/kieapp/rhpamcentr/objects.go
@@ -16,7 +16,7 @@ func ConstructObject(object v1.CustomObject, cr *v1.KieApp) v1.CustomObject {
 
 			err := mergo.Merge(&c.Resources, cr.Spec.Objects.Console.Resources, mergo.WithOverride)
 			if err != nil {
-				log.Error(err, "Error merging interfaces")
+				log.Error("Error merging interfaces. ", err)
 			}
 			dc.Spec.Template.Spec.Containers[containerIndex] = c
 		}

--- a/pkg/controller/kieapp/shared/utils.go
+++ b/pkg/controller/kieapp/shared/utils.go
@@ -49,7 +49,7 @@ func getEnvVars(defaults map[string]string, vars []corev1.EnvVar) []corev1.EnvVa
 func GenerateKeystore(commonName, alias string, password []byte) []byte {
 	cert, derPK, err := genCert(commonName)
 	if err != nil {
-		log.Error(err, "Error generating certificate")
+		log.Error("Error generating certificate. ", err)
 	}
 
 	var chain []keystore.Certificate
@@ -69,7 +69,7 @@ func GenerateKeystore(commonName, alias string, password []byte) []byte {
 	var b bytes.Buffer
 	err = keystore.Encode(&b, keyStore, password)
 	if err != nil {
-		log.Error(err, "Error encryting and signing keystore")
+		log.Error("Error encryting and signing keystore. ", err)
 	}
 
 	return b.Bytes()
@@ -89,7 +89,7 @@ func genCert(commonName string) (cert []byte, derPK []byte, err error) {
 
 	serialNumber, err := crand.Int(crand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
 	if err != nil {
-		log.Error(err, "Error getting serial number")
+		log.Error("Error getting serial number. ", err)
 		return nil, nil, err
 	}
 
@@ -110,19 +110,19 @@ func genCert(commonName string) (cert []byte, derPK []byte, err error) {
 
 	priv, err := rsa.GenerateKey(crand.Reader, 2048)
 	if err != nil {
-		log.Error(err, "create key failed")
+		log.Error("create key failed. ", err)
 		return nil, nil, err
 	}
 
 	cert, err = x509.CreateCertificate(crand.Reader, ca, ca, &priv.PublicKey, priv)
 	if err != nil {
-		log.Error(err, "create cert failed")
+		log.Error("create cert failed. ", err)
 		return nil, nil, err
 	}
 
 	derPK, err = x509.MarshalPKCS8PrivateKey(priv)
 	if err != nil {
-		log.Error(err, "Marshal to PKCS8 key failed")
+		log.Error("Marshal to PKCS8 key failed. ", err)
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
 - reorder args sent to logger for most log items

Error, Info, Warn, & Debug all use fmt.Sprint to construct and log a message.
https://godoc.org/go.uber.org/zap#SugaredLogger.Error

Signed-off-by: tchughesiv <tchughesiv@gmail.com>