### PR TITLE
[KIECLOUD-88] Allow immutable environment with multiple KIE servers

### DIFF
--- a/config/envs/production-immutable.yaml
+++ b/config/envs/production-immutable.yaml
@@ -86,14 +86,6 @@ servers:
                 - name: "{{.ApplicationName}}-kieserver-{{$index}}"
                   image: "{{.ApplicationName}}-kieserver-{{$index}}"
                   env:
-                    - name: KIE_SERVER_CONTROLLER_USER
-                      value: ""
-                    - name: KIE_SERVER_CONTROLLER_PWD
-                      value: ""
-                    - name: KIE_SERVER_CONTROLLER_SERVICE
-                      value: ""
-                    - name: KIE_SERVER_CONTROLLER_TOKEN
-                      value: ""
                     - name: EXTERNAL_MAVEN_REPO_ID
                       value: ""
                     - name: EXTERNAL_MAVEN_REPO_URL

--- a/deploy/crs/kieapp_production-immutable.yaml
+++ b/deploy/crs/kieapp_production-immutable.yaml
@@ -5,8 +5,8 @@ metadata:
 spec:
   environment: production-immutable
   objects:
-    build:
-      kieServerContainerDeployment: rhpam-kieserver-library=org.openshift.quickstarts:rhpam-kieserver-library:1.4.0-SNAPSHOT
+    builds:
+    - kieServerContainerDeployment: rhpam-kieserver-library=org.openshift.quickstarts:rhpam-kieserver-library:1.4.0-SNAPSHOT
       gitSource:
         uri: https://github.com/jboss-container-images/rhpam-7-openshift-image.git
         reference: master

--- a/pkg/apis/app/v1/kieapp_types.go
+++ b/pkg/apis/app/v1/kieapp_types.go
@@ -71,7 +71,7 @@ type KieAppObjects struct {
 	// Smartrouter container configs
 	Smartrouter KieAppObject `json:"smartrouter,omitempty"`
 	// S2I Build configuration
-	Build KieAppBuildObject `json:"build,omitempty"`
+	Builds []KieAppBuildObject `json:"builds,omitempty"`
 }
 
 type KieAppObject struct {

--- a/pkg/apis/app/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/app/v1/zz_generated.deepcopy.go
@@ -317,7 +317,13 @@ func (in *KieAppObjects) DeepCopyInto(out *KieAppObjects) {
 	in.Console.DeepCopyInto(&out.Console)
 	in.Server.DeepCopyInto(&out.Server)
 	in.Smartrouter.DeepCopyInto(&out.Smartrouter)
-	in.Build.DeepCopyInto(&out.Build)
+	if in.Builds != nil {
+		in, out := &in.Builds, &out.Builds
+		*out = make([]KieAppBuildObject, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
- Schema change to allow an array of KieAppBuildObject entries, where each indicates a KIE server deployment
- Template change to populate each iteration of KIE server template individually based on provided build config details
- Removing KIE_SERVER_CONTROLLER paramenters to allow connection to monitoring console

Signed-off-by: Babak Mozaffari <bmozaffa@redhat.com>