### PR TITLE
[KIECLOUD-90] authoring-ha db env & bc role fixes

### DIFF
--- a/config/envs/authoring-ha.yaml
+++ b/config/envs/authoring-ha.yaml
@@ -407,6 +407,8 @@ servers:
                       value: "{{.ApplicationName}}-mysql"
                     - name: RHPAM_SERVICE_PORT
                       value: "3306"
+                    - name: RHPAM_XA_CONNECTION_PROPERTY_URL
+                      value: ""
                     ## MySQL driver settings END
                     - name: TIMER_SERVICE_DATA_STORE_REFRESH_INTERVAL
                       value: "60000"

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -37,6 +37,7 @@ rules:
       - app.kiegroup.org
       - apps.openshift.io
       - image.openshift.io
+      - build.openshift.io
       - route.openshift.io
     resources:
       - "*"


### PR DESCRIPTION
 - unset `RHPAM_XA_CONNECTION_PROPERTY_URL` env var, similarly done in other envs.
 - add permission for buildconfigs to operator role

Signed-off-by: tchughesiv <tchughesiv@gmail.com>