### PR TITLE
[KIECLOUD-89] Log messages should be in lowercase. Refactor pwd gener…

### DIFF
--- a/pkg/controller/kieapp/defaults/defaults.go
+++ b/pkg/controller/kieapp/defaults/defaults.go
@@ -88,11 +88,7 @@ func getEnvTemplate(cr *v1.KieApp) v1.EnvTemplate {
 		}
 	}
 
-	setPassword(&config.KeyStorePassword, isTrialEnv)
-	setPassword(&config.AdminPassword, isTrialEnv)
-	setPassword(&config.ControllerPassword, isTrialEnv)
-	setPassword(&config.ServerPassword, isTrialEnv)
-	setPassword(&config.MavenPassword, isTrialEnv)
+	setPasswords(config, isTrialEnv)
 
 	crTemplate := v1.Template{
 		CommonConfig:    config,
@@ -121,14 +117,23 @@ func getEnvTemplate(cr *v1.KieApp) v1.EnvTemplate {
 	return envTemplate
 }
 
-func setPassword(password *string, isTrialEnv bool) {
-	if len(*password) != 0 {
-		return
-	}
-	if isTrialEnv {
-		*password = constants.DefaultPassword
-	} else {
-		*password = string(shared.GeneratePassword(8))
+func setPasswords(config *v1.CommonConfig, isTrialEnv bool) {
+	passwords := []*string{
+		&config.KeyStorePassword,
+		&config.AdminPassword,
+		&config.ConsoleImage,
+		&config.MavenPassword,
+		&config.ServerPassword}
+
+	for i := range passwords {
+		if len(*passwords[i]) != 0 {
+			continue
+		}
+		if isTrialEnv {
+			*passwords[i] = constants.DefaultPassword
+		} else {
+			*passwords[i] = string(shared.GeneratePassword(8))
+		}
 	}
 }
 

--- a/pkg/controller/kieapp/defaults/defaults.go
+++ b/pkg/controller/kieapp/defaults/defaults.go
@@ -87,41 +87,12 @@ func getEnvTemplate(cr *v1.KieApp) v1.EnvTemplate {
 			config.ConsoleImage = constants.RhpamcentrImageName
 		}
 	}
-	if len(config.KeyStorePassword) == 0 {
-		if isTrialEnv {
-			config.KeyStorePassword = constants.DefaultPassword
-		} else {
-			config.KeyStorePassword = string(shared.GeneratePassword(8))
-		}
-	}
-	if len(config.AdminPassword) == 0 {
-		if isTrialEnv {
-			config.AdminPassword = constants.DefaultPassword
-		} else {
-			config.AdminPassword = string(shared.GeneratePassword(8))
-		}
-	}
-	if len(config.ControllerPassword) == 0 {
-		if isTrialEnv {
-			config.ControllerPassword = constants.DefaultPassword
-		} else {
-			config.ControllerPassword = string(shared.GeneratePassword(8))
-		}
-	}
-	if len(config.ServerPassword) == 0 {
-		if isTrialEnv {
-			config.ServerPassword = constants.DefaultPassword
-		} else {
-			config.ServerPassword = string(shared.GeneratePassword(8))
-		}
-	}
-	if len(config.MavenPassword) == 0 {
-		if isTrialEnv {
-			config.MavenPassword = constants.DefaultPassword
-		} else {
-			config.MavenPassword = string(shared.GeneratePassword(8))
-		}
-	}
+
+	setPassword(&config.KeyStorePassword, isTrialEnv)
+	setPassword(&config.AdminPassword, isTrialEnv)
+	setPassword(&config.ControllerPassword, isTrialEnv)
+	setPassword(&config.ServerPassword, isTrialEnv)
+	setPassword(&config.MavenPassword, isTrialEnv)
 
 	crTemplate := v1.Template{
 		CommonConfig:    config,
@@ -148,6 +119,17 @@ func getEnvTemplate(cr *v1.KieApp) v1.EnvTemplate {
 	}
 
 	return envTemplate
+}
+
+func setPassword(password *string, isTrialEnv bool) {
+	if len(*password) != 0 {
+		return
+	}
+	if isTrialEnv {
+		*password = constants.DefaultPassword
+	} else {
+		*password = string(shared.GeneratePassword(8))
+	}
 }
 
 func getWebhookSecret(webhookType v1.WebhookType, webhooks []v1.WebhookSecret) string {

--- a/pkg/controller/kieapp/defaults/merge.go
+++ b/pkg/controller/kieapp/defaults/merge.go
@@ -31,7 +31,7 @@ func merge(baseline v1.Environment, overwrite v1.Environment) (v1.Environment, e
 		}
 	}
 	if len(baseline.Servers) != len(overwrite.Servers) {
-		return v1.Environment{}, errors.New("Incompatible objects with different array lengths cannot be merged")
+		return v1.Environment{}, errors.New("incompatible objects with different array lengths cannot be merged")
 	}
 	for index := range baseline.Servers {
 		mergedObject := mergeCustomObject(baseline.Servers[index], overwrite.Servers[index])


### PR DESCRIPTION
* Log messages in Go should start with lower case
* Password generation logic extracted to a new function to reduce duplicity

Fix https://issues.jboss.org/browse/KIECLOUD-89

Signed-off-by: Ruben Romero Montes <rromerom@redhat.com>