### PR TITLE
[KIECLOUD-93] Add OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - bmozaffa
+  - tchughesiv
+  - ruromero
+approvers:
+  - bmozaffa


### PR DESCRIPTION
Signed-off-by: Ruben Romero Montes <rromerom@redhat.com>

Fix https://issues.jboss.org/browse/KIECLOUD-93

Adding OWNERS file required by the ci tool ([Prow approve plugin](https://github.com/kubernetes/test-infra/tree/master/prow/plugins/approve/approvers))