### PR TITLE
[KIECLOUD-53] ConfigMap & reconcile improvements

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1068,6 +1068,7 @@
     "go.uber.org/zap",
     "go.uber.org/zap/zapcore",
     "golang.org/x/sync/errgroup",
+    "k8s.io/api/apps/v1",
     "k8s.io/api/core/v1",
     "k8s.io/api/rbac/v1",
     "k8s.io/apimachinery/pkg/api/errors",

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/kiegroup/kie-cloud-operator/pkg/apis"
 	"github.com/kiegroup/kie-cloud-operator/pkg/controller"
+	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/constants"
 	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/logs"
 	"github.com/kiegroup/kie-cloud-operator/version"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
@@ -90,6 +91,14 @@ func main() {
 	}
 
 	log.Info("Starting the Operator.")
+
+	message := "ConfigMaps not available. Using embedded configs."
+	if os.Getenv(constants.NameSpaceEnv) == "" {
+		log.Warnf("%s required env %s not set, please configure downward API", message, constants.NameSpaceEnv)
+	}
+	if os.Getenv(constants.OpNameEnv) == "" {
+		log.Warnf("%s required env %s not set, please configure env", message, constants.OpNameEnv)
+	}
 
 	// Start the Cmd
 	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {

--- a/pkg/controller/kieapp/constants/constants.go
+++ b/pkg/controller/kieapp/constants/constants.go
@@ -25,6 +25,12 @@ const (
 	DefaultPassword = "RedHat"
 	// SSODefaultPrincipalAttribute default PrincipalAttribute to use for SSO integration
 	SSODefaultPrincipalAttribute = "preferred_username"
+	// NameSpaceEnv is an environment variable of the current namespace
+	// set via downward api when the code is running via deployment
+	NameSpaceEnv = "WATCH_NAMESPACE"
+	// OpNameEnv is an environment variable of the operator name
+	// set when the code is running via deployment
+	OpNameEnv = "OPERATOR_NAME"
 )
 
 // MonitoringEnvs Type of environments that will deploy the Monitoring console.

--- a/pkg/controller/kieapp/kieapp_controller.go
+++ b/pkg/controller/kieapp/kieapp_controller.go
@@ -8,17 +8,17 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/status"
-
 	"github.com/kiegroup/kie-cloud-operator/pkg/apis/app/v1"
 	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/constants"
 	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/defaults"
 	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/logs"
 	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/shared"
+	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/status"
 	oappsv1 "github.com/openshift/api/apps/v1"
 	buildv1 "github.com/openshift/api/build/v1"
 	oimagev1 "github.com/openshift/api/image/v1"
 	routev1 "github.com/openshift/api/route/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -43,9 +43,15 @@ type Reconciler struct {
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (reconciler *Reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	// Create critical ConfigMaps if don't exist
-	if result, err := reconciler.createConfigMaps(request.Namespace); err != nil {
-		return result, err
+	if opName, depNameSpace, useEmbedded := defaults.UseEmbeddedFiles(reconciler.Service); !useEmbedded {
+		myDep := &appsv1.Deployment{}
+		err := reconciler.Service.Get(context.TODO(), types.NamespacedName{Namespace: depNameSpace, Name: opName}, myDep)
+		if err == nil {
+			// Reconcile ConfigMaps
+			reconciler.CreateConfigMaps(myDep)
+		} else {
+			log.Error("Can't properly create ConfigMaps. ", err)
+		}
 	}
 
 	// Fetch the KieApp instance
@@ -79,6 +85,7 @@ func (reconciler *Reconciler) Reconcile(request reconcile.Request) (reconcile.Re
 		return reconcile.Result{}, err
 	}
 	dcNames := getDcNames(dcList.Items, instance)
+	instance.Status.Deployments = dcNames
 
 	// Update DeploymentConfigs if needed
 	var dcUpdates []oappsv1.DeploymentConfig
@@ -116,7 +123,9 @@ func (reconciler *Reconciler) Reconcile(request reconcile.Request) (reconcile.Re
 				return rResult, err
 			}
 		}
-		return rResult, nil
+		if status.SetProvisioning(instance) {
+			return reconciler.UpdateObj(instance)
+		}
 	}
 
 	// Fetch the cached KieApp instance
@@ -133,17 +142,21 @@ func (reconciler *Reconciler) Reconcile(request reconcile.Request) (reconcile.Re
 		reconciler.setFailedStatus(instance, v1.UnknownReason, err)
 		return reconcile.Result{}, err
 	}
-	instance.Status.Deployments = dcNames
 
 	// Update CR if needed
 	if !reflect.DeepEqual(instance.Status, cachedInstance.Status) || !reflect.DeepEqual(instance.Spec, cachedInstance.Spec) {
-		status.SetProvisioning(instance)
-		return reconciler.UpdateObj(instance)
+		if status.SetProvisioning(instance) && instance.ResourceVersion == cachedInstance.ResourceVersion {
+			return reconciler.UpdateObj(instance)
+		}
+		return reconcile.Result{Requeue: true}, nil
 	}
-	status.SetDeployed(instance)
-	if !reflect.DeepEqual(instance.Status, cachedInstance.Status) {
-		return reconciler.UpdateObj(instance)
+	if status.SetDeployed(instance) {
+		if instance.ResourceVersion == cachedInstance.ResourceVersion {
+			return reconciler.UpdateObj(instance)
+		}
+		return reconcile.Result{Requeue: true}, nil
 	}
+
 	return reconcile.Result{}, nil
 }
 
@@ -153,35 +166,6 @@ func (reconciler *Reconciler) setFailedStatus(instance *v1.KieApp, reason v1.Rea
 	if updateError != nil {
 		log.Warn("Unable to update object after receiving failed status. ", err)
 	}
-}
-
-func (reconciler *Reconciler) createConfigMaps(namespace string) (reconcile.Result, error) {
-	configMaps := defaults.ConfigMapsFromFile(namespace)
-	for _, configMap := range configMaps {
-		var testDir bool
-		result := strings.Split(configMap.Name, "-")
-		if len(result) > 1 {
-			if result[1] == "testdata" {
-				testDir = true
-			}
-		}
-		// don't create configmaps for test directories
-		if !testDir {
-			configMap.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("ConfigMap"))
-			emptyObj := &corev1.ConfigMap{}
-			err := reconciler.Service.Get(context.TODO(), types.NamespacedName{Name: configMap.Name, Namespace: configMap.Namespace}, emptyObj)
-			if err != nil {
-				_, err := reconciler.createObj(
-					&configMap,
-					err,
-				)
-				if err != nil && !errors.IsAlreadyExists(err) {
-					return reconcile.Result{RequeueAfter: time.Duration(1) * time.Second}, err
-				}
-			}
-		}
-	}
-	return reconcile.Result{}, nil
 }
 
 // Check ImageStream
@@ -530,7 +514,7 @@ func (reconciler *Reconciler) UpdateObj(obj v1.OpenShiftObject) (reconcile.Resul
 		log.Warn("Failed to update object. ", err)
 		return reconcile.Result{}, err
 	}
-	// Spec updated - return and requeue
+	// Object updated - return and requeue
 	return reconcile.Result{Requeue: true}, nil
 }
 
@@ -588,4 +572,62 @@ func (reconciler *Reconciler) GetRouteHost(route routev1.Route, cr *v1.KieApp) s
 	}
 
 	return found.Spec.Host
+}
+
+// CreateConfigMaps generates & creates necessary ConfigMaps from embedded files
+func (reconciler *Reconciler) CreateConfigMaps(myDep *appsv1.Deployment) {
+	configMaps := defaults.ConfigMapsFromFile(myDep, myDep.Namespace, reconciler.Service.GetScheme())
+	for _, configMap := range configMaps {
+		var testDir bool
+		result := strings.Split(configMap.Name, "-")
+		if len(result) > 1 {
+			if result[1] == "testdata" {
+				testDir = true
+			}
+		}
+		// don't create configmaps for test directories
+		if !testDir {
+			// if configmap already exists, compare to new
+			if existingCM, exists := reconciler.createConfigMap(&configMap); exists {
+				// if new configmap and existing have different data
+				if !reflect.DeepEqual(configMap.Data, existingCM.Data) || !reflect.DeepEqual(configMap.BinaryData, existingCM.BinaryData) {
+					log.Infof("Differences detected in %s ConfigMap.", configMap.Name)
+					existingCM.Name = strings.Join([]string{configMap.Name, "bak"}, "-")
+					for annotation, ver := range configMap.Annotations {
+						if annotation == v1.SchemeGroupVersion.Group {
+							existingCM.Name = strings.Join([]string{configMap.Name, ver, "bak"}, "-")
+						}
+					}
+					existingCM.ResourceVersion = ""
+					existingCM.OwnerReferences = nil
+					// create a backup configmap of existing
+					// if backup configmap already exists, overwrite w/ new backup
+					if existingBackupCM, exists := reconciler.createConfigMap(existingCM); exists {
+						// if backup configmap and existing backup have different data
+						if !reflect.DeepEqual(existingCM.Data, existingBackupCM.Data) || !reflect.DeepEqual(existingCM.BinaryData, existingBackupCM.BinaryData) {
+							existingBackupCM.Data = existingCM.Data
+							reconciler.UpdateObj(existingBackupCM)
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// createConfigMap creates an individual ConfigMap, will return the existing ConfigMap object should one exist
+func (reconciler *Reconciler) createConfigMap(obj v1.OpenShiftObject) (*corev1.ConfigMap, bool) {
+	emptyObj := &corev1.ConfigMap{}
+	err := reconciler.Service.Get(context.TODO(), types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, emptyObj)
+	if errors.IsNotFound(err) {
+		// attempt creation of configmap if doesn't exist
+		_, err = reconciler.createObj(obj, err)
+		return &corev1.ConfigMap{}, false
+	} else if err != nil {
+		if err != nil {
+			log.Error(err)
+		}
+		return &corev1.ConfigMap{}, false
+	}
+	return emptyObj, true
 }


### PR DESCRIPTION
 - initialize ConfigMaps on startup
    - only when running with a deployment
    - allow for proper CR deployment in dev env w/o configmaps
    - add versioned annotation
 - set ownerref on them for proper cleanup when the operator is deleted
 - if user makes changes to default CMs, take versioned backup and remove ownerref so it remains
 - improve general reconciliation

Signed-off-by: tchughesiv <tchughesiv@gmail.com>