### PR TITLE
[KIECLOUD-125] add application label to objects

### DIFF
--- a/config/common.yaml
+++ b/config/common.yaml
@@ -4,6 +4,7 @@ console:
         name: "{{.ApplicationName}}-{{.Console.Name}}"
         labels:
           app: "{{.ApplicationName}}"
+          application: "{{.ApplicationName}}"
           service: "{{.ApplicationName}}-{{.Console.Name}}"
       spec:
         strategy:
@@ -28,6 +29,7 @@ console:
             labels:
               deploymentConfig: "{{.ApplicationName}}-{{.Console.Name}}"
               app: "{{.ApplicationName}}"
+              application: "{{.ApplicationName}}"
               service: "{{.ApplicationName}}-{{.Console.Name}}"
           spec:
             serviceAccountName: "{{.ApplicationName}}-{{.Product}}svc"
@@ -233,6 +235,7 @@ console:
         name: "{{.ApplicationName}}-{{.Console.Name}}"
         labels:
           app: "{{.ApplicationName}}"
+          application: "{{.ApplicationName}}"
           service: "{{.ApplicationName}}-{{.Console.Name}}"
         annotations:
           description: All the Business Central web server's ports.
@@ -248,6 +251,7 @@ console:
         name: "{{.ApplicationName}}-{{.Console.Name}}-ping"
         labels:
           app: "{{.ApplicationName}}"
+          application: "{{.ApplicationName}}"
           service: "{{.ApplicationName}}-{{.Console.Name}}"
         annotations:
           service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
@@ -258,6 +262,7 @@ console:
         name: "{{.ApplicationName}}-{{.Console.Name}}"
         labels:
           app: "{{.ApplicationName}}"
+          application: "{{.ApplicationName}}"
           service: "{{.ApplicationName}}-{{.Console.Name}}"
         annotations:
           description: Route for Business Central's https service.
@@ -278,6 +283,7 @@ smartrouter:
         name: "{{.ApplicationName}}-smartrouter-claim"
         labels:
           app: "{{.ApplicationName}}"
+          application: "{{.ApplicationName}}"
           service: "{{.ApplicationName}}-smartrouter"
       spec:
         accessModes:
@@ -290,6 +296,7 @@ smartrouter:
         name: "{{.ApplicationName}}-smartrouter"
         labels:
           app: "{{.ApplicationName}}"
+          application: "{{.ApplicationName}}"
           service: "{{.ApplicationName}}-smartrouter"
       spec:
         strategy:
@@ -313,6 +320,7 @@ smartrouter:
             name: "{{.ApplicationName}}-smartrouter"
             labels:
               app: "{{.ApplicationName}}"
+              application: "{{.ApplicationName}}"
               deploymentConfig: "{{.ApplicationName}}-smartrouter"
               service: "{{.ApplicationName}}-smartrouter"
           spec:
@@ -387,6 +395,7 @@ smartrouter:
         name: "{{.ApplicationName}}-smartrouter"
         labels:
           app: "{{.ApplicationName}}"
+          application: "{{.ApplicationName}}"
           service: "{{.ApplicationName}}-smartrouter"
         annotations:
       description: The smart router server http and https ports.
@@ -396,6 +405,7 @@ smartrouter:
         name: "{{.ApplicationName}}-smartrouter"
         labels:
           app: "{{.ApplicationName}}"
+          application: "{{.ApplicationName}}"
           service: "{{.ApplicationName}}-smartrouter"
         annotations:
           description: Route for Smart Router's https service.
@@ -419,6 +429,7 @@ servers:
           name: "{{$.ApplicationName}}-kieserver-{{$index}}"
           labels:
             app: "{{$.ApplicationName}}"
+            application: "{{$.ApplicationName}}"
             service: "{{$.ApplicationName}}-kieserver-{{$index}}"
         spec:
           strategy:
@@ -444,6 +455,7 @@ servers:
               name: "{{$.ApplicationName}}-kieserver-{{$index}}"
               labels:
                 app: "{{$.ApplicationName}}"
+                application: "{{$.ApplicationName}}"
                 service: "{{$.ApplicationName}}-kieserver-{{$index}}"
                 deploymentConfig: "{{$.ApplicationName}}-kieserver-{{$index}}"
             spec:
@@ -659,6 +671,7 @@ servers:
           name: "{{$.ApplicationName}}-kieserver-{{$index}}"
           labels:
             app: "{{$.ApplicationName}}"
+            application: "{{$.ApplicationName}}"
             service: "{{$.ApplicationName}}-kieserver-{{$index}}"
           annotations:
             description: All the KIE server web server's ports. (KIE server)
@@ -674,6 +687,7 @@ servers:
           name: "{{$.ApplicationName}}-kieserver-{{$index}}-ping"
           labels:
             app: "{{$.ApplicationName}}"
+            application: "{{$.ApplicationName}}"
             service: "{{$.ApplicationName}}-kieserver-{{$index}}"
           annotations:
             service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
@@ -686,6 +700,7 @@ servers:
           name: "{{$.ApplicationName}}-kieserver-{{$index}}"
           labels:
             app: "{{$.ApplicationName}}"
+            application: "{{$.ApplicationName}}"
             service: "{{$.ApplicationName}}-kieserver-{{$index}}"
           annotations:
             description: Route for KIE server's https service.
@@ -730,6 +745,7 @@ others:
           name: "{{.ApplicationName}}-{{.Product}}svc"
           labels:
             app: "{{.ApplicationName}}"
+            application: "{{.ApplicationName}}"
 
     rolebindings:
       - metadata:

--- a/config/envs/rhdm-authoring-ha.yaml
+++ b/config/envs/rhdm-authoring-ha.yaml
@@ -4,6 +4,7 @@ console:
         name: "{{.ApplicationName}}-{{.Console.Name}}-claim"
         labels:
           app: "{{.ApplicationName}}"
+          application: "{{.ApplicationName}}"
       spec:
         accessModes:
           - ReadWriteMany
@@ -64,6 +65,7 @@ others:
           name: "{{.ApplicationName}}-{{.Product}}index-claim"
           labels:
             app: "{{.ApplicationName}}"
+            application: "{{.ApplicationName}}"
         spec:
           accessModes:
             - ReadWriteOnce
@@ -76,6 +78,7 @@ others:
           name: "{{.ApplicationName}}-{{.Product}}index"
           labels:
             app: "{{.ApplicationName}}"
+            application: "{{.ApplicationName}}"
             service: "{{.ApplicationName}}-{{.Product}}index"
         spec:
           strategy:
@@ -100,6 +103,7 @@ others:
               labels:
                 deploymentConfig: "{{.ApplicationName}}-{{.Product}}index"
                 app: "{{.ApplicationName}}"
+                application: "{{.ApplicationName}}"
             spec:
               terminationGracePeriodSeconds: 60
               containers:
@@ -136,6 +140,7 @@ others:
       - metadata:
           labels:
             app: "{{.ApplicationName}}"
+            application: "{{.ApplicationName}}"
           name: "{{.ApplicationName}}-amq"
         spec:
           replicas: 1
@@ -149,6 +154,7 @@ others:
             metadata:
               labels:
                 app: "{{.ApplicationName}}"
+                application: "{{.ApplicationName}}"
                 deploymentConfig: "{{.ApplicationName}}-amq"
               name: "{{.ApplicationName}}-amq"
             spec:
@@ -220,6 +226,7 @@ others:
           name: "{{.ApplicationName}}-amq-tcp"
           labels:
             app: "{{.ApplicationName}}"
+            application: "{{.ApplicationName}}"
             service: "{{.ApplicationName}}-amq"
           annotations:
             description: The broker's OpenWire port.
@@ -238,6 +245,7 @@ others:
           name: "{{.ApplicationName}}-{{.Product}}index"
           labels:
             app: "{{.ApplicationName}}"
+            application: "{{.ApplicationName}}"
             service: "{{.ApplicationName}}-{{.Product}}index"
           annotations:
             description: All the Decision Central Indexing Elasticsearch ports.
@@ -248,6 +256,7 @@ others:
           name: "{{.ApplicationName}}-{{.Product}}index"
           labels:
             app: "{{.ApplicationName}}"
+            application: "{{.ApplicationName}}"
           annotations:
             description: Route for Decision Central Indexing's Elasticsearch http service.
         spec:

--- a/config/envs/rhdm-optaweb-trial.yaml
+++ b/config/envs/rhdm-optaweb-trial.yaml
@@ -8,12 +8,13 @@ servers:
   - omit: true
   #{{end}}
 others:
-## Optaweb BEGIN
+  ## Optaweb BEGIN
   - deploymentConfigs:
       - metadata:
           name: "{{.ApplicationName}}-optaweb-employee-rostering"
           labels:
             app: "{{.ApplicationName}}"
+            application: "{{.ApplicationName}}"
             service: "{{.ApplicationName}}-optaweb-employee-rostering"
         spec:
           strategy:
@@ -38,6 +39,7 @@ others:
               labels:
                 deploymentConfig: "{{.ApplicationName}}-optaweb-employee-rostering"
                 app: "{{.ApplicationName}}"
+                application: "{{.ApplicationName}}"
                 service: "{{.ApplicationName}}-optaweb-employee-rostering"
             spec:
               serviceAccountName: "{{.ApplicationName}}-{{.Product}}svc"
@@ -98,6 +100,7 @@ others:
           name: "{{.ApplicationName}}-optaweb-employee-rostering"
           labels:
             app: "{{.ApplicationName}}"
+            application: "{{.ApplicationName}}"
             service: "{{.ApplicationName}}-optaweb-employee-rostering"
           annotations:
             description: All the Optaweb's ports. (KIE server)
@@ -107,6 +110,7 @@ others:
           name: "{{.ApplicationName}}-optaweb-employee-rostering"
           labels:
             app: "{{.ApplicationName}}"
+            application: "{{.ApplicationName}}"
             service: "{{.ApplicationName}}-optaweb-employee-rostering"
           annotations:
             description: Route for Optaweb's https service.
@@ -121,6 +125,7 @@ others:
           name: "{{.ApplicationName}}-optaweb-employee-rostering-http"
           labels:
             app: "{{.ApplicationName}}"
+            application: "{{.ApplicationName}}"
             service: "{{.ApplicationName}}-optaweb-employee-rostering"
           annotations:
             description: Route for Optaweb's http service.

--- a/config/envs/rhdm-production-immutable.yaml
+++ b/config/envs/rhdm-production-immutable.yaml
@@ -6,12 +6,13 @@ smartrouter:
 servers:
   ## RANGE BEGINS
   #{{ range $index, $Map := .Servers }}
-    ## KIE server deployment config BEGIN
+  ## KIE server deployment config BEGIN
   - deploymentConfigs:
       - metadata:
           name: "{{$.ApplicationName}}-kieserver-{{$index}}"
           labels:
             app: "{{$.ApplicationName}}"
+            application: "{{$.ApplicationName}}"
             service: "{{$.ApplicationName}}-kieserver-{{$index}}"
         spec:
           replicas: 2
@@ -37,19 +38,21 @@ servers:
                       value: "EXTERNAL"
 
       ## KIE server deployment config END
-  ## KIE server build config BEGIN
-  #{{if .Build.KieServerContainerDeployment}}
+    ## KIE server build config BEGIN
+    #{{if .Build.KieServerContainerDeployment}}
     imageStreams:
       - metadata:
           name: "{{$.ApplicationName}}-kieserver-{{$index}}"
           labels:
             app: "{{$.ApplicationName}}"
+            application: "{{$.ApplicationName}}"
             service: "{{$.ApplicationName}}-kieserver-{{$index}}"
     buildConfigs:
       - metadata:
           name: "{{$.ApplicationName}}-kieserver-{{$index}}"
           labels:
             app: "{{$.ApplicationName}}"
+            application: "{{$.ApplicationName}}"
             service: "{{$.ApplicationName}}-kieserver-{{$index}}"
         spec:
           source:

--- a/config/envs/rhdm-trial.yaml
+++ b/config/envs/rhdm-trial.yaml
@@ -33,6 +33,7 @@ console:
         name: "{{.ApplicationName}}-{{.Console.Name}}-http"
         labels:
           app: "{{.ApplicationName}}"
+          application: "{{.ApplicationName}}"
           service: "{{.ApplicationName}}-{{.Console.Name}}"
         annotations:
           description: Route for Business Central's http service.
@@ -96,6 +97,7 @@ servers:
           name: "{{$.ApplicationName}}-kieserver-{{$index}}-http"
           labels:
             app: "{{$.ApplicationName}}"
+            application: "{{$.ApplicationName}}"
             service: "{{$.ApplicationName}}-kieserver-{{$index}}"
           annotations:
             description: Route for KIE server's http service.

--- a/config/envs/rhpam-authoring-ha.yaml
+++ b/config/envs/rhpam-authoring-ha.yaml
@@ -4,6 +4,7 @@ console:
         name: "{{.ApplicationName}}-{{.Console.Name}}-claim"
         labels:
           app: "{{.ApplicationName}}"
+          application: "{{.ApplicationName}}"
       spec:
         accessModes:
           - ReadWriteMany
@@ -64,6 +65,7 @@ others:
           name: "{{.ApplicationName}}-mysql-claim"
           labels:
             app: "{{.ApplicationName}}"
+            application: "{{.ApplicationName}}"
         spec:
           accessModes:
             - ReadWriteOnce
@@ -75,6 +77,7 @@ others:
           name: "{{.ApplicationName}}-{{.Product}}index-claim"
           labels:
             app: "{{.ApplicationName}}"
+            application: "{{.ApplicationName}}"
         spec:
           accessModes:
             - ReadWriteOnce
@@ -111,6 +114,7 @@ others:
               labels:
                 deploymentConfig: "{{.ApplicationName}}-{{.Product}}index"
                 app: "{{.ApplicationName}}"
+                application: "{{.ApplicationName}}"
             spec:
               terminationGracePeriodSeconds: 60
               containers:
@@ -148,6 +152,7 @@ others:
           name: "{{.ApplicationName}}-mysql"
           labels:
             app: "{{.ApplicationName}}"
+            application: "{{.ApplicationName}}"
         spec:
           strategy:
             type: Recreate
@@ -171,6 +176,7 @@ others:
               labels:
                 deploymentConfig: "{{.ApplicationName}}-mysql"
                 app: "{{.ApplicationName}}"
+                application: "{{.ApplicationName}}"
             spec:
               terminationGracePeriodSeconds: 60
               containers:
@@ -213,6 +219,7 @@ others:
       - metadata:
           labels:
             app: "{{.ApplicationName}}"
+            application: "{{.ApplicationName}}"
           name: "{{.ApplicationName}}-amq"
         spec:
           replicas: 1
@@ -226,6 +233,7 @@ others:
             metadata:
               labels:
                 app: "{{.ApplicationName}}"
+                application: "{{.ApplicationName}}"
                 deploymentConfig: "{{.ApplicationName}}-amq"
               name: "{{.ApplicationName}}-amq"
             spec:
@@ -297,6 +305,7 @@ others:
           name: "{{.ApplicationName}}-amq-tcp"
           labels:
             app: "{{.ApplicationName}}"
+            application: "{{.ApplicationName}}"
             service: "{{.ApplicationName}}-amq"
           annotations:
             description: The broker's OpenWire port.
@@ -311,6 +320,7 @@ others:
           name: "{{.ApplicationName}}-mysql"
           labels:
             app: "{{.ApplicationName}}"
+            application: "{{.ApplicationName}}"
             service: "{{.ApplicationName}}-mysql"
           annotations:
             description: The MySQL server's port.
@@ -329,6 +339,7 @@ others:
           name: "{{.ApplicationName}}-{{.Product}}index"
           labels:
             app: "{{.ApplicationName}}"
+            application: "{{.ApplicationName}}"
             service: "{{.ApplicationName}}-{{.Product}}index"
           annotations:
             description: All the Business Central Indexing Elasticsearch ports.
@@ -339,6 +350,7 @@ others:
           name: "{{.ApplicationName}}-{{.Product}}index"
           labels:
             app: "{{.ApplicationName}}"
+            application: "{{.ApplicationName}}"
           annotations:
             description: Route for Business Central Indexing's Elasticsearch http service.
         spec:

--- a/config/envs/rhpam-authoring.yaml
+++ b/config/envs/rhpam-authoring.yaml
@@ -60,7 +60,7 @@ servers:
                       value: "true"
                     - name: KIE_SERVER_PERSISTENCE_DS
                       value: "java:/jboss/datasources/rhpam"
-                  ## H2 driver settings BEGIN
+                    ## H2 driver settings BEGIN
                     - name: RHPAM_DRIVER
                       value: "h2"
                     - name: RHPAM_USERNAME
@@ -90,6 +90,7 @@ servers:
           name: "{{$.ApplicationName}}-h2-claim-{{$index}}"
           labels:
             app: "{{$.ApplicationName}}"
+            application: "{{$.ApplicationName}}"
             service: "{{$.ApplicationName}}-kieserver-{{$index}}"
         spec:
           accessModes:

--- a/config/envs/rhpam-production-immutable.yaml
+++ b/config/envs/rhpam-production-immutable.yaml
@@ -12,6 +12,7 @@ servers:
           name: "{{$.ApplicationName}}-postgresql-claim-{{$index}}"
           labels:
             app: "{{$.ApplicationName}}"
+            application: "{{$.ApplicationName}}"
             service: "{{$.ApplicationName}}-postgresql-{{$index}}"
         spec:
           accessModes:
@@ -27,12 +28,14 @@ servers:
           name: "{{$.ApplicationName}}-kieserver-{{$index}}"
           labels:
             app: "{{$.ApplicationName}}"
+            application: "{{$.ApplicationName}}"
             service: "{{$.ApplicationName}}-kieserver-{{$index}}"
     buildConfigs:
       - metadata:
           name: "{{$.ApplicationName}}-kieserver-{{$index}}"
           labels:
             app: "{{$.ApplicationName}}"
+            application: "{{$.ApplicationName}}"
             service: "{{$.ApplicationName}}-kieserver-{{$index}}"
         spec:
           source:
@@ -78,6 +81,7 @@ servers:
           name: "{{$.ApplicationName}}-kieserver-{{$index}}"
           labels:
             app: "{{$.ApplicationName}}"
+            application: "{{$.ApplicationName}}"
             service: "{{$.ApplicationName}}-kieserver-{{$index}}"
         spec:
           replicas: 2
@@ -137,6 +141,7 @@ servers:
           name: "{{$.ApplicationName}}-postgresql-{{$index}}"
           labels:
             app: "{{$.ApplicationName}}"
+            application: "{{$.ApplicationName}}"
             service: "{{$.ApplicationName}}-postgresql-{{$index}}"
         spec:
           strategy:
@@ -161,6 +166,7 @@ servers:
               labels:
                 deploymentConfig: "{{$.ApplicationName}}-postgresql-{{$index}}"
                 app: "{{$.ApplicationName}}"
+                application: "{{$.ApplicationName}}"
                 service: "{{$.ApplicationName}}-postgresql-{{$index}}"
             spec:
               containers:

--- a/config/envs/rhpam-production.yaml
+++ b/config/envs/rhpam-production.yaml
@@ -24,6 +24,7 @@ servers:
           name: "{{$.ApplicationName}}-postgresql-claim-{{$index}}"
           labels:
             app: "{{$.ApplicationName}}"
+            application: "{{$.ApplicationName}}"
             service: "{{$.ApplicationName}}-postgresql-{{$index}}"
         spec:
           accessModes:
@@ -39,6 +40,7 @@ servers:
           name: "{{$.ApplicationName}}-kieserver-{{$index}}"
           labels:
             app: "{{$.ApplicationName}}"
+            application: "{{$.ApplicationName}}"
             service: "{{$.ApplicationName}}-kieserver-{{$index}}"
         spec:
           replicas: 3
@@ -95,6 +97,7 @@ servers:
           name: "{{$.ApplicationName}}-postgresql-{{$index}}"
           labels:
             app: "{{$.ApplicationName}}"
+            application: "{{$.ApplicationName}}"
             service: "{{$.ApplicationName}}-postgresql-{{$index}}"
         spec:
           strategy:
@@ -119,6 +122,7 @@ servers:
               labels:
                 deploymentConfig: "{{$.ApplicationName}}-postgresql-{{$index}}"
                 app: "{{$.ApplicationName}}"
+                application: "{{$.ApplicationName}}"
                 service: "{{$.ApplicationName}}-postgresql-{{$index}}"
             spec:
               containers:

--- a/config/envs/rhpam-trial.yaml
+++ b/config/envs/rhpam-trial.yaml
@@ -33,6 +33,7 @@ console:
         name: "{{.ApplicationName}}-{{.Console.Name}}-http"
         labels:
           app: "{{.ApplicationName}}"
+          application: "{{.ApplicationName}}"
           service: "{{.ApplicationName}}-{{.Console.Name}}"
         annotations:
           description: Route for Business Central's http service.
@@ -72,7 +73,7 @@ servers:
                       value: "true"
                     - name: KIE_SERVER_PERSISTENCE_DS
                       value: "java:/jboss/datasources/rhpam"
-                  ## H2 driver settings BEGIN
+                    ## H2 driver settings BEGIN
                     - name: RHPAM_DRIVER
                       value: "h2"
                     - name: RHPAM_USERNAME
@@ -87,7 +88,7 @@ servers:
                       value: "org.hibernate.dialect.H2Dialect"
                     - name: RHPAM_XA_CONNECTION_PROPERTY_URL
                       value: "jdbc:h2:/opt/eap/standalone/data/rhpam"
-                  ## H2 driver settings END
+                    ## H2 driver settings END
                     - name: KIE_SERVER_ROUTE_NAME
                       value: "{{$.ApplicationName}}-kieserver-{{$index}}-http"
                     - name: KIE_SERVER_PROTOCOL
@@ -129,6 +130,7 @@ servers:
           name: "{{$.ApplicationName}}-kieserver-{{$index}}-http"
           labels:
             app: "{{$.ApplicationName}}"
+            application: "{{$.ApplicationName}}"
             service: "{{$.ApplicationName}}-kieserver-{{$index}}"
           annotations:
             description: Route for KIE server's http service.

--- a/pkg/controller/kieapp/kieapp_controller.go
+++ b/pkg/controller/kieapp/kieapp_controller.go
@@ -306,7 +306,8 @@ func (reconciler *Reconciler) newEnv(cr *v1.KieApp) (v1.Environment, reconcile.R
 			ObjectMeta: metav1.ObjectMeta{
 				Name: fmt.Sprintf("%s-businesscentral-app-secret", cr.Name),
 				Labels: map[string]string{
-					"app": cr.Name,
+					"app":         cr.Name,
+					"application": cr.Name,
 				},
 			},
 			Data: map[string][]byte{
@@ -337,7 +338,8 @@ func (reconciler *Reconciler) newEnv(cr *v1.KieApp) (v1.Environment, reconcile.R
 			ObjectMeta: metav1.ObjectMeta{
 				Name: fmt.Sprintf("%s-kieserver-%d-app-secret", cr.Name, i),
 				Labels: map[string]string{
-					"app": cr.Name,
+					"app":         cr.Name,
+					"application": cr.Name,
 				},
 			},
 			Data: map[string][]byte{
@@ -368,7 +370,8 @@ func (reconciler *Reconciler) newEnv(cr *v1.KieApp) (v1.Environment, reconcile.R
 			ObjectMeta: metav1.ObjectMeta{
 				Name: fmt.Sprintf("%s-smartrouter-app-secret", cr.Name),
 				Labels: map[string]string{
-					"app": cr.Name,
+					"app":         cr.Name,
+					"application": cr.Name,
 				},
 			},
 			Data: map[string][]byte{


### PR DESCRIPTION
the rhpam and rhdm templates use an "application" label for further identification.

Signed-off-by: tchughesiv <tchughesiv@gmail.com>