### PR TITLE
[KIECLOUD-128] set default server object in CR

### DIFF
--- a/pkg/controller/kieapp/defaults/defaults.go
+++ b/pkg/controller/kieapp/defaults/defaults.go
@@ -131,11 +131,12 @@ func getServersConfig(cr *v1.KieApp, commonConfig *v1.CommonConfig) ([]v1.Server
 			servers = append(servers, crTemplate)
 		}
 	} else {
-		deployments := constants.DefaultKieDeployments
-		if cr.Spec.Objects.Server != nil && cr.Spec.Objects.Server.Deployments != 0 {
-			deployments = cr.Spec.Objects.Server.Deployments
+		if cr.Spec.Objects.Server == nil {
+			cr.Spec.Objects.Server = &v1.CommonKieServerSet{
+				Deployments: constants.DefaultKieDeployments,
+			}
 		}
-		for i := 0; i < deployments; i++ {
+		for i := 0; i < cr.Spec.Objects.Server.Deployments; i++ {
 			crTemplate := v1.ServerTemplate{
 				KieServerID: fmt.Sprintf(defaultKieServerIDTemplate, cr.Name, i),
 			}


### PR DESCRIPTION
defaults to 1 kieserver in CR when neither Server or Servers objects are set.

e.g.
```yaml
objects:
  console:
    resources: {}
  server:
    deployments: 1
    server:
      resources: {}
  smartrouter:
    resources: {}
```

/assign @bmozaffa 

Signed-off-by: tchughesiv <tchughesiv@gmail.com>