### PR TITLE
[WIP] Align all labels

### DIFF
--- a/config/common.yaml
+++ b/config/common.yaml
@@ -3,9 +3,9 @@ console:
     - metadata:
         name: "{{.ApplicationName}}-{{.Console.Name}}"
         labels:
-          app: "{{.ApplicationName}}"
+          app: "{{.ApplicationName}}-{{.Console.Name}}"
           application: "{{.ApplicationName}}"
-          service: "{{.ApplicationName}}-{{.Console.Name}}"
+          service: "{{.Product}}-{{.Console.Name}}"
       spec:
         strategy:
           type: Recreate
@@ -28,9 +28,9 @@ console:
             name: "{{.ApplicationName}}-{{.Console.Name}}"
             labels:
               deploymentConfig: "{{.ApplicationName}}-{{.Console.Name}}"
-              app: "{{.ApplicationName}}"
+              app: "{{.ApplicationName}}-{{.Console.Name}}"
               application: "{{.ApplicationName}}"
-              service: "{{.ApplicationName}}-{{.Console.Name}}"
+              service: "{{.Product}}-{{.Console.Name}}"
           spec:
             serviceAccountName: "{{.ApplicationName}}-{{.Product}}svc"
             terminationGracePeriodSeconds: 60
@@ -234,9 +234,9 @@ console:
       metadata:
         name: "{{.ApplicationName}}-{{.Console.Name}}"
         labels:
-          app: "{{.ApplicationName}}"
+          app: "{{.ApplicationName}}-{{.Console.Name}}"
           application: "{{.ApplicationName}}"
-          service: "{{.ApplicationName}}-{{.Console.Name}}"
+          service: "{{.Product}}-{{.Console.Name}}"
         annotations:
           description: All the Business Central web server's ports.
     - spec:
@@ -250,9 +250,9 @@ console:
       metadata:
         name: "{{.ApplicationName}}-{{.Console.Name}}-ping"
         labels:
-          app: "{{.ApplicationName}}"
+          app: "{{.ApplicationName}}-{{.Console.Name}}"
           application: "{{.ApplicationName}}"
-          service: "{{.ApplicationName}}-{{.Console.Name}}"
+          service: "{{.Product}}-{{.Console.Name}}"
         annotations:
           service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
           description: "The JGroups ping port for clustering."
@@ -261,9 +261,9 @@ console:
       metadata:
         name: "{{.ApplicationName}}-{{.Console.Name}}"
         labels:
-          app: "{{.ApplicationName}}"
+          app: "{{.ApplicationName}}-{{.Console.Name}}"
           application: "{{.ApplicationName}}"
-          service: "{{.ApplicationName}}-{{.Console.Name}}"
+          service: "{{.Product}}-{{.Console.Name}}"
         annotations:
           description: Route for Business Central's https service.
           haproxy.router.openshift.io/timeout: 60s
@@ -282,9 +282,9 @@ smartrouter:
     - metadata:
         name: "{{.ApplicationName}}-smartrouter-claim"
         labels:
-          app: "{{.ApplicationName}}"
+          app: "{{.ApplicationName}}-smartrouter"
           application: "{{.ApplicationName}}"
-          service: "{{.ApplicationName}}-smartrouter"
+          service: "{{.Product}}-smartrouter"
       spec:
         accessModes:
           - ReadWriteMany
@@ -295,9 +295,9 @@ smartrouter:
     - metadata:
         name: "{{.ApplicationName}}-smartrouter"
         labels:
-          app: "{{.ApplicationName}}"
+          app: "{{.ApplicationName}}-smartrouter"
           application: "{{.ApplicationName}}"
-          service: "{{.ApplicationName}}-smartrouter"
+          service: "{{.Product}}-smartrouter"
       spec:
         strategy:
           type: Recreate
@@ -319,10 +319,10 @@ smartrouter:
           metadata:
             name: "{{.ApplicationName}}-smartrouter"
             labels:
-              app: "{{.ApplicationName}}"
+              app: "{{.ApplicationName}}-smartrouter"
               application: "{{.ApplicationName}}"
               deploymentConfig: "{{.ApplicationName}}-smartrouter"
-              service: "{{.ApplicationName}}-smartrouter"
+              service: "{{.Product}}-smartrouter"
           spec:
             terminationGracePeriodSeconds: 60
             containers:
@@ -394,9 +394,9 @@ smartrouter:
       metadata:
         name: "{{.ApplicationName}}-smartrouter"
         labels:
-          app: "{{.ApplicationName}}"
+          app: "{{.ApplicationName}}-smartrouter"
           application: "{{.ApplicationName}}"
-          service: "{{.ApplicationName}}-smartrouter"
+          service: "{{.Product}}-smartrouter"
         annotations:
       description: The smart router server http and https ports.
   routes:
@@ -404,9 +404,9 @@ smartrouter:
       metadata:
         name: "{{.ApplicationName}}-smartrouter"
         labels:
-          app: "{{.ApplicationName}}"
+          app: "{{.ApplicationName}}-smartrouter"
           application: "{{.ApplicationName}}"
-          service: "{{.ApplicationName}}-smartrouter"
+          service: "{{.Product}}-smartrouter"
         annotations:
           description: Route for Smart Router's https service.
       spec:
@@ -428,9 +428,9 @@ servers:
       - metadata:
           name: "{{$.ApplicationName}}-kieserver-{{$index}}"
           labels:
-            app: "{{$.ApplicationName}}"
+            app: "{{$.ApplicationName}}-kieserver-{{$index}}"
             application: "{{$.ApplicationName}}"
-            service: "{{$.ApplicationName}}-kieserver-{{$index}}"
+            service: "{{$.Product}}-kieserver"
         spec:
           strategy:
             rollingParams:
@@ -454,9 +454,9 @@ servers:
             metadata:
               name: "{{$.ApplicationName}}-kieserver-{{$index}}"
               labels:
-                app: "{{$.ApplicationName}}"
+                app: "{{$.ApplicationName}}-kieserver-{{$index}}"
                 application: "{{$.ApplicationName}}"
-                service: "{{$.ApplicationName}}-kieserver-{{$index}}"
+                service: "{{$.Product}}-kieserver"
                 deploymentConfig: "{{$.ApplicationName}}-kieserver-{{$index}}"
             spec:
               serviceAccountName: "{{$.ApplicationName}}-{{$.Product}}svc"
@@ -670,9 +670,9 @@ servers:
         metadata:
           name: "{{$.ApplicationName}}-kieserver-{{$index}}"
           labels:
-            app: "{{$.ApplicationName}}"
+            app: "{{$.ApplicationName}}-kieserver-{{$index}}"
             application: "{{$.ApplicationName}}"
-            service: "{{$.ApplicationName}}-kieserver-{{$index}}"
+            service: "{{$.Product}}-kieserver"
           annotations:
             description: All the KIE server web server's ports. (KIE server)
       - spec:
@@ -686,9 +686,9 @@ servers:
         metadata:
           name: "{{$.ApplicationName}}-kieserver-{{$index}}-ping"
           labels:
-            app: "{{$.ApplicationName}}"
+            app: "{{$.ApplicationName}}-kieserver-{{$index}}"
             application: "{{$.ApplicationName}}"
-            service: "{{$.ApplicationName}}-kieserver-{{$index}}"
+            service: "{{$.Product}}-kieserver"
           annotations:
             service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
             description: "The JGroups ping port for clustering."
@@ -699,9 +699,9 @@ servers:
         metadata:
           name: "{{$.ApplicationName}}-kieserver-{{$index}}"
           labels:
-            app: "{{$.ApplicationName}}"
+            app: "{{$.ApplicationName}}-kieserver-{{$index}}"
             application: "{{$.ApplicationName}}"
-            service: "{{$.ApplicationName}}-kieserver-{{$index}}"
+            service: "{{$.Product}}-kieserver"
           annotations:
             description: Route for KIE server's https service.
             haproxy.router.openshift.io/timeout: 60s
@@ -744,7 +744,6 @@ others:
       - metadata:
           name: "{{.ApplicationName}}-{{.Product}}svc"
           labels:
-            app: "{{.ApplicationName}}"
             application: "{{.ApplicationName}}"
 
     rolebindings:

--- a/config/envs/rhdm-authoring-ha.yaml
+++ b/config/envs/rhdm-authoring-ha.yaml
@@ -3,8 +3,9 @@ console:
     - metadata:
         name: "{{.ApplicationName}}-{{.Console.Name}}-claim"
         labels:
-          app: "{{.ApplicationName}}"
+          app: "{{.ApplicationName}}-{{.Console.Name}}"
           application: "{{.ApplicationName}}"
+          service: "{{.Product}}-{{.Console.Name}}"
       spec:
         accessModes:
           - ReadWriteMany
@@ -64,8 +65,9 @@ others:
       - metadata:
           name: "{{.ApplicationName}}-{{.Product}}index-claim"
           labels:
-            app: "{{.ApplicationName}}"
+            app: "{{.ApplicationName}}-{{.Product}}index"
             application: "{{.ApplicationName}}"
+            service: "{{.Product}}-{{.Product}}index"
         spec:
           accessModes:
             - ReadWriteOnce
@@ -77,9 +79,9 @@ others:
       - metadata:
           name: "{{.ApplicationName}}-{{.Product}}index"
           labels:
-            app: "{{.ApplicationName}}"
+            app: "{{.ApplicationName}}-{{.Product}}index"
             application: "{{.ApplicationName}}"
-            service: "{{.ApplicationName}}-{{.Product}}index"
+            service: "{{.Product}}-{{.Product}}index"
         spec:
           strategy:
             type: Recreate
@@ -102,8 +104,9 @@ others:
               name: "{{.ApplicationName}}-{{.Product}}index"
               labels:
                 deploymentConfig: "{{.ApplicationName}}-{{.Product}}index"
-                app: "{{.ApplicationName}}"
+                app: "{{.ApplicationName}}-{{.Product}}index"
                 application: "{{.ApplicationName}}"
+                service: "{{.Product}}-{{.Product}}index"
             spec:
               terminationGracePeriodSeconds: 60
               containers:
@@ -139,8 +142,9 @@ others:
 
       - metadata:
           labels:
-            app: "{{.ApplicationName}}"
+            app: "{{.ApplicationName}}-amq"
             application: "{{.ApplicationName}}"
+            service: "{{.Product}}-amq"
           name: "{{.ApplicationName}}-amq"
         spec:
           replicas: 1
@@ -153,8 +157,9 @@ others:
           template:
             metadata:
               labels:
-                app: "{{.ApplicationName}}"
+                app: "{{.ApplicationName}}-amq"
                 application: "{{.ApplicationName}}"
+                service: "{{.Product}}-amq"
                 deploymentConfig: "{{.ApplicationName}}-amq"
               name: "{{.ApplicationName}}-amq"
             spec:
@@ -225,9 +230,9 @@ others:
         metadata:
           name: "{{.ApplicationName}}-amq-tcp"
           labels:
-            app: "{{.ApplicationName}}"
+            app: "{{.ApplicationName}}-amq"
             application: "{{.ApplicationName}}"
-            service: "{{.ApplicationName}}-amq"
+            service: "{{.Product}}-amq"
           annotations:
             description: The broker's OpenWire port.
 
@@ -244,9 +249,9 @@ others:
         metadata:
           name: "{{.ApplicationName}}-{{.Product}}index"
           labels:
-            app: "{{.ApplicationName}}"
+            app: "{{.ApplicationName}}-{{.Product}}index"
             application: "{{.ApplicationName}}"
-            service: "{{.ApplicationName}}-{{.Product}}index"
+            service: "{{.Product}}-{{.Product}}index"
           annotations:
             description: All the Decision Central Indexing Elasticsearch ports.
 
@@ -255,8 +260,9 @@ others:
         metadata:
           name: "{{.ApplicationName}}-{{.Product}}index"
           labels:
-            app: "{{.ApplicationName}}"
+            app: "{{.ApplicationName}}-{{.Product}}index"
             application: "{{.ApplicationName}}"
+            service: "{{.Product}}-{{.Product}}index"
           annotations:
             description: Route for Decision Central Indexing's Elasticsearch http service.
         spec:

--- a/config/envs/rhdm-optaweb-trial.yaml
+++ b/config/envs/rhdm-optaweb-trial.yaml
@@ -13,9 +13,9 @@ others:
       - metadata:
           name: "{{.ApplicationName}}-optaweb-employee-rostering"
           labels:
-            app: "{{.ApplicationName}}"
+            app: "{{.ApplicationName}}-optaweb-employee-rostering"
             application: "{{.ApplicationName}}"
-            service: "{{.ApplicationName}}-optaweb-employee-rostering"
+            service: "{{.Product}}-optaweb-employee-rostering"
         spec:
           strategy:
             type: Recreate
@@ -38,9 +38,9 @@ others:
               name: "{{.ApplicationName}}-optaweb-employee-rostering"
               labels:
                 deploymentConfig: "{{.ApplicationName}}-optaweb-employee-rostering"
-                app: "{{.ApplicationName}}"
+                app: "{{.ApplicationName}}-optaweb-employee-rostering"
                 application: "{{.ApplicationName}}"
-                service: "{{.ApplicationName}}-optaweb-employee-rostering"
+                service: "{{.Product}}-optaweb-employee-rostering"
             spec:
               serviceAccountName: "{{.ApplicationName}}-{{.Product}}svc"
               terminationGracePeriodSeconds: 60
@@ -99,9 +99,9 @@ others:
         metadata:
           name: "{{.ApplicationName}}-optaweb-employee-rostering"
           labels:
-            app: "{{.ApplicationName}}"
+            app: "{{.ApplicationName}}-optaweb-employee-rostering"
             application: "{{.ApplicationName}}"
-            service: "{{.ApplicationName}}-optaweb-employee-rostering"
+            service: "{{.Product}}-optaweb-employee-rostering"
           annotations:
             description: All the Optaweb's ports. (KIE server)
     routes:
@@ -109,9 +109,9 @@ others:
         metadata:
           name: "{{.ApplicationName}}-optaweb-employee-rostering"
           labels:
-            app: "{{.ApplicationName}}"
+            app: "{{.ApplicationName}}-optaweb-employee-rostering"
             application: "{{.ApplicationName}}"
-            service: "{{.ApplicationName}}-optaweb-employee-rostering"
+            service: "{{.Product}}-optaweb-employee-rostering"
           annotations:
             description: Route for Optaweb's https service.
             haproxy.router.openshift.io/timeout: 60s
@@ -124,9 +124,9 @@ others:
         metadata:
           name: "{{.ApplicationName}}-optaweb-employee-rostering-http"
           labels:
-            app: "{{.ApplicationName}}"
+            app: "{{.ApplicationName}}-optaweb-employee-rostering"
             application: "{{.ApplicationName}}"
-            service: "{{.ApplicationName}}-optaweb-employee-rostering"
+            service: "{{.Product}}-optaweb-employee-rostering"
           annotations:
             description: Route for Optaweb's http service.
             haproxy.router.openshift.io/timeout: 60s

--- a/config/envs/rhdm-production-immutable.yaml
+++ b/config/envs/rhdm-production-immutable.yaml
@@ -11,9 +11,9 @@ servers:
       - metadata:
           name: "{{$.ApplicationName}}-kieserver-{{$index}}"
           labels:
-            app: "{{$.ApplicationName}}"
+            app: "{{$.ApplicationName}}-kieserver-{{$index}}"
             application: "{{$.ApplicationName}}"
-            service: "{{$.ApplicationName}}-kieserver-{{$index}}"
+            service: "{{$.Product}}-kieserver"
         spec:
           replicas: 2
           template:
@@ -44,16 +44,16 @@ servers:
       - metadata:
           name: "{{$.ApplicationName}}-kieserver-{{$index}}"
           labels:
-            app: "{{$.ApplicationName}}"
+            app: "{{$.ApplicationName}}-kieserver-{{$index}}"
             application: "{{$.ApplicationName}}"
-            service: "{{$.ApplicationName}}-kieserver-{{$index}}"
+            service: "{{$.Product}}-kieserver"
     buildConfigs:
       - metadata:
           name: "{{$.ApplicationName}}-kieserver-{{$index}}"
           labels:
-            app: "{{$.ApplicationName}}"
+            app: "{{$.ApplicationName}}-kieserver-{{$index}}"
             application: "{{$.ApplicationName}}"
-            service: "{{$.ApplicationName}}-kieserver-{{$index}}"
+            service: "{{$.Product}}-kieserver"
         spec:
           source:
             type: Git

--- a/config/envs/rhdm-trial.yaml
+++ b/config/envs/rhdm-trial.yaml
@@ -32,9 +32,9 @@ console:
       metadata:
         name: "{{.ApplicationName}}-{{.Console.Name}}-http"
         labels:
-          app: "{{.ApplicationName}}"
+          app: "{{.ApplicationName}}-{{.Console.Name}}"
           application: "{{.ApplicationName}}"
-          service: "{{.ApplicationName}}-{{.Console.Name}}"
+          service: "{{.Product}}-{{.Console.Name}}"
         annotations:
           description: Route for Business Central's http service.
           haproxy.router.openshift.io/timeout: 60s
@@ -96,9 +96,9 @@ servers:
         metadata:
           name: "{{$.ApplicationName}}-kieserver-{{$index}}-http"
           labels:
-            app: "{{$.ApplicationName}}"
+            app: "{{$.ApplicationName}}-kieserver-{{$index}}"
             application: "{{$.ApplicationName}}"
-            service: "{{$.ApplicationName}}-kieserver-{{$index}}"
+            service: "{{$.Product}}-kieserver"
           annotations:
             description: Route for KIE server's http service.
             haproxy.router.openshift.io/timeout: 60s

--- a/config/envs/rhpam-authoring-ha.yaml
+++ b/config/envs/rhpam-authoring-ha.yaml
@@ -3,8 +3,9 @@ console:
     - metadata:
         name: "{{.ApplicationName}}-{{.Console.Name}}-claim"
         labels:
-          app: "{{.ApplicationName}}"
+          app: "{{.ApplicationName}}-{{.Console.Name}}"
           application: "{{.ApplicationName}}"
+          service: "{{.Product}}-{{.Console.Name}}"
       spec:
         accessModes:
           - ReadWriteMany
@@ -64,8 +65,9 @@ others:
       - metadata:
           name: "{{.ApplicationName}}-mysql-claim"
           labels:
-            app: "{{.ApplicationName}}"
+            app: "{{.ApplicationName}}-mysql"
             application: "{{.ApplicationName}}"
+            service: "{{.Product}}-mysql"
         spec:
           accessModes:
             - ReadWriteOnce
@@ -76,8 +78,9 @@ others:
       - metadata:
           name: "{{.ApplicationName}}-{{.Product}}index-claim"
           labels:
-            app: "{{.ApplicationName}}"
+            app: "{{.ApplicationName}}-{{.Product}}index"
             application: "{{.ApplicationName}}"
+            service: "{{.Product}}-{{.Product}}index"
         spec:
           accessModes:
             - ReadWriteOnce
@@ -89,8 +92,9 @@ others:
       - metadata:
           name: "{{.ApplicationName}}-{{.Product}}index"
           labels:
-            app: "{{.ApplicationName}}"
-            service: "{{.ApplicationName}}-{{.Product}}index"
+            app: "{{.ApplicationName}}-{{.Product}}index"
+            application: "{{.ApplicationName}}"
+            service: "{{.Product}}-{{.Product}}index"
         spec:
           strategy:
             type: Recreate
@@ -113,8 +117,9 @@ others:
               name: "{{.ApplicationName}}-{{.Product}}index"
               labels:
                 deploymentConfig: "{{.ApplicationName}}-{{.Product}}index"
-                app: "{{.ApplicationName}}"
+                app: "{{.ApplicationName}}-{{.Product}}index"
                 application: "{{.ApplicationName}}"
+                service: "{{.Product}}-{{.Product}}index"
             spec:
               terminationGracePeriodSeconds: 60
               containers:
@@ -151,8 +156,9 @@ others:
       - metadata:
           name: "{{.ApplicationName}}-mysql"
           labels:
-            app: "{{.ApplicationName}}"
+            app: "{{.ApplicationName}}-mysql"
             application: "{{.ApplicationName}}"
+            service: "{{.Product}}-mysql"
         spec:
           strategy:
             type: Recreate
@@ -175,8 +181,9 @@ others:
               name: "{{.ApplicationName}}-mysql"
               labels:
                 deploymentConfig: "{{.ApplicationName}}-mysql"
-                app: "{{.ApplicationName}}"
+                app: "{{.ApplicationName}}-mysql"
                 application: "{{.ApplicationName}}"
+                service: "{{.Product}}-mysql"
             spec:
               terminationGracePeriodSeconds: 60
               containers:
@@ -217,10 +224,11 @@ others:
                     claimName: "{{.ApplicationName}}-mysql-claim"
 
       - metadata:
-          labels:
-            app: "{{.ApplicationName}}"
-            application: "{{.ApplicationName}}"
           name: "{{.ApplicationName}}-amq"
+          labels:
+            app: "{{.ApplicationName}}-amq"
+            application: "{{.ApplicationName}}"
+            service: "{{.Product}}-amq"
         spec:
           replicas: 1
           selector:
@@ -232,8 +240,9 @@ others:
           template:
             metadata:
               labels:
-                app: "{{.ApplicationName}}"
+                app: "{{.ApplicationName}}-amq"
                 application: "{{.ApplicationName}}"
+                service: "{{.Product}}-amq"
                 deploymentConfig: "{{.ApplicationName}}-amq"
               name: "{{.ApplicationName}}-amq"
             spec:
@@ -304,9 +313,9 @@ others:
         metadata:
           name: "{{.ApplicationName}}-amq-tcp"
           labels:
-            app: "{{.ApplicationName}}"
+            app: "{{.ApplicationName}}-amq"
             application: "{{.ApplicationName}}"
-            service: "{{.ApplicationName}}-amq"
+            service: "{{.Product}}-amq"
           annotations:
             description: The broker's OpenWire port.
 
@@ -319,9 +328,9 @@ others:
         metadata:
           name: "{{.ApplicationName}}-mysql"
           labels:
-            app: "{{.ApplicationName}}"
+            app: "{{.ApplicationName}}-mysql"
             application: "{{.ApplicationName}}"
-            service: "{{.ApplicationName}}-mysql"
+            service: "{{.Product}}-mysql"
           annotations:
             description: The MySQL server's port.
 
@@ -338,9 +347,9 @@ others:
         metadata:
           name: "{{.ApplicationName}}-{{.Product}}index"
           labels:
-            app: "{{.ApplicationName}}"
+            app: "{{.ApplicationName}}-{{.Product}}index"
             application: "{{.ApplicationName}}"
-            service: "{{.ApplicationName}}-{{.Product}}index"
+            service: "{{.Product}}-{{.Product}}index"
           annotations:
             description: All the Business Central Indexing Elasticsearch ports.
 
@@ -349,8 +358,9 @@ others:
         metadata:
           name: "{{.ApplicationName}}-{{.Product}}index"
           labels:
-            app: "{{.ApplicationName}}"
+            app: "{{.ApplicationName}}-{{.Product}}index"
             application: "{{.ApplicationName}}"
+            service: "{{.Product}}-{{.Product}}index"
           annotations:
             description: Route for Business Central Indexing's Elasticsearch http service.
         spec:

--- a/config/envs/rhpam-authoring.yaml
+++ b/config/envs/rhpam-authoring.yaml
@@ -89,9 +89,9 @@ servers:
       - metadata:
           name: "{{$.ApplicationName}}-h2-claim-{{$index}}"
           labels:
-            app: "{{$.ApplicationName}}"
+            app: "{{$.ApplicationName}}-kieserver-{{$index}}"
             application: "{{$.ApplicationName}}"
-            service: "{{$.ApplicationName}}-kieserver-{{$index}}"
+            service: "{{$.Product}}-kieserver"
         spec:
           accessModes:
             - ReadWriteOnce

--- a/config/envs/rhpam-production-immutable.yaml
+++ b/config/envs/rhpam-production-immutable.yaml
@@ -11,9 +11,9 @@ servers:
       - metadata:
           name: "{{$.ApplicationName}}-postgresql-claim-{{$index}}"
           labels:
-            app: "{{$.ApplicationName}}"
+            app: "{{$.ApplicationName}}-postgresql"
             application: "{{$.ApplicationName}}"
-            service: "{{$.ApplicationName}}-postgresql-{{$index}}"
+            service: "{{$.Product}}-posgtresql"
         spec:
           accessModes:
             - ReadWriteOnce
@@ -27,16 +27,16 @@ servers:
       - metadata:
           name: "{{$.ApplicationName}}-kieserver-{{$index}}"
           labels:
-            app: "{{$.ApplicationName}}"
+            app: "{{$.ApplicationName}}-kieserver"
             application: "{{$.ApplicationName}}"
-            service: "{{$.ApplicationName}}-kieserver-{{$index}}"
+            service: "{{$.Product}}-kieserver"
     buildConfigs:
       - metadata:
           name: "{{$.ApplicationName}}-kieserver-{{$index}}"
           labels:
-            app: "{{$.ApplicationName}}"
+            app: "{{$.ApplicationName}}-kieserver-{{$index}}"
             application: "{{$.ApplicationName}}"
-            service: "{{$.ApplicationName}}-kieserver-{{$index}}"
+            service: "{{$.Product}}-kieserver"
         spec:
           source:
             type: Git
@@ -80,9 +80,9 @@ servers:
       - metadata:
           name: "{{$.ApplicationName}}-kieserver-{{$index}}"
           labels:
-            app: "{{$.ApplicationName}}"
+            app: "{{$.ApplicationName}}-kieserver"
             application: "{{$.ApplicationName}}"
-            service: "{{$.ApplicationName}}-kieserver-{{$index}}"
+            service: "{{$.Product}}-kieserver"
         spec:
           replicas: 2
           template:
@@ -140,9 +140,9 @@ servers:
       - metadata:
           name: "{{$.ApplicationName}}-postgresql-{{$index}}"
           labels:
-            app: "{{$.ApplicationName}}"
+            app: "{{$.ApplicationName}}-postgresql-{{$index}}"
             application: "{{$.ApplicationName}}"
-            service: "{{$.ApplicationName}}-postgresql-{{$index}}"
+            service: "{{$.Product}}-posgtresql"
         spec:
           strategy:
             type: Recreate
@@ -165,9 +165,9 @@ servers:
               name: "{{$.ApplicationName}}-postgresql-{{$index}}"
               labels:
                 deploymentConfig: "{{$.ApplicationName}}-postgresql-{{$index}}"
-                app: "{{$.ApplicationName}}"
+                app: "{{$.ApplicationName}}-postgresql-{{$index}}"
                 application: "{{$.ApplicationName}}"
-                service: "{{$.ApplicationName}}-postgresql-{{$index}}"
+                service: "{{$.Product}}-posgtresql"
             spec:
               containers:
                 - name: "{{$.ApplicationName}}-postgresql"
@@ -213,7 +213,7 @@ servers:
             description: The database server's port.
           labels:
             application: prod
-            service: "{{$.ApplicationName}}-postgresql-{{$index}}"
+            service: "{{$.Product}}-posgtresql"
           name: "{{$.ApplicationName}}-postgresql-{{$index}}"
         spec:
           ports:

--- a/config/envs/rhpam-production.yaml
+++ b/config/envs/rhpam-production.yaml
@@ -23,9 +23,9 @@ servers:
       - metadata:
           name: "{{$.ApplicationName}}-postgresql-claim-{{$index}}"
           labels:
-            app: "{{$.ApplicationName}}"
+            app: "{{$.ApplicationName}}-postgresql-{{$index}}"
             application: "{{$.ApplicationName}}"
-            service: "{{$.ApplicationName}}-postgresql-{{$index}}"
+            service: "{{$.Product}}-posgtresql"
         spec:
           accessModes:
             - ReadWriteOnce
@@ -39,9 +39,9 @@ servers:
       - metadata:
           name: "{{$.ApplicationName}}-kieserver-{{$index}}"
           labels:
-            app: "{{$.ApplicationName}}"
+            app: "{{$.ApplicationName}}-kieserver-{{$index}}"
             application: "{{$.ApplicationName}}"
-            service: "{{$.ApplicationName}}-kieserver-{{$index}}"
+            service: "{{$.Product}}-kieserver"
         spec:
           replicas: 3
           template:
@@ -96,9 +96,9 @@ servers:
       - metadata:
           name: "{{$.ApplicationName}}-postgresql-{{$index}}"
           labels:
-            app: "{{$.ApplicationName}}"
+            app: "{{$.ApplicationName}}-kieserver-{{$index}}"
             application: "{{$.ApplicationName}}"
-            service: "{{$.ApplicationName}}-postgresql-{{$index}}"
+            service: "{{$.Product}}-posgtresql"
         spec:
           strategy:
             type: Recreate
@@ -121,9 +121,9 @@ servers:
               name: "{{$.ApplicationName}}-postgresql-{{$index}}"
               labels:
                 deploymentConfig: "{{$.ApplicationName}}-postgresql-{{$index}}"
-                app: "{{$.ApplicationName}}"
+                app: "{{$.ApplicationName}}-postgresql-{{$index}}"
                 application: "{{$.ApplicationName}}"
-                service: "{{$.ApplicationName}}-postgresql-{{$index}}"
+                service: "{{$.Product}}-posgtresql"
             spec:
               containers:
                 - name: "{{$.ApplicationName}}-postgresql"
@@ -169,7 +169,7 @@ servers:
             description: The database server's port.
           labels:
             application: prod
-            service: "{{$.ApplicationName}}-postgresql-{{$index}}"
+            service: "{{$.Product}}-posgtresql"
           name: "{{$.ApplicationName}}-postgresql-{{$index}}"
         spec:
           ports:

--- a/config/envs/rhpam-trial.yaml
+++ b/config/envs/rhpam-trial.yaml
@@ -32,9 +32,9 @@ console:
       metadata:
         name: "{{.ApplicationName}}-{{.Console.Name}}-http"
         labels:
-          app: "{{.ApplicationName}}"
+          app: "{{.ApplicationName}}-{{.Console.Name}}"
           application: "{{.ApplicationName}}"
-          service: "{{.ApplicationName}}-{{.Console.Name}}"
+          service: "{{.Product}}-{{.Console.Name}}"
         annotations:
           description: Route for Business Central's http service.
           haproxy.router.openshift.io/timeout: 60s
@@ -129,9 +129,9 @@ servers:
         metadata:
           name: "{{$.ApplicationName}}-kieserver-{{$index}}-http"
           labels:
-            app: "{{$.ApplicationName}}"
+            app: "{{$.ApplicationName}}-kieserver-{{$index}}"
             application: "{{$.ApplicationName}}"
-            service: "{{$.ApplicationName}}-kieserver-{{$index}}"
+            service: "{{$.Product}}-kieserver"
           annotations:
             description: Route for KIE server's http service.
             haproxy.router.openshift.io/timeout: 60s


### PR DESCRIPTION
Signed-off-by: Ruben Romero Montes <rromerom@redhat.com>

As a follow up of #67 

I see more organised the following use of the labels, which is the same pattern I followed in the APB:
* **app**: group the resources of the same type and deployment together. E.g. *rhpam-trial-businesscentral*. This will create a group in the Openshift UI showing the services, dc, secret, pods and route
* **application**: should be the name of the application to be able to virtually group all the resources of the same deployment e.g. *rhpam-trial* will fetch all the service, routes, dc, secrets, pods, ... created for business central, process server, postgres, etc.
* **service**: would retrieve all the resources of any deployment of the same type. e.g. *rhpam-businesscentral*. Identifying routes, dcs, pods, services, etc. from rhpam-trial and rhpam-authoringl but only related to businesscentral.