### PR TITLE
[KIECLOUD-115] osbs changes

### DIFF
--- a/container.yaml
+++ b/container.yaml
@@ -1,6 +1,0 @@
----
-platforms:
-  only:
-  - x86_64
-compose:
-  pulp_repos: true

--- a/hack/go-build.sh
+++ b/hack/go-build.sh
@@ -9,12 +9,12 @@ if [[ -z ${CI} ]]; then
     source hack/go-test.sh
     operator-sdk build ${REGISTRY}/${IMAGE}:${TAG}
     if [[ ${1} == "rhel" ]]; then
-        mkdir -p target/image
-        RESULT=$(md5sum build/_output/bin/kie-cloud-operator)
-        MD5=$(echo ${RESULT} | awk {'print $1'})
-        cekit-cache -v add --md5 ${RESULT}
-        cekit build --redhat --build-engine=osbs \
-            --overrides "{'version': '${TAG}', 'artifacts': [{'name': 'kie-cloud-operator', 'md5': '${MD5}'}]}"
+        cekit build \
+            --redhat \
+            --build-tech-preview \
+            --package-manager=microdnf \
+            --build-engine=osbs \
+            --build-osbs-target=rhpam-7-rhel-7-containers-candidate
     fi
 else
     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o build/_output/bin/kie-cloud-operator github.com/kiegroup/kie-cloud-operator/cmd/manager

--- a/image.yaml
+++ b/image.yaml
@@ -1,37 +1,46 @@
 schema_version: 1
 
-name: "rhpam-7-tech-preview/business-automation-operator"
+name: "rhpam-7/rhpam-7-operator"
 description: "Red Hat Business Automation Operator"
-version: "x.x"
-from: "rhel-minimal:7.6"
+version: "0.1"
+from: "rhel7-minimal"
 labels:
   - name: "maintainer"
     value: "bsig-cloud@redhat.com"
   - name: "com.redhat.component"
-    value: "business-automation-operator-container"
+    value: "rhpam-7-rhpam73-operator-container"
   - name: "io.k8s.description"
     value: "Operator for deploying RHPAM & RHDM"
   - name: "io.k8s.display-name"
     value: "Red Hat Business Automation Operator"
-  - name: "io.openshift.expose-services"
-    value: "60000:metrics"
   - name: "io.openshift.tags"
     value: "rhpam,rhdm,operator"
+packages:
+  content_sets:
+    x86_64:
+      - rhel-7-server-rpms
+  install:
+    - tar
+    - gzip
 modules:
   repositories:
     - path: modules
   install:
-    - name: business-automation-operator
+    - name: kie-cloud-operator
 artifacts:
-  - name: kie-cloud-operator
-    md5: md5sum
-ports:
-  - value: 6000
+  - name: kie-cloud-operator.tar.gz
+    url: https://github.com/kiegroup/kie-cloud-operator/releases/download/v0.1/kie-cloud-operator.v0.1.tar.gz
+    md5: 257f8c9bc142380411b51aaafb8b17c8
 osbs:
   configuration:
-    container_file: container.yaml
+    container:
+      platforms:
+        only:
+          - x86_64
+      compose:
+        pulp_repos: true
   repository:
-    name: containers/business-automation-operator
+    name: containers/rhpam-7-operator
     branch: rhpam-7.3-openshift-rhel-7
 run:
   user: nobody

--- a/modules/business-automation-operator/install
+++ b/modules/business-automation-operator/install
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-cp /tmp/artifacts/kie-cloud-operator /usr/local/bin/kie-cloud-operator
-chmod +x /usr/local/bin/kie-cloud-operator

--- a/modules/kie-cloud-operator/install
+++ b/modules/kie-cloud-operator/install
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+tar xvfz /tmp/artifacts/kie-cloud-operator.tar.gz -C /usr/local/bin/
+chmod +x /usr/local/bin/kie-cloud-operator

--- a/modules/kie-cloud-operator/module.yaml
+++ b/modules/kie-cloud-operator/module.yaml
@@ -1,5 +1,5 @@
 schema_version: 1
 
-name: business-automation-operator
+name: kie-cloud-operator
 execute:
   - script: install


### PR DESCRIPTION
With these changes, we see successful builds in OSBS.

Current build method relies on a preexisting tarball of operator binary being available for download via GitHub release. e.g. - https://github.com/kiegroup/kie-cloud-operator/releases/tag/v0.1

Signed-off-by: tchughesiv <tchughesiv@gmail.com>