### PR TITLE
[KIECLOUD-133] add cekit flag so image properly tagged after build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,10 @@ build:
 rhel:
 	./hack/go-build.sh rhel
 
+.PHONY: rhel-release
+rhel-release:
+	./hack/go-build.sh rhel release
+
 .PHONY: clean
 clean:
 	rm -rf build/_output \

--- a/README.md
+++ b/README.md
@@ -160,5 +160,8 @@ spec:
 
 Requires `cekit` and `rhpkg` -
 ```bash
+# scratch build
 make rhel
+# release candidate
+make rhel-release
 ```

--- a/hack/go-build.sh
+++ b/hack/go-build.sh
@@ -9,7 +9,10 @@ if [[ -z ${CI} ]]; then
     source hack/go-test.sh
     operator-sdk build ${REGISTRY}/${IMAGE}:${TAG}
     if [[ ${1} == "rhel" ]]; then
-        cekit build \
+        if [[ ${2} == "release" ]]; then
+            CFLAG="--build-osbs-release"
+        fi
+        cekit build ${CFLAG} \
             --redhat \
             --build-tech-preview \
             --package-manager=microdnf \

--- a/image.yaml
+++ b/image.yaml
@@ -19,6 +19,7 @@ packages:
   content_sets:
     x86_64:
       - rhel-7-server-rpms
+      - rhel-atomic-host-rpms
   install:
     - tar
     - gzip


### PR DESCRIPTION
- add rhel-release option to Makefile
  - uses release candidate build flag `--build-osbs-release` for proper tagging.
- additional content_set necessary for minimal image builds.

Signed-off-by: tchughesiv <tchughesiv@gmail.com>