### PR TITLE
bundle shell script mod

### DIFF
--- a/hack/catalog-redhat.sh
+++ b/hack/catalog-redhat.sh
@@ -42,7 +42,10 @@ status:
     namespace: ${CATALOG_NS}
 EOF
 
-cat <<EOF >deploy/catalog_resources/redhat/bundle.1.0.0.yaml
+BUNDLE_FILE="deploy/catalog_resources/redhat/bundle.1.0.0.yaml"
+if [ -d $(dirname "${BUNDLE_FILE}") ]; then
+echo "Generating ${BUNDLE_FILE}"
+cat <<EOF >${BUNDLE_FILE}
 data:
   clusterServiceVersions: |
 ${CSV}
@@ -51,3 +54,4 @@ ${CRD}
   packages: >
 ${PKG}
 EOF
+fi


### PR DESCRIPTION
Logic added so bundle file only generates if the necessary subdir exists. This is important as this script will likely also be executed by end users outside of this github branch.

Signed-off-by: tchughesiv <tchughesiv@gmail.com>