### PR TITLE
[KIECLOUD-116] Fix CRD and S2I reconciliation

### DIFF
--- a/config/common.yaml
+++ b/config/common.yaml
@@ -488,14 +488,10 @@ servers:
                       value: ws
                     - name: KIE_MBEANS
                       value: enabled
-                    - name: KIE_SERVER_ROUTE_NAME
-                      value: "{{.KieName}}{{.KieIndex}}"
-                    - name: KIE_SERVER_USE_SECURE_ROUTE_NAME
-                      value: "false"
-                    - name: KIE_SERVER_PROTOCOL
-                      value: https
-                    - name: KIE_SERVER_PORT
-                      value: "443"
+                    - name: KIE_SERVER_HOST
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: status.podIP
                     - name: KIE_SERVER_ID
                       value: "{{.KieName}}{{.KieIndex}}"
                     - name: "{{$.MavenRepo}}_MAVEN_REPO_USERNAME"

--- a/deploy/crds/kieapp.crd.yaml
+++ b/deploy/crds/kieapp.crd.yaml
@@ -143,7 +143,6 @@ spec:
                             required:
                               - uri
                               - reference
-                              - contextDir
                             properties:
                               uri:
                                 type: string

--- a/deploy/examples/immutable_deployment.yaml
+++ b/deploy/examples/immutable_deployment.yaml
@@ -21,7 +21,6 @@ spec:
           - name: KIE_SERVER_CONTAINER_DEPLOYMENT
             value: rhpam-kieserver-library=org.openshift.quickstarts:rhpam-kieserver-library:1.4.0-SNAPSHOT
       - name: kieserver-b
-        deployments: 2
         # Replace the default image stream
         from:
           kind: ImageStreamTag


### PR DESCRIPTION
Signed-off-by: Ruben Romero Montes <rromerom@redhat.com>

Fix https://issues.jboss.org/browse/KIECLOUD-116

* Added some unit tests
* Missing Buildconfig reconciliation
* contextDir should not be mandatory
* use podIP as kieServerLocation. Shouldn't use routes