### PR TITLE
[KIECLOUD-149] Fix trial environments

### DIFF
--- a/config/dbs/h2.yaml
+++ b/config/dbs/h2.yaml
@@ -13,32 +13,6 @@ servers:
             spec:
               containers:
                 - name: "[[.KieName]]"
-                  env:
-                    ## H2 driver settings BEGIN
-                    - name: DATASOURCES
-                      value: "RHPAM"
-                    - name: RHPAM_DATABASE
-                      value: "rhpam7"
-                    - name: RHPAM_JNDI
-                      value: "java:/jboss/datasources/rhpam"
-                    - name: RHPAM_JTA
-                      value: "true"
-                    - name: KIE_SERVER_PERSISTENCE_DS
-                      value: "java:/jboss/datasources/rhpam"
-                    - name: RHPAM_DRIVER
-                      value: "h2"
-                    - name: RHPAM_USERNAME
-                      value: "sa"
-                    - name: RHPAM_PASSWORD
-                      value: "[[$.AdminPassword]]"
-                    - name: RHPAM_SERVICE_HOST
-                      value: "dummy_ignored"
-                    - name: RHPAM_SERVICE_PORT
-                      value: "12345"
-                    - name: KIE_SERVER_PERSISTENCE_DIALECT
-                      value: "org.hibernate.dialect.H2Dialect"
-                    - name: RHPAM_XA_CONNECTION_PROPERTY_URL
-                      value: "jdbc:h2:/opt/eap/standalone/data/rhpam"
                   volumeMounts:
                     - name: "[[.KieName]]-h2-pvol"
                       mountPath: "/opt/eap/standalone/data"

--- a/config/envs/rhdm-authoring.yaml
+++ b/config/envs/rhdm-authoring.yaml
@@ -23,13 +23,17 @@ console:
           requests:
             storage: 1Gi
   services:
-    - spec:
+    - metadata:
+        name: "[[.ApplicationName]]-[[.Console.Name]]"
+      spec:
         ports:
           - name: git-ssh
             port: 8001
             targetPort: 8001
-      metadata:
-        name: "[[.ApplicationName]]-[[.Console.Name]]"
+    - metadata:
+        name: "[[.ApplicationName]]-[[.Console.Name]]-ping"
+        annotations:
+          delete: "true"
 ## KIE smartrouter BEGIN
 smartRouter:
   omit: true

--- a/config/envs/rhdm-trial.yaml
+++ b/config/envs/rhdm-trial.yaml
@@ -27,6 +27,10 @@ console:
           - name: git-ssh
             port: 8001
             targetPort: 8001
+    - metadata:
+        name: "[[.ApplicationName]]-[[.Console.Name]]-ping"
+        annotations:
+          delete: "true"
   routes:
     - id: "[[.ApplicationName]]-[[.Console.Name]]-http"
       metadata:
@@ -63,10 +67,9 @@ servers:
               containers:
                 - name: "[[.KieName]]"
                   env:
-                    - name: KIE_SERVER_ROUTE_NAME
-                      value: "[[.KieName]]-http"
-                    - name: KIE_SERVER_PROTOCOL
-                    - name: KIE_SERVER_PORT
+                    - name: JGROUPS_PING_PROTOCOL
+                    - name: OPENSHIFT_DNS_PING_SERVICE_NAME
+                    - name: OPENSHIFT_DNS_PING_SERVICE_PORT
                     - name: FILTERS
                       value: "AC_ALLOW_ORIGIN,AC_ALLOW_METHODS,AC_ALLOW_HEADERS,AC_ALLOW_CREDENTIALS,AC_MAX_AGE"
                     - name: AC_ALLOW_ORIGIN_FILTER_RESPONSE_HEADER_NAME

--- a/config/envs/rhpam-authoring.yaml
+++ b/config/envs/rhpam-authoring.yaml
@@ -23,13 +23,17 @@ console:
           requests:
             storage: 1Gi
   services:
-    - spec:
+    - metadata:
+        name: "[[.ApplicationName]]-[[.Console.Name]]"
+      spec:
         ports:
           - name: git-ssh
             port: 8001
             targetPort: 8001
-      metadata:
-        name: "[[.ApplicationName]]-[[.Console.Name]]"
+    - metadata:
+        name: "[[.ApplicationName]]-[[.Console.Name]]-ping"
+        annotations:
+          delete: "true"
 ## KIE smartrouter BEGIN
 smartRouter:
   omit: true

--- a/config/envs/rhpam-trial.yaml
+++ b/config/envs/rhpam-trial.yaml
@@ -27,6 +27,10 @@ console:
           - name: git-ssh
             port: 8001
             targetPort: 8001
+    - metadata:
+        name: "[[.ApplicationName]]-[[.Console.Name]]-ping"
+        annotations:
+          delete: "true"
   routes:
     - id: "[[.ApplicationName]]-[[.Console.Name]]-http"
       metadata:
@@ -63,10 +67,9 @@ servers:
               containers:
                 - name: "[[.KieName]]"
                   env:
-                    - name: KIE_SERVER_ROUTE_NAME
-                      value: "[[.KieName]]-http"
-                    - name: KIE_SERVER_PROTOCOL
-                    - name: KIE_SERVER_PORT
+                    - name: JGROUPS_PING_PROTOCOL
+                    - name: OPENSHIFT_DNS_PING_SERVICE_NAME
+                    - name: OPENSHIFT_DNS_PING_SERVICE_PORT
                     - name: FILTERS
                       value: "AC_ALLOW_ORIGIN,AC_ALLOW_METHODS,AC_ALLOW_HEADERS,AC_ALLOW_CREDENTIALS,AC_MAX_AGE"
                     - name: AC_ALLOW_ORIGIN_FILTER_RESPONSE_HEADER_NAME

--- a/deploy/crs/kieapp_rhdm_production-immutable.yaml
+++ b/deploy/crs/kieapp_rhdm_production-immutable.yaml
@@ -12,4 +12,4 @@ spec:
             uri: https://github.com/jboss-container-images/rhdm-7-openshift-image.git
             reference: master
             contextDir: quickstarts/hello-rules/hellorules
-        deployments: 2
+

--- a/pkg/controller/kieapp/constants/constants.go
+++ b/pkg/controller/kieapp/constants/constants.go
@@ -47,7 +47,7 @@ var rhdmAppConstants = v1.AppConstants{Product: RhdmPrefix, Prefix: "rhdmcentr",
 
 var ReplicasTrial = v1.ReplicaConstants{
 	Console:     v1.Replicas{Replicas: 1, DenyScale: true},
-	Server:      v1.Replicas{Replicas: 2},
+	Server:      v1.Replicas{Replicas: 1},
 	SmartRouter: v1.Replicas{Replicas: 1},
 }
 var replicasRhpamProductionImmutable = v1.ReplicaConstants{

--- a/pkg/controller/kieapp/defaults/merge_test.go
+++ b/pkg/controller/kieapp/defaults/merge_test.go
@@ -46,19 +46,19 @@ func TestMergeServices(t *testing.T) {
 	overwrite.Console.Services = append(overwrite.Console.Services, *service5)
 
 	mergedEnv, _ := merge(baseline, *overwrite)
-	assert.Equal(t, 4, len(mergedEnv.Console.Services), "Expected 4 services")
+	assert.Equal(t, 3, len(mergedEnv.Console.Services), "Expected 4 services")
 	finalService1 := mergedEnv.Console.Services[0]
+	finalService2 := mergedEnv.Console.Services[1]
 	finalService3 := mergedEnv.Console.Services[2]
-	finalService4 := mergedEnv.Console.Services[3]
 	assert.Equal(t, "true", finalService1.Labels["baseline"], "Expected the baseline label to be set")
 	assert.Equal(t, "true", finalService1.Labels["overwrite"], "Expected the overwrite label to also be set as part of the merge")
 	assert.Equal(t, "overwrite", finalService1.Labels["source"], "Expected the source label to have been overwritten by merge")
-	assert.Equal(t, "true", finalService3.Labels["baseline"], "Expected the baseline label to be set")
-	assert.Equal(t, "baseline", finalService3.Labels["source"], "Expected the source label to be baseline")
-	assert.Equal(t, "true", finalService4.Labels["overwrite"], "Expected the overwrite label to be set")
-	assert.Equal(t, "overwrite", finalService4.Labels["source"], "Expected the source label to be overwrite")
-	assert.Equal(t, "test-rhpamcentr-2", finalService3.Name, "Second service name should end with -2")
-	assert.Equal(t, "test-rhpamcentr-3", finalService4.Name, "Second service name should end with -3")
+	assert.Equal(t, "true", finalService2.Labels["baseline"], "Expected the baseline label to be set")
+	assert.Equal(t, "baseline", finalService2.Labels["source"], "Expected the source label to be baseline")
+	assert.Equal(t, "true", finalService3.Labels["overwrite"], "Expected the overwrite label to be set")
+	assert.Equal(t, "overwrite", finalService3.Labels["source"], "Expected the source label to be overwrite")
+	assert.Equal(t, "test-rhpamcentr-2", finalService2.Name, "Second service name should end with -2")
+	assert.Equal(t, "test-rhpamcentr-3", finalService3.Name, "Second service name should end with -3")
 }
 
 func TestMergeRoutes(t *testing.T) {

--- a/pkg/controller/kieapp/defaults/merge_test.go
+++ b/pkg/controller/kieapp/defaults/merge_test.go
@@ -46,7 +46,7 @@ func TestMergeServices(t *testing.T) {
 	overwrite.Console.Services = append(overwrite.Console.Services, *service5)
 
 	mergedEnv, _ := merge(baseline, *overwrite)
-	assert.Equal(t, 3, len(mergedEnv.Console.Services), "Expected 4 services")
+	assert.Equal(t, 3, len(mergedEnv.Console.Services), "Expected 3 services")
 	finalService1 := mergedEnv.Console.Services[0]
 	finalService2 := mergedEnv.Console.Services[1]
 	finalService3 := mergedEnv.Console.Services[2]


### PR DESCRIPTION
Signed-off-by: Ruben Romero Montes <rromerom@redhat.com>

Fix https://issues.jboss.org/browse/KIECLOUD-149

* Remove h2 configuration as it is already the default one
* Remove ping service and env vars for rhpamcentr in trial environments
* Remove kie_server_port and protocol env vars
* Use podIP as KIE_SERVER_HOST also for trial envs
* Trial server replicas set to 1