### PR TITLE
[RHPAM-1952] resolve kie server sticky session issue

### DIFF
--- a/config/common.yaml
+++ b/config/common.yaml
@@ -434,6 +434,7 @@ servers:
         spec:
           strategy:
             rollingParams:
+              maxSurge: 100%
               maxUnavailable: 0
             type: Rolling
           triggers:

--- a/config/dbs/h2.yaml
+++ b/config/dbs/h2.yaml
@@ -7,6 +7,8 @@ servers:
       - metadata:
           name: "[[.KieName]]"
         spec:
+          strategy:
+            type: Recreate
           template:
             metadata:
               name: "[[.KieName]]"

--- a/config/envs/rhdm-trial.yaml
+++ b/config/envs/rhdm-trial.yaml
@@ -104,6 +104,7 @@ servers:
             service: "[[.KieName]]"
           annotations:
             description: Route for KIE server's http service.
+            haproxy.router.openshift.io/balance: source
             haproxy.router.openshift.io/timeout: 60s
         spec:
           to:

--- a/config/envs/rhpam-trial.yaml
+++ b/config/envs/rhpam-trial.yaml
@@ -104,6 +104,7 @@ servers:
             service: "[[.KieName]]"
           annotations:
             description: Route for KIE server's http service.
+            haproxy.router.openshift.io/balance: source
             haproxy.router.openshift.io/timeout: 60s
         spec:
           to:

--- a/pkg/controller/kieapp/defaults/defaults_test.go
+++ b/pkg/controller/kieapp/defaults/defaults_test.go
@@ -13,6 +13,7 @@ import (
 	v1 "github.com/kiegroup/kie-cloud-operator/pkg/apis/app/v1"
 	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/constants"
 	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/test"
+	appsv1 "github.com/openshift/api/apps/v1"
 	buildv1 "github.com/openshift/api/build/v1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -422,6 +423,7 @@ func TestAuthoringEnvironment(t *testing.T) {
 	dbPassword := getEnvVariable(env.Servers[0].DeploymentConfigs[0].Spec.Template.Spec.Containers[0], "RHPAM_PASSWORD")
 	assert.Equal(t, "Database", dbPassword, "Expected provided password to take effect, but found %v", dbPassword)
 	assert.Equal(t, fmt.Sprintf("%s-kieserver", cr.Spec.CommonConfig.ApplicationName), env.Servers[len(env.Servers)-1].DeploymentConfigs[0].Spec.Template.Spec.Containers[0].Name, "the container name should have incremented")
+	assert.Equal(t, string(appsv1.DeploymentStrategyTypeRecreate), string(env.Servers[len(env.Servers)-1].DeploymentConfigs[0].Spec.Strategy.Type), "The DC should use a Recreate strategy when using the H2 DB")
 	assert.NotEqual(t, v1.Environment{}, env, "Environment should not be empty")
 }
 


### PR DESCRIPTION
 - kie servers which are using a persisted h2 db require the `Recreate` DC strategy, otherwise the following errors are thrown and rollout never successfully finishes.
```shell
18:54:10,431 ERROR [org.jboss.jca.core.tx.jbossts.XAResourceRecoveryImpl] (Periodic Recovery) IJ000906: Error during crash recovery: java:/jboss/datasources/rhpam_EJBTimer (IJ031084: Unable to create connection): javax.resource.ResourceException: IJ031084: Unable to create connection
	at org.jboss.jca.adapters.jdbc.xa.XAManagedConnectionFactory.getXAManagedConnection(XAManagedConnectionFactory.java:531)
Caused by: org.h2.jdbc.JdbcSQLException: Database may be already in use: null. Possible solutions: close all other connection(s); use the server mode [90020-193]
	at org.h2.message.DbException.getJdbcSQLException(DbException.java:345)
	at org.h2.message.DbException.get(DbException.java:168)
org.jboss.jca.adapters.jdbc.xa.XAManagedConnectionFactory.getXAManagedConnection(XAManagedConnectionFactory.java:515)
	... 16 more
Caused by: java.lang.IllegalStateException: The file is locked: nio:/opt/eap/standalone/data/rhpam.mv.db [1.4.193/7]
	at org.h2.mvstore.DataUtils.newIllegalStateException(DataUtils.java:766)
	at org.h2.mvstore.FileStore.open(FileStore.java:173)
```

/assign @sutaakar @bmozaffa 

Signed-off-by: tchughesiv <tchughesiv@gmail.com>