### PR TITLE
increment version 1.0.1 for 7.3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ build/_output/
 build/_test/
 target/
 *-packr.go
+*.tar.gz
 
 # Created by https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 ### Emacs ###

--- a/image.yaml
+++ b/image.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 name: "rhpam-7/rhpam73-operator"
 description: "Red Hat Business Automation Operator"
-version: "1.0"
+version: "1.1"
 from: "rhel7:7-released"
 labels:
   - name: "maintainer"
@@ -15,10 +15,6 @@ labels:
     value: "Red Hat Business Automation Operator"
   - name: "io.openshift.tags"
     value: "rhpam,rhdm,operator"
-artifacts:
-  - name: kie-cloud-operator.tar.gz
-    url: https://github.com/kiegroup/kie-cloud-operator/archive/1.0.x.tar.gz
-    md5: 2b442efe6cea6cb50f7742f14afdbadd
 packages:
   content_sets:
     x86_64:

--- a/pkg/controller/kieapp/constants/constants.go
+++ b/pkg/controller/kieapp/constants/constants.go
@@ -18,7 +18,7 @@ const (
 	// ProductVersion default version
 	ProductVersion = "7.3"
 	// ImageStreamTag default tag name for the ImageStreams
-	ImageStreamTag = "1.0"
+	ImageStreamTag = "1.1"
 	// ConfigMapPrefix prefix to use for the configmaps
 	ConfigMapPrefix = "kieconfigs"
 	// DefaultPassword default password to use for test environments

--- a/version/version.go
+++ b/version/version.go
@@ -2,5 +2,5 @@ package version
 
 var (
 	// Version - current development version
-	Version = "1.0.0"
+	Version = "1.0.1"
 )


### PR DESCRIPTION
/assign @bmozaffa 

 - improved handling of source code artifact

bring up master to 1.0.1 / 7.3.1 to match `1.0.x` branch before versioning for 1.1 / 7.4 in master.
i should have done this to master first originally and cherry-picked to 1.0.x ... will do next time.

Signed-off-by: tchughesiv <tchughesiv@gmail.com>