### PR TITLE
[JBPM-8150] Allow users to change Kie server id in Deployment config

### DIFF
--- a/config/common.yaml
+++ b/config/common.yaml
@@ -93,12 +93,14 @@ console:
                   - name: KIE_MBEANS
                     value: enabled
                   ## OpenShift Enhancement BEGIN
-                  #- name: KIE_CONTROLLER_OCP_ENABLED
+                  #- name: KIE_SERVER_CONTROLLER_OPENSHIFT_GLOBAL_DISCOVERY_ENABLED
                   #  value: "true"
-                  #- name: KIE_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
+                  #- name: KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
                   #  value: "true"
-                  #- name: KIE_CONTROLLER_TEMPLATE_CACHE_TTL
+                  #- name: KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL
                   #  value: "60000"
+                  #- name: KIE_WORKBENCH_CONTROLLER_OPENSHIFT_ENABLED
+                  #  value: "true"
                   ## OpenShift Enhancement END
                   - name: HTTPS_KEYSTORE_DIR
                     value: "/etc/businesscentral-secret-volume"
@@ -431,6 +433,7 @@ servers:
             app: "[[$.ApplicationName]]"
             application: "[[$.ApplicationName]]"
             service: "[[.KieName]]"
+            services.server.kie.org/kie-server-id: "[[.KieServerID]]"
         spec:
           strategy:
             rollingParams:
@@ -459,6 +462,7 @@ servers:
                 application: "[[$.ApplicationName]]"
                 service: "[[.KieName]]"
                 deploymentConfig: "[[.KieName]]"
+                services.server.kie.org/kie-server-id: "[[.KieServerID]]"
             spec:
               serviceAccountName: "[[$.ApplicationName]]-[[$.Constants.Product]]svc"
               terminationGracePeriodSeconds: 60
@@ -496,7 +500,9 @@ servers:
                         fieldRef:
                           fieldPath: status.podIP
                     - name: KIE_SERVER_ID
-                      value: "[[.KieName]]"
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.labels['services.server.kie.org/kie-server-id']
                     - name: "[[$.Constants.MavenRepo]]_MAVEN_REPO_USERNAME"
                       value: mavenUser
                     - name: "[[$.Constants.MavenRepo]]_MAVEN_REPO_PASSWORD"

--- a/deploy/crds/kieapp.crd.yaml
+++ b/deploy/crds/kieapp.crd.yaml
@@ -145,6 +145,9 @@ spec:
                       name:
                         type: string
                         description: Server name
+                      id:
+                        type: string
+                        description: Server ID
                       deployments:
                         type: integer
                         format: int

--- a/deploy/examples/openshift_startup.yaml
+++ b/deploy/examples/openshift_startup.yaml
@@ -1,0 +1,25 @@
+apiVersion: app.kiegroup.org/v1
+kind: KieApp
+metadata:
+  name: openshift-startup-strategy
+spec:
+  environment: rhpam-trial
+  objects:
+    console:
+      env:
+        - name: KIE_SERVER_CONTROLLER_OPENSHIFT_GLOBAL_DISCOVERY_ENABLED
+          value: "true"
+        - name: KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
+          value: "true"
+        - name: KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL
+          value: "60000"
+        - name: KIE_WORKBENCH_CONTROLLER_OPENSHIFT_ENABLED
+          value: "true"
+    servers:
+      - env:
+          - name: KIE_SERVER_STARTUP_STRATEGY
+            value: "OpenShiftStartupStrategy"
+      - id: testing
+        env:
+          - name: KIE_SERVER_STARTUP_STRATEGY
+            value: "OpenShiftStartupStrategy"

--- a/deploy/examples/server_config.yaml
+++ b/deploy/examples/server_config.yaml
@@ -10,7 +10,7 @@ spec:
         - name: MY_VALUE
           value: "example"
     servers:
-      # Kieserver sets will be named sequentially server-config-kieserver1, server-config-kieserver1-2
+      # Kieserver sets will be named sequentially server-config-kieserver, server-config-kieserver-2
       - deployments: 2
         # Env variables that will be added to all the kie servers in this set
         env:

--- a/pkg/apis/app/v1/kieapp_types.go
+++ b/pkg/apis/app/v1/kieapp_types.go
@@ -112,6 +112,7 @@ type KieAppObjects struct {
 type KieServerSet struct {
 	Deployments         *int                    `json:"deployments,omitempty"` // Number of KieServer DeploymentConfigs (defaults to 1)
 	Name                string                  `json:"name,omitempty"`
+	ID                  string                  `json:"id,omitempty"`
 	From                *corev1.ObjectReference `json:"from,omitempty"`
 	Build               *KieAppBuildObject      `json:"build,omitempty"` // S2I Build configuration
 	SecuredKieAppObject `json:",inline"`
@@ -332,6 +333,7 @@ type ConsoleTemplate struct {
 // ServerTemplate contains all the variables used in the yaml templates
 type ServerTemplate struct {
 	KieName        string                 `json:"kieName,omitempty"`
+	KieServerID    string                 `json:"kieServerID,omitempty"`
 	Replicas       int32                  `json:"replicas,omitempty"`
 	SSOAuthClient  SSOAuthClient          `json:"ssoAuthClient,omitempty"`
 	From           corev1.ObjectReference `json:"from,omitempty"`

--- a/pkg/controller/kieapp/constants/constants.go
+++ b/pkg/controller/kieapp/constants/constants.go
@@ -21,6 +21,8 @@ const (
 	ImageStreamTag = "1.0"
 	// ConfigMapPrefix prefix to use for the configmaps
 	ConfigMapPrefix = "kieconfigs"
+	// KieServerCMLabel the label to modify when replicas is set to 0
+	KieServerCMLabel = "services.server.kie.org/kie-server-state"
 	// DefaultAdminUser default admin user
 	DefaultAdminUser = "adminUser"
 	// DefaultPassword default password to use for test environments

--- a/pkg/controller/kieapp/defaults/defaults.go
+++ b/pkg/controller/kieapp/defaults/defaults.go
@@ -275,8 +275,12 @@ func getServersConfig(cr *v1.KieApp, commonConfig *v1.CommonConfig) ([]v1.Server
 			usedNames[name] = true
 			template := v1.ServerTemplate{
 				KieName:        name,
+				KieServerID:    name,
 				Build:          getBuildConfig(product, commonConfig, serverSet.Build),
 				KeystoreSecret: serverSet.KeystoreSecret,
+			}
+			if serverSet.ID != "" {
+				template.KieServerID = serverSet.ID
 			}
 			if serverSet.Build != nil {
 				if *serverSet.Deployments > 1 {

--- a/pkg/controller/kieapp/defaults/defaults_test.go
+++ b/pkg/controller/kieapp/defaults/defaults_test.go
@@ -1159,10 +1159,8 @@ func TestDefaultKieServerID(t *testing.T) {
 	env, err := GetEnvironment(cr, test.MockService())
 
 	assert.Nil(t, err, "Error getting trial environment")
-	kieServerID := corev1.EnvVar{Name: "KIE_SERVER_ID", Value: "test-kieserver"}
-	assert.Contains(t, env.Servers[0].DeploymentConfigs[0].Spec.Template.Spec.Containers[0].Env, kieServerID)
-	kieServerID2 := corev1.EnvVar{Name: "KIE_SERVER_ID", Value: "test-kieserver-2"}
-	assert.Contains(t, env.Servers[1].DeploymentConfigs[0].Spec.Template.Spec.Containers[0].Env, kieServerID2)
+	assert.Equal(t, env.Servers[0].DeploymentConfigs[0].Labels["services.server.kie.org/kie-server-id"], cr.Spec.Objects.Servers[0].Name)
+	assert.Equal(t, env.Servers[1].DeploymentConfigs[0].Labels["services.server.kie.org/kie-server-id"], strings.Join([]string{cr.Spec.Objects.Servers[0].Name, "2"}, "-"))
 }
 
 func TestSetKieServerID(t *testing.T) {
@@ -1176,6 +1174,7 @@ func TestSetKieServerID(t *testing.T) {
 				Servers: []v1.KieServerSet{
 					{
 						Name: "alpha",
+						ID:   "omega",
 					},
 					{
 						Name: "beta",
@@ -1187,10 +1186,8 @@ func TestSetKieServerID(t *testing.T) {
 	env, err := GetEnvironment(cr, test.MockService())
 
 	assert.Nil(t, err, "Error getting trial environment")
-	kieServerID := corev1.EnvVar{Name: "KIE_SERVER_ID", Value: "alpha"}
-	assert.Contains(t, env.Servers[0].DeploymentConfigs[0].Spec.Template.Spec.Containers[0].Env, kieServerID)
-	kieServerID = corev1.EnvVar{Name: "KIE_SERVER_ID", Value: "beta"}
-	assert.Contains(t, env.Servers[1].DeploymentConfigs[0].Spec.Template.Spec.Containers[0].Env, kieServerID)
+	assert.Equal(t, env.Servers[0].DeploymentConfigs[0].Labels["services.server.kie.org/kie-server-id"], cr.Spec.Objects.Servers[0].ID)
+	assert.Equal(t, env.Servers[1].DeploymentConfigs[0].Labels["services.server.kie.org/kie-server-id"], cr.Spec.Objects.Servers[1].Name)
 }
 
 func TestSetKieServerFrom(t *testing.T) {

--- a/pkg/controller/kieapp/watch.go
+++ b/pkg/controller/kieapp/watch.go
@@ -76,5 +76,19 @@ func Add(mgr manager.Manager, reconciler reconcile.Reconciler) error {
 		}
 	}
 
+	watchOwnedObjects = []runtime.Object{
+		&corev1.ConfigMap{},
+	}
+	ownerHandler = &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    &oappsv1.DeploymentConfig{},
+	}
+	for _, watchObject := range watchOwnedObjects {
+		err = c.Watch(&source.Kind{Type: watchObject}, ownerHandler)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }


### PR DESCRIPTION
/assign @bmozaffa @rhtevan

 - still not defaulting to OpenShiftStartupStrategy, but include an example that enables it
 - adds ability to set server id within CR spec
 - changes appropriate server ConfigMap label to "DETACHED" when the operator detects a server's replicas set to zero

Signed-off-by: tchughesiv <tchughesiv@gmail.com>