### PR TITLE
[KIECLOUD-190] KIE Server needs to respect configured imageTag

### DIFF
--- a/pkg/controller/kieapp/defaults/defaults.go
+++ b/pkg/controller/kieapp/defaults/defaults.go
@@ -417,7 +417,7 @@ func getDefaultKieServerImage(product string, config *v1.CommonConfig, from *cor
 	if from != nil {
 		return *from
 	}
-	imageName := fmt.Sprintf("%s%s-kieserver-openshift:%s", product, config.Version, constants.ImageStreamTag)
+	imageName := fmt.Sprintf("%s%s-kieserver-openshift:%s", product, config.Version, config.ImageTag)
 	return corev1.ObjectReference{
 		Kind:      "ImageStreamTag",
 		Name:      imageName,


### PR DESCRIPTION
KIE Server should also use any provided commonConfig imageTag, as console and smart router do

Signed-off-by: Babak Mozaffari <bmozaffa@redhat.com>