### PR TITLE
[KIECLOUD-190] KIE Server needs to respect configured imageTag

### DIFF
--- a/deploy/catalog_resources/courier/kiecloud-operatorsource.yaml
+++ b/deploy/catalog_resources/courier/kiecloud-operatorsource.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorSource
+metadata:
+  name: kiecloud-operators
+  namespace: openshift-marketplace
+spec:
+  type: appregistry
+  endpoint: https://quay.io/cnr
+  registryNamespace: kiegroup
+  displayName: "KIE Cloud Operators"
+  publisher: "Red Hat"

--- a/pkg/controller/kieapp/defaults/defaults.go
+++ b/pkg/controller/kieapp/defaults/defaults.go
@@ -413,7 +413,7 @@ func getDefaultKieServerImage(product string, config *v1.CommonConfig, from *cor
 	if from != nil {
 		return *from
 	}
-	imageName := fmt.Sprintf("%s%s-kieserver-openshift:%s", product, config.Version, constants.ImageStreamTag)
+	imageName := fmt.Sprintf("%s%s-kieserver-openshift:%s", product, config.Version, config.ImageTag)
 	return corev1.ObjectReference{
 		Kind:      "ImageStreamTag",
 		Name:      imageName,

--- a/pkg/controller/kieapp/defaults/defaults_test.go
+++ b/pkg/controller/kieapp/defaults/defaults_test.go
@@ -1873,6 +1873,45 @@ func TestDatabasePostgresqlTrialEphemeral(t *testing.T) {
 	}
 }
 
+func TestCustomImageTag(t *testing.T) {
+	cr := &v1.KieApp{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "prod",
+		},
+		Spec: v1.KieAppSpec{
+			Environment: v1.RhpamProduction,
+			CommonConfig: v1.CommonConfig{
+				ImageTag: "1.2",
+			},
+			Objects: v1.KieAppObjects{
+				Servers: []v1.KieServerSet{
+					{
+						Deployments: Pint(2),
+					},
+				},
+			},
+		},
+	}
+	env, err := GetEnvironment(cr, test.MockService())
+
+	assert.Nil(t, err, "Error getting prod environment")
+	assert.Len(t, env.Servers, 2, "Expect two KIE Servers to be created based on provided build configs")
+
+	assert.True(t, strings.HasSuffix(getImageChangeName(env.Console.DeploymentConfigs[0]), cr.Spec.CommonConfig.ImageTag), "Image expected to have tag of %s", cr.Spec.CommonConfig.ImageTag)
+	assert.True(t, strings.HasSuffix(getImageChangeName(env.Servers[0].DeploymentConfigs[0]), cr.Spec.CommonConfig.ImageTag), "Image expected to have tag of %s", cr.Spec.CommonConfig.ImageTag)
+	assert.True(t, strings.HasSuffix(getImageChangeName(env.Servers[1].DeploymentConfigs[0]), cr.Spec.CommonConfig.ImageTag), "Image expected to have tag of %s", cr.Spec.CommonConfig.ImageTag)
+	assert.True(t, strings.HasSuffix(getImageChangeName(env.SmartRouter.DeploymentConfigs[0]), cr.Spec.CommonConfig.ImageTag), "Image expected to have tag of %s", cr.Spec.CommonConfig.ImageTag)
+}
+
+func getImageChangeName(dc appsv1.DeploymentConfig) string {
+	for _, trigger := range dc.Spec.Triggers {
+		if trigger.Type == appsv1.DeploymentTriggerOnImageChange {
+			return trigger.ImageChangeParams.From.Name
+		}
+	}
+	return ""
+}
+
 func LoadKieApp(t *testing.T, folder string, fileName string) v1.KieApp {
 	box := packr.NewBox("../../../../deploy/" + folder)
 	yamlString, err := box.FindString(fileName)


### PR DESCRIPTION
Cherry-pick from master
KIE Server should also use any provided commonConfig imageTag, as console and smart router do

Signed-off-by: Babak Mozaffari <bmozaffa@redhat.com>