### PR TITLE
user_setup script fixes

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,8 +1,5 @@
 FROM registry.access.redhat.com/ubi8-minimal
 
-ENV USER_UID=1001 \
-    USER_NAME=kie-cloud-operator
-
 # install operator binary
 COPY build/_output/bin/kie-cloud-operator /usr/local/bin/kie-cloud-operator
 COPY build/_output/bin/console-cr-form /usr/local/bin/console-cr-form
@@ -12,4 +9,4 @@ RUN  /usr/local/bin/user_setup
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 
-USER ${USER_UID}
+USER 1001

--- a/build/bin/user_setup
+++ b/build/bin/user_setup
@@ -1,13 +1,10 @@
 #!/bin/sh
 set -x
 
-# ensure $HOME exists and is accessible by group 0 (we don't know what the runtime UID will be)
-mkdir -p ${HOME}
-chown ${USER_UID}:0 ${HOME}
 chmod ug+rwx ${HOME}
 
 # runtime user will need to be able to self-insert in /etc/passwd
-chmod g+rw /etc/passwd
+chmod g=u /etc/passwd
 
 # no need for this script to remain in the image after running
 rm $0

--- a/image.yaml
+++ b/image.yaml
@@ -17,13 +17,6 @@ labels:
     value: "rhpam,rhdm,operator"
   - name: "com.redhat.delivery.appregistry"
     value: "true"
-envs:
-  - name: "USER_UID"
-    value: "1001"
-  - name: "USER_NAME"
-    value: "kie-cloud-operator"
-  - name: "OPERATOR_VERSION"
-    value: "1.1.0"
 packages:
   content_sets:
     x86_64:

--- a/modules/kie-cloud-operator/install
+++ b/modules/kie-cloud-operator/install
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 INSTALL_PKGS="go-toolset"
+OPERATOR_VERSION="1.1.0"
 OPERATOR_PATH=/usr/local/bin/kie-cloud-operator
 UI_PATH=/usr/local/bin/console-cr-form
 


### PR DESCRIPTION
 - USER_NAME and USER_UID vars are unecessary
 - HOME dir always already exists because build occurs as root
 - this simplifies a bit and bring the 2 builds closer (docker & osbs)

/assign @bmozaffa @ruromero 

Signed-off-by: tchughesiv <tchughesiv@gmail.com>