### PR TITLE
[KIECLOUD-226] - Set RHPAM_NONXA to false on authoring scenarios with…

### DIFF
--- a/config/dbs/h2.yaml
+++ b/config/dbs/h2.yaml
@@ -39,6 +39,8 @@ servers:
                       value: "12345"
                     - name: KIE_SERVER_PERSISTENCE_DS
                       value: "java:/jboss/datasources/rhpam"
+                    - name: RHPAM_NONXA
+                      value: "false"
                     - name: RHPAM_XA_CONNECTION_PROPERTY_URL
                       value: "jdbc:h2:/opt/kie/data/h2/rhpam;AUTO_SERVER=TRUE"
                     ## H2 driver settings END


### PR DESCRIPTION
… H2 database

See: https://issues.jboss.org/browse/KIECLOUD-226

Signed-off-by: Ricardo Zanini <zanini@redhat.com>