### PR TITLE
[KIECLOUD-97] - Cherry-picked Synchronize OpenShiftStartupStrategy related changes …

### DIFF
--- a/config/common.yaml
+++ b/config/common.yaml
@@ -517,8 +517,6 @@ servers:
                           fieldPath: metadata.labels['services.server.kie.org/kie-server-id']
                     - name: KIE_SERVER_ROUTE_NAME
                       value: "[[.KieName]]"
-                    - name: KIE_SERVER_USE_SECURE_ROUTE_NAME
-                      value: "true"
                     - name: "[[$.Constants.MavenRepo]]_MAVEN_REPO_USERNAME"
                       value: mavenUser
                     - name: "[[$.Constants.MavenRepo]]_MAVEN_REPO_PASSWORD"
@@ -722,7 +720,7 @@ servers:
     routes:
       - id: "[[.KieName]]-https"
         metadata:
-          name: "secure-[[.KieName]]"
+          name: "[[.KieName]]"
           labels:
             app: "[[$.ApplicationName]]"
             application: "[[$.ApplicationName]]"

--- a/pkg/controller/kieapp/defaults/defaults_test.go
+++ b/pkg/controller/kieapp/defaults/defaults_test.go
@@ -992,7 +992,7 @@ func TestMergeTrialAndCommonConfig(t *testing.T) {
 	assert.Equal(t, "test-rhpamcentr", env.Console.Routes[0].Name)
 	assert.Equal(t, "test-rhpamcentr-http", env.Console.Routes[1].Name)
 
-	assert.Equal(t, "secure-test-kieserver", env.Servers[0].Routes[0].Name)
+	assert.Equal(t, "test-kieserver", env.Servers[0].Routes[0].Name)
 	assert.Equal(t, "test-kieserver-http", env.Servers[0].Routes[1].Name)
 
 	// Env vars overrides
@@ -1528,12 +1528,12 @@ func TestExampleServerCommonConfig(t *testing.T) {
 	assert.Equal(t, "server-config-kieserver2", env.Servers[len(env.Servers)-2].DeploymentConfigs[0].Name, "Unexpected name for object")
 	assert.Equal(t, "server-config-kieserver2", env.Servers[len(env.Servers)-2].Services[0].Name, "Unexpected name for object")
 	assert.Equal(t, "server-config-kieserver2-ping", env.Servers[len(env.Servers)-2].Services[1].Name, "Unexpected name for object")
-	assert.Equal(t, "secure-server-config-kieserver2", env.Servers[len(env.Servers)-2].Routes[0].Name, "Unexpected name for object")
+	assert.Equal(t, "server-config-kieserver2", env.Servers[len(env.Servers)-2].Routes[0].Name, "Unexpected name for object")
 	assert.Equal(t, "server-config-kieserver2-http", env.Servers[len(env.Servers)-2].Routes[1].Name, "Unexpected name for object")
 	assert.Equal(t, "server-config-kieserver2-2", env.Servers[len(env.Servers)-1].DeploymentConfigs[0].Name, "Unexpected name for object")
 	assert.Equal(t, "server-config-kieserver2-2", env.Servers[len(env.Servers)-1].Services[0].Name, "Unexpected name for object")
 	assert.Equal(t, "server-config-kieserver2-2-ping", env.Servers[len(env.Servers)-1].Services[1].Name, "Unexpected name for object")
-	assert.Equal(t, "secure-server-config-kieserver2-2", env.Servers[len(env.Servers)-1].Routes[0].Name, "Unexpected name for object")
+	assert.Equal(t, "server-config-kieserver2-2", env.Servers[len(env.Servers)-1].Routes[0].Name, "Unexpected name for object")
 	assert.Equal(t, "server-config-kieserver2-2-http", env.Servers[len(env.Servers)-1].Routes[1].Name, "Unexpected name for object")
 }
 


### PR DESCRIPTION
/assign @bmozaffa 

…between Template, APB, and Operator

Follow-up requrest, rollback the secure prefix ( it is now aligned between
templates, apb and operator)

update imagestream tag, 7.4 images uses tasg 1.0

Signed-off-by: Filippe Spolti <fspolti@redhat.com>