### PR TITLE
Rename JMS fields

### DIFF
--- a/config/jms/activemq-jms-config.yaml
+++ b/config/jms/activemq-jms-config.yaml
@@ -14,35 +14,35 @@ servers:
                 env:
                   # JMS config BEGIN
                   - name: KIE_SERVER_JMS_QUEUE_REQUEST
-                    value: "[[.Jms.KieServerJmsQueueRequest]]"
+                    value: "[[.Jms.QueueRequest]]"
                   - name: KIE_SERVER_JMS_QUEUE_RESPONSE
-                    value: "[[.Jms.KieServerJmsQueueResponse]]"
+                    value: "[[.Jms.QueueResponse]]"
                   - name: KIE_SERVER_JMS_QUEUE_EXECUTOR
-                    value: "[[.Jms.KieServerJmsQueueExecutor]]"
+                    value: "[[.Jms.QueueExecutor]]"
                   - name: KIE_SERVER_JMS_ENABLE_SIGNAL
-                    value: "[[.Jms.KieServerJmsEnableSignal]]"
-                    # [[ if .Jms.KieServerJmsEnableSignal]]
+                    value: "[[.Jms.EnableSignal]]"
+                    # [[ if .Jms.EnableSignal]]
                   - name: KIE_SERVER_JMS_QUEUE_SIGNAL
-                    value: "[[.Jms.KieServerJmsQueueSignal]]"
+                    value: "[[.Jms.QueueSignal]]"
                     # [[end]]
                   - name: KIE_SERVER_JMS_ENABLE_AUDIT
-                    value: "[[.Jms.KieServerJmsEnableAudit]]"
-                    # [[ if .Jms.KieServerJmsEnableAudit]]
+                    value: "[[.Jms.EnableAudit]]"
+                    # [[ if .Jms.EnableAudit]]
                   - name: KIE_SERVER_JMS_QUEUE_AUDIT
-                    value: "[[.Jms.KieServerJmsQueueAudit]]"
+                    value: "[[.Jms.QueueAudit]]"
                     # [[end]]
                   - name: KIE_SERVER_JMS_AUDIT_TRANSACTED
-                    value: "[[.Jms.KieServerJmsAuditTransacted]]"
+                    value: "[[.Jms.AuditTransacted]]"
                   - name: MQ_SERVICE_PREFIX_MAPPING
                     value: "[[.KieName]]-amq7=AMQ"
                   - name: AMQ_USERNAME
-                    value: "[[.Jms.KieServerJmsUsername]]"
+                    value: "[[.Jms.Username]]"
                   - name: AMQ_PASSWORD
-                    value: "[[.Jms.KieServerJmsPassword]]"
+                    value: "[[.Jms.Password]]"
                   - name: AMQ_PROTOCOL
                     value: "tcp"
                   - name: AMQ_QUEUES
-                    value: "[[.Jms.KieServerJmsAMQQueues]]"
+                    value: "[[.Jms.AMQQueues]]"
                   # JMS config END
     ## KIE server deployment config END
     ## AMQ deployment BEGIN
@@ -109,9 +109,9 @@ servers:
                   protocol: TCP
               env:
                 - name: AMQ_USER
-                  value: "[[.Jms.KieServerJmsUsername]]"
+                  value: "[[.Jms.Username]]"
                 - name: AMQ_PASSWORD
-                  value: "[[.Jms.KieServerJmsPassword]]"
+                  value: "[[.Jms.Password]]"
                   # maybe turn it in a parameter and defaults to admin if empty?
                 - name: AMQ_ROLE
                   value: "admin"
@@ -120,7 +120,7 @@ servers:
                 - name: AMQ_TRANSPORTS
                   value: "openwire"
                 - name: AMQ_QUEUES
-                  value: "[[.Jms.KieServerJmsAMQQueues]]"
+                  value: "[[.Jms.AMQQueues]]"
                 - name: AMQ_REQUIRE_LOGIN
                   value: "false"
                 - name: AMQ_ANYCAST_PREFIX

--- a/deploy/crds/kieapp.crd.yaml
+++ b/deploy/crds/kieapp.crd.yaml
@@ -394,48 +394,48 @@ spec:
                         type: object
                         description: Configuration for JMS integration with KIE Server.
                         required:
-                        - enableKieServerJMSIntegration
+                        - enableIntegration
                         properties:
-                          enableKieServerJMSIntegration:
+                          enableIntegration:
                             type: boolean
                             description: When set to true will configure the KIE Server with JMS integration, if no configuration is added, the default will be used.
-                          kieServerJmsExecutor:
+                          executor:
                             type: boolean
                             description: Set false to disable the JMS executor, it is enabled by default.
-                          kieServerJmsQueueExecutor:
+                          queueExecutor:
                             type: string
                             description: JNDI name of executor queue for JMS, example queue/CUSTOM.KIE.SERVER.EXECUTOR, default is queue/KIE.SERVER.EXECUTOR.
-                          kieServerJmsExecutorTransacted:
+                          executorTransacted:
                             type: boolean
                             description: Enable transactions for JMS executor, disabled by default.
-                          kieServerJmsQueueRequest:
+                          queueRequest:
                             type: string
                             description: JNDI name of request queue for JMS, example queue/CUSTOM.KIE.SERVER.REQUEST, default is queue/KIE.SERVER.REQUEST.
-                          kieServerJmsQueueResponse:
+                          queueResponse:
                             type: string
                             description: JNDI name of response queue for JMS, example queue/CUSTOM.KIE.SERVER.RESPONSE, default is queue/KIE.SERVER.RESPONSE.
-                          kieServerJmsEnableSignal:
+                          enableSignal:
                             type: boolean
                             description: Enable the Signal configuration through JMS. Default is false.
-                          kieServerJmsQueueSignal:
+                          queueSignal:
                             type: string
                             description: JNDI name of signal queue for JMS, example queue/CUSTOM.KIE.SERVER.SIGNAL, default is queue/KIE.SERVER.SIGNAL.
-                          kieServerJmsEnableAudit:
+                          enableAudit:
                             type: boolean
                             description: Enable the Audit logging through JMS. Default is false.
-                          kieServerJmsQueueAudit:
+                          queueAudit:
                             type: string
                             description: JNDI name of audit logging queue for JMS, example queue/CUSTOM.KIE.SERVER.AUDIT, default is queue/KIE.SERVER.AUDIT.
-                          kieServerJmsAuditTransacted:
+                          auditTransacted:
                             type: boolean
                             description: Determines if JMS session is transacted or not - default true.
-                          kieServerJmsUsername:
+                          username:
                             type: string
                             description: AMQ broker username to connect do the AMQ, generated if empty.
-                          kieServerJmsPassword:
+                          password:
                             type: string
                             description: AMQ broker password to connect do the AMQ, generated if empty.
-                          kieServerJmsAMQQueues:
+                          amqQueues:
                             type: string
                             description: AMQ broker broker comma separated queues, if empty the values from default queues will be used.
                 smartRouter:

--- a/deploy/crs/kieapp_rhdm_production-immutable-jms.yaml
+++ b/deploy/crs/kieapp_rhdm_production-immutable-jms.yaml
@@ -13,6 +13,6 @@ spec:
             reference: master
             contextDir: quickstarts/hello-rules/hellorules
         jms:
-          enableKieServerJMSIntegration: true
-          kieServerJmsEnableSignal: true
-          kieServerJmsEnableAudit: true
+          enableIntegration: true
+          enableSignal: true
+          enableAudit: true

--- a/deploy/crs/kieapp_rhpam_production-immutable-jms.yaml
+++ b/deploy/crs/kieapp_rhpam_production-immutable-jms.yaml
@@ -13,6 +13,6 @@ spec:
             reference: master
             contextDir: quickstarts/library-process/library
         jms:
-          enableKieServerJMSIntegration: true
-          kieServerJmsEnableSignal: true
-          kieServerJmsEnableAudit: true
+          enableIntegration: true
+          enableSignal: true
+          enableAudit: true

--- a/pkg/apis/app/v1/kieapp_types.go
+++ b/pkg/apis/app/v1/kieapp_types.go
@@ -135,21 +135,20 @@ type SecuredKieAppObject struct {
 
 // KieAppJmsObject messaging specification to be used by the KieApp
 type KieAppJmsObject struct {
-	EnableKieServerJMSIntegration  bool   `json:"enableKieServerJMSIntegration,omitempty"`
-	KieServerJmsExecutor           bool   `json:"kieServerJmsExecutor,omitempty"`
-	KieServerJmsExecutorTransacted bool   `json:"kieServerJmsExecutorTransacted,omitempty"`
-	KieServerJmsQueueRequest       string `json:"kieServerJmsQueueRequest,omitempty"`
-	KieServerJmsQueueResponse      string `json:"kieServerJmsQueueResponse,omitempty"`
-	KieServerJmsQueueExecutor      string `json:"kieServerJmsQueueExecutor,omitempty"`
-	KieServerJmsEnableSignal       bool   `json:"kieServerJmsEnableSignal,omitempty"`
-	KieServerJmsQueueSignal        string `json:"kieServerJmsQueueSignal,omitempty"`
-	KieServerJmsEnableAudit        bool   `json:"kieServerJmsEnableAudit,omitempty"`
-	KieServerJmsQueueAudit         string `json:"kieServerJmsQueueAudit,omitempty"`
-	KieServerJmsAuditTransacted    bool   `json:"kieServerJmsAuditTransacted,omitempty"`
-	KieServerJmsUsername           string `json:"kieServerJmsUsername,omitempty"`
-	KieServerJmsPassword           string `json:"kieServerJmsPassword,omitempty"`
-	// It will receives the default value for the Executor, Request, Response, Signal and Audit queues.
-	KieServerJmsAMQQueues string `json:"kieServerJmsAMQQueues,omitempty"`
+	EnableIntegration  bool   `json:"enableIntegration,omitempty"`
+	Executor           bool   `json:"executor,omitempty"`
+	ExecutorTransacted bool   `json:"executorTransacted,omitempty"`
+	QueueRequest       string `json:"queueRequest,omitempty"`
+	QueueResponse      string `json:"queueResponse,omitempty"`
+	QueueExecutor      string `json:"queueExecutor,omitempty"`
+	EnableSignal       bool   `json:"enableSignal,omitempty"`
+	QueueSignal        string `json:"queueSignal,omitempty"`
+	EnableAudit        bool   `json:"enableAudit,omitempty"`
+	QueueAudit         string `json:"queueAudit,omitempty"`
+	AuditTransacted    bool   `json:"auditTransacted,omitempty"`
+	Username           string `json:"username,omitempty"`
+	Password           string `json:"password,omitempty"`
+	AMQQueues          string `json:"amqQueues,omitempty"` // It will receive the default value for the Executor, Request, Response, Signal and Audit queues.
 }
 
 // KieAppObject Generic object definition

--- a/pkg/controller/kieapp/defaults/defaults.go
+++ b/pkg/controller/kieapp/defaults/defaults.go
@@ -121,7 +121,7 @@ func mergeJms(service v1.PlatformService, cr *v1.KieApp, env v1.Environment, env
 	for i := range env.Servers {
 		kieServerSet := envTemplate.Servers[i]
 
-		isJmsEnabled := kieServerSet.Jms.EnableKieServerJMSIntegration
+		isJmsEnabled := kieServerSet.Jms.EnableIntegration
 
 		if isJmsEnabled {
 			yamlBytes, err := loadYaml(service, fmt.Sprintf("jms/activemq-jms-config.yaml"), cr.Namespace, envTemplate)
@@ -513,31 +513,31 @@ func getDatabaseConfig(environment v1.EnvironmentType, database *v1.DatabaseObje
 func getJmsConfig(environment v1.EnvironmentType, jms *v1.KieAppJmsObject) (*v1.KieAppJmsObject, error) {
 
 	envConstants := constants.EnvironmentConstants[environment]
-	if envConstants == nil || jms == nil || !jms.EnableKieServerJMSIntegration {
+	if envConstants == nil || jms == nil || !jms.EnableIntegration {
 		return nil, nil
 	}
 	// if enabled, prepare the default values
 	defaultJms := &v1.KieAppJmsObject{
-		KieServerJmsExecutor:           true,
-		KieServerJmsExecutorTransacted: false,
-		KieServerJmsQueueExecutor:      "queue/KIE.SERVER.EXECUTOR",
-		KieServerJmsQueueRequest:       "queue/KIE.SERVER.REQUEST",
-		KieServerJmsQueueResponse:      "queue/KIE.SERVER.RESPONSE",
-		KieServerJmsEnableSignal:       false,
-		KieServerJmsQueueSignal:        "queue/KIE.SERVER.SIGNAL",
-		KieServerJmsEnableAudit:        false,
-		KieServerJmsQueueAudit:         "queue/KIE.SERVER.AUDIT",
-		KieServerJmsAuditTransacted:    true,
-		KieServerJmsUsername:           "user" + string(shared.GeneratePassword(4)),
-		KieServerJmsPassword:           string(shared.GeneratePassword(8)),
+		Executor:           true,
+		ExecutorTransacted: false,
+		QueueExecutor:      "queue/KIE.SERVER.EXECUTOR",
+		QueueRequest:       "queue/KIE.SERVER.REQUEST",
+		QueueResponse:      "queue/KIE.SERVER.RESPONSE",
+		EnableSignal:       false,
+		QueueSignal:        "queue/KIE.SERVER.SIGNAL",
+		EnableAudit:        false,
+		QueueAudit:         "queue/KIE.SERVER.AUDIT",
+		AuditTransacted:    true,
+		Username:           "user" + string(shared.GeneratePassword(4)),
+		Password:           string(shared.GeneratePassword(8)),
 	}
 
 	queuesList := []string{
-		getDefaultQueue(true, defaultJms.KieServerJmsQueueExecutor, jms.KieServerJmsQueueExecutor),
-		getDefaultQueue(true, defaultJms.KieServerJmsQueueRequest, jms.KieServerJmsQueueRequest),
-		getDefaultQueue(true, defaultJms.KieServerJmsQueueResponse, jms.KieServerJmsQueueResponse),
-		getDefaultQueue(jms.KieServerJmsEnableSignal, defaultJms.KieServerJmsQueueSignal, jms.KieServerJmsQueueSignal),
-		getDefaultQueue(jms.KieServerJmsEnableAudit, defaultJms.KieServerJmsQueueAudit, jms.KieServerJmsQueueAudit)}
+		getDefaultQueue(true, defaultJms.QueueExecutor, jms.QueueExecutor),
+		getDefaultQueue(true, defaultJms.QueueRequest, jms.QueueRequest),
+		getDefaultQueue(true, defaultJms.QueueResponse, jms.QueueResponse),
+		getDefaultQueue(jms.EnableSignal, defaultJms.QueueSignal, jms.QueueSignal),
+		getDefaultQueue(jms.EnableAudit, defaultJms.QueueAudit, jms.QueueAudit)}
 
 	// clean empty values
 	for i, queue := range queuesList {
@@ -546,7 +546,7 @@ func getJmsConfig(environment v1.EnvironmentType, jms *v1.KieAppJmsObject) (*v1.
 			break
 		}
 	}
-	defaultJms.KieServerJmsAMQQueues = strings.Join(queuesList[:], ", ")
+	defaultJms.AMQQueues = strings.Join(queuesList[:], ", ")
 
 	// merge the defaultJms into jms, preserving the values set by cr
 	mergo.Merge(jms, defaultJms)

--- a/pkg/controller/kieapp/defaults/defaults_test.go
+++ b/pkg/controller/kieapp/defaults/defaults_test.go
@@ -316,12 +316,12 @@ func TestRhdmProdImmutableJMSEnvironment(t *testing.T) {
 				Servers: []v1.KieServerSet{
 					{
 						Jms: &v1.KieAppJmsObject{
-							EnableKieServerJMSIntegration: true,
-							KieServerJmsUsername:          "adminUser",
-							KieServerJmsPassword:          "adminPassword",
-							KieServerJmsAuditTransacted:   false,
-							KieServerJmsEnableAudit:       true,
-							KieServerJmsQueueAudit:        "queue/CUSTOM.KIE.SERVER.AUDIT",
+							EnableIntegration: true,
+							Username:          "adminUser",
+							Password:          "adminPassword",
+							AuditTransacted:   false,
+							EnableAudit:       true,
+							QueueAudit:        "queue/CUSTOM.KIE.SERVER.AUDIT",
 						},
 					},
 				},
@@ -370,12 +370,12 @@ func TestRhpamProdImmutableJMSEnvironment(t *testing.T) {
 				Servers: []v1.KieServerSet{
 					{
 						Jms: &v1.KieAppJmsObject{
-							EnableKieServerJMSIntegration: true,
-							KieServerJmsUsername:          "adminUser",
-							KieServerJmsPassword:          "adminPassword",
-							KieServerJmsAuditTransacted:   false,
-							KieServerJmsEnableAudit:       true,
-							KieServerJmsQueueAudit:        "queue/CUSTOM.KIE.SERVER.AUDIT",
+							EnableIntegration: true,
+							Username:          "adminUser",
+							Password:          "adminPassword",
+							AuditTransacted:   false,
+							EnableAudit:       true,
+							QueueAudit:        "queue/CUSTOM.KIE.SERVER.AUDIT",
 						},
 					},
 				},


### PR DESCRIPTION
It doesn't make sense to repeat `KieServerJms` in the struct's attributes as it is obvious they are KieServer.Jms attributes

Signed-off-by: Ruben Romero Montes <rromerom@redhat.com>