### PR TITLE
[KIECLOUD-149] Fix rhdm/rhpam trial environments

### DIFF
--- a/config/envs/rhdm-trial.yaml
+++ b/config/envs/rhdm-trial.yaml
@@ -7,6 +7,11 @@ console:
           spec:
             containers:
               - name: "[[.ApplicationName]]-[[.Console.Name]]"
+                env:
+                  - name: KIE_SERVER_HOST
+                  - name: JGROUPS_PING_PROTOCOL
+                  - name: OPENSHIFT_DNS_PING_SERVICE_NAME
+                  - name: OPENSHIFT_DNS_PING_SERVICE_PORT
                 ports:
                   - name: git-ssh
                     containerPort: 8001
@@ -63,6 +68,7 @@ servers:
               containers:
                 - name: "[[.KieName]]"
                   env:
+                    - name: KIE_SERVER_HOST
                     - name: JGROUPS_PING_PROTOCOL
                     - name: OPENSHIFT_DNS_PING_SERVICE_NAME
                     - name: OPENSHIFT_DNS_PING_SERVICE_PORT

--- a/config/envs/rhdm-trial.yaml
+++ b/config/envs/rhdm-trial.yaml
@@ -68,7 +68,6 @@ servers:
               containers:
                 - name: "[[.KieName]]"
                   env:
-                    - name: KIE_SERVER_HOST
                     - name: JGROUPS_PING_PROTOCOL
                     - name: OPENSHIFT_DNS_PING_SERVICE_NAME
                     - name: OPENSHIFT_DNS_PING_SERVICE_PORT

--- a/config/envs/rhpam-trial.yaml
+++ b/config/envs/rhpam-trial.yaml
@@ -7,6 +7,11 @@ console:
           spec:
             containers:
               - name: "[[.ApplicationName]]-[[.Console.Name]]"
+                env:
+                  - name: KIE_SERVER_HOST
+                  - name: JGROUPS_PING_PROTOCOL
+                  - name: OPENSHIFT_DNS_PING_SERVICE_NAME
+                  - name: OPENSHIFT_DNS_PING_SERVICE_PORT
                 ports:
                   - name: git-ssh
                     containerPort: 8001
@@ -63,6 +68,7 @@ servers:
               containers:
                 - name: "[[.KieName]]"
                   env:
+                    - name: KIE_SERVER_HOST
                     - name: JGROUPS_PING_PROTOCOL
                     - name: OPENSHIFT_DNS_PING_SERVICE_NAME
                     - name: OPENSHIFT_DNS_PING_SERVICE_PORT

--- a/config/envs/rhpam-trial.yaml
+++ b/config/envs/rhpam-trial.yaml
@@ -68,7 +68,6 @@ servers:
               containers:
                 - name: "[[.KieName]]"
                   env:
-                    - name: KIE_SERVER_HOST
                     - name: JGROUPS_PING_PROTOCOL
                     - name: OPENSHIFT_DNS_PING_SERVICE_NAME
                     - name: OPENSHIFT_DNS_PING_SERVICE_PORT


### PR DESCRIPTION
Fix https://issues.jboss.org/browse/KIECLOUD-149

* Disable JGROUPS for DecisionManager and BusinessCentral in trial environments

Signed-off-by: Ruben Romero Montes <rromerom@redhat.com>