### PR TITLE
[RHPAM-2226] Validation subelement is missing for datasources

### DIFF
--- a/config/dbs/mysql.yaml
+++ b/config/dbs/mysql.yaml
@@ -46,6 +46,10 @@ servers:
                       value: "[[.KieName]]-mysql"
                     - name: RHPAM_SERVICE_PORT
                       value: "3306"
+                    - name: RHPAM_CONNECTION_CHECKER
+                      value: "org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLValidConnectionChecker"
+                    - name: RHPAM_EXCEPTION_SORTER
+                      value: "org.jboss.jca.adapters.jdbc.extensions.mysql.MySQLExceptionSorter"
                     - name: TIMER_SERVICE_DATA_STORE_REFRESH_INTERVAL
                       value: "60000"
                     ## MySQL driver settings END

--- a/config/dbs/postgresql.yaml
+++ b/config/dbs/postgresql.yaml
@@ -46,6 +46,10 @@ servers:
                       value: "[[.KieName]]-postgresql"
                     - name: RHPAM_SERVICE_PORT
                       value: "5432"
+                    - name: RHPAM_CONNECTION_CHECKER
+                      value: "org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLValidConnectionChecker"
+                    - name: RHPAM_EXCEPTION_SORTER
+                      value: "org.jboss.jca.adapters.jdbc.extensions.postgres.PostgreSQLExceptionSorter"
                     - name: TIMER_SERVICE_DATA_STORE_REFRESH_INTERVAL
                       value: "30000"
                     ## PostgreSQL driver settings END


### PR DESCRIPTION
[RHPAM-2226] Validation subelement is missing for datasources
Validation subelement is missing for datasources

Signed-off-by: David Ward <dward@redhat.com>