### PR TITLE
[KIECLOUD-160] Removing unnecessary git ports from containers

### DIFF
--- a/config/7.5.0/envs/rhdm-authoring-ha.yaml
+++ b/config/7.5.0/envs/rhdm-authoring-ha.yaml
@@ -25,10 +25,6 @@ console:
                 volumeMounts:
                   - name: "[[.ApplicationName]]-[[.Console.Name]]-pvol"
                     mountPath: "/opt/kie/data"
-                ports:
-                  - name: git-ssh
-                    containerPort: 8001
-                    protocol: TCP
                 env:
                   - name: APPFORMER_INFINISPAN_SERVICE_NAME
                     value: "[[.ApplicationName]]-datagrid"
@@ -46,15 +42,6 @@ console:
               - name: "[[.ApplicationName]]-[[.Console.Name]]-pvol"
                 persistentVolumeClaim:
                   claimName: "[[.ApplicationName]]-[[.Console.Name]]-claim"
-
-  services:
-    - spec:
-        ports:
-          - name: git-ssh
-            port: 8001
-            targetPort: 8001
-      metadata:
-        name: "[[.ApplicationName]]-[[.Console.Name]]"
 
 # ES/AMQ BEGIN
 others:

--- a/config/7.5.0/envs/rhdm-authoring.yaml
+++ b/config/7.5.0/envs/rhdm-authoring.yaml
@@ -26,10 +26,6 @@ console:
                     value: ""
                   - name: OPENSHIFT_DNS_PING_SERVICE_PORT
                     value: ""
-                ports:
-                  - name: git-ssh
-                    containerPort: 8001
-                    protocol: TCP
   persistentVolumeClaims:
     - metadata:
         name: "[[.ApplicationName]]-[[.Console.Name]]-claim"
@@ -40,13 +36,6 @@ console:
           requests:
             storage: 1Gi
   services:
-    - metadata:
-        name: "[[.ApplicationName]]-[[.Console.Name]]"
-      spec:
-        ports:
-          - name: git-ssh
-            port: 8001
-            targetPort: 8001
     - metadata:
         name: "[[.ApplicationName]]-[[.Console.Name]]-ping"
         annotations:

--- a/config/7.5.0/envs/rhdm-trial.yaml
+++ b/config/7.5.0/envs/rhdm-trial.yaml
@@ -12,10 +12,6 @@ console:
                   - name: JGROUPS_PING_PROTOCOL
                   - name: OPENSHIFT_DNS_PING_SERVICE_NAME
                   - name: OPENSHIFT_DNS_PING_SERVICE_PORT
-                ports:
-                  - name: git-ssh
-                    containerPort: 8001
-                    protocol: TCP
             volumes:
               - name: "[[.ApplicationName]]-[[.Console.Name]]-pvol"
                 emptyDir: {}
@@ -25,13 +21,6 @@ console:
         annotations:
           delete: "true"
   services:
-    - metadata:
-        name: "[[.ApplicationName]]-[[.Console.Name]]"
-      spec:
-        ports:
-          - name: git-ssh
-            port: 8001
-            targetPort: 8001
     - metadata:
         name: "[[.ApplicationName]]-[[.Console.Name]]-ping"
         annotations:

--- a/config/7.5.0/envs/rhpam-authoring-ha.yaml
+++ b/config/7.5.0/envs/rhpam-authoring-ha.yaml
@@ -25,10 +25,6 @@ console:
                 volumeMounts:
                   - name: "[[.ApplicationName]]-[[.Console.Name]]-pvol"
                     mountPath: "/opt/kie/data"
-                ports:
-                  - name: git-ssh
-                    containerPort: 8001
-                    protocol: TCP
                 env:
                   - name: APPFORMER_INFINISPAN_SERVICE_NAME
                     value: "[[.ApplicationName]]-datagrid"
@@ -46,15 +42,6 @@ console:
               - name: "[[.ApplicationName]]-[[.Console.Name]]-pvol"
                 persistentVolumeClaim:
                   claimName: "[[.ApplicationName]]-[[.Console.Name]]-claim"
-
-  services:
-    - spec:
-        ports:
-          - name: git-ssh
-            port: 8001
-            targetPort: 8001
-      metadata:
-        name: "[[.ApplicationName]]-[[.Console.Name]]"
 
 # ES/AMQ BEGIN
 others:

--- a/config/7.5.0/envs/rhpam-authoring.yaml
+++ b/config/7.5.0/envs/rhpam-authoring.yaml
@@ -9,10 +9,6 @@ console:
           spec:
             containers:
               - name: "[[.ApplicationName]]-[[.Console.Name]]"
-                ports:
-                  - name: git-ssh
-                    containerPort: 8001
-                    protocol: TCP
   persistentVolumeClaims:
     - metadata:
         name: "[[.ApplicationName]]-[[.Console.Name]]-claim"
@@ -23,13 +19,6 @@ console:
           requests:
             storage: 1Gi
   services:
-    - metadata:
-        name: "[[.ApplicationName]]-[[.Console.Name]]"
-      spec:
-        ports:
-          - name: git-ssh
-            port: 8001
-            targetPort: 8001
     - metadata:
         name: "[[.ApplicationName]]-[[.Console.Name]]-ping"
         annotations:

--- a/config/7.5.0/envs/rhpam-trial.yaml
+++ b/config/7.5.0/envs/rhpam-trial.yaml
@@ -12,10 +12,6 @@ console:
                   - name: JGROUPS_PING_PROTOCOL
                   - name: OPENSHIFT_DNS_PING_SERVICE_NAME
                   - name: OPENSHIFT_DNS_PING_SERVICE_PORT
-                ports:
-                  - name: git-ssh
-                    containerPort: 8001
-                    protocol: TCP
             volumes:
               - name: "[[.ApplicationName]]-[[.Console.Name]]-pvol"
                 emptyDir: {}
@@ -25,13 +21,6 @@ console:
         annotations:
           delete: "true"
   services:
-    - metadata:
-        name: "[[.ApplicationName]]-[[.Console.Name]]"
-      spec:
-        ports:
-          - name: git-ssh
-            port: 8001
-            targetPort: 8001
     - metadata:
         name: "[[.ApplicationName]]-[[.Console.Name]]-ping"
         annotations:

--- a/pkg/controller/kieapp/defaults/defaults_test.go
+++ b/pkg/controller/kieapp/defaults/defaults_test.go
@@ -127,8 +127,8 @@ func TestRHPAMTrialEnvironment(t *testing.T) {
 	wbServices := env.Console.Services
 	mainService := getService(wbServices, "test-rhpamcentr")
 	assert.NotNil(t, mainService, "rhpamcentr service not found")
-	assert.Len(t, mainService.Spec.Ports, 3, "The rhpamcentr service should have three ports")
-	assert.True(t, hasPort(mainService, 8001), "The rhpamcentr service should listen on port 8001")
+	assert.Len(t, mainService.Spec.Ports, 2, "The rhpamcentr service should have two ports")
+	assert.False(t, hasPort(mainService, 8001), "The rhpamcentr service should NOT listen on port 8001")
 
 	pingService := getService(wbServices, "test-rhpamcentr-ping")
 	assert.NotNil(t, pingService, "Ping service not found")
@@ -161,8 +161,8 @@ func TestRHDMTrialEnvironment(t *testing.T) {
 	wbServices := env.Console.Services
 	mainService := getService(wbServices, "test-rhdmcentr")
 	assert.NotNil(t, mainService, "rhdmcentr service not found")
-	assert.Len(t, mainService.Spec.Ports, 3, "The rhdmcentr service should have three ports")
-	assert.True(t, hasPort(mainService, 8001), "The rhdmcentr service should listen on port 8001")
+	assert.Len(t, mainService.Spec.Ports, 2, "The rhdmcentr service should have three ports")
+	assert.False(t, hasPort(mainService, 8001), "The rhdmcentr service should NOT listen on port 8001")
 
 	pingService := getService(wbServices, "test-rhdmcentr-ping")
 	assert.False(t, hasPort(pingService, 8888), "The ping service should not listen on port 8888")


### PR DESCRIPTION
See:
https://issues.jboss.org/browse/KIECLOUD-160

```
git clone https://rhpam-authoring-rhpamcentr-kie-operator.apps.rhba-zanini2.openshift-aws.rhocf-dev.com:443/git/MySpace/example-Course_Scheduling
Cloning into 'example-Course_Scheduling'...
Username for 'https://rhpam-authoring-rhpamcentr-kie-operator.apps.rhba-zanini2.openshift-aws.rhocf-dev.com:443': adminUser
Password for 'https://adminUser@rhpam-authoring-rhpamcentr-kie-operator.apps.rhba-zanini2.openshift-aws.rhocf-dev.com:443': 
remote: Counting objects: 69, done
remote: Finding sources: 100% (69/69)
remote: Getting sizes: 100% (65/65)
remote: Compressing objects: 100% (69535/69535)
remote: Total 69 (delta 38), reused 0 (delta 0)
Unpacking objects: 100% (69/69), done.
```

Successfully cloned a project via HTTPS deploying Kie Operator on OCP 4.1

This PR also removes git-ssh ports since we don't need them any more. :)

Signed-off-by: Ricardo Zanini <zanini@redhat.com>