### PR TITLE
[KIECLOUD-285] Enable basic upgrade support

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -424,7 +424,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:4c7b0fbaba9c61f310f3c5b34d7fbafad0b245a0cb94e2da7aed5c97600d84db"
+  digest = "1:9fcb267c272bc5054564b392e3ff7e65e35400fd9914afb1d169f92b95e7dbc9"
   name = "github.com/google/go-cmp"
   packages = [
     "cmp",
@@ -434,8 +434,7 @@
     "cmp/internal/value",
   ]
   pruneopts = ""
-  revision = "6f77996f0c42f7b84e5a2b252227263f93432e9b"
-  version = "v0.3.0"
+  revision = "2d0692c2e9617365a95b295612ac0d4415ba4627"
 
 [[projects]]
   digest = "1:8d4a577a9643f713c25a32151c0f26af7228b4b97a219b5ddb7fd38d16f6e673"
@@ -1448,6 +1447,7 @@
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/api/resource",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",
     "k8s.io/apimachinery/pkg/runtime/serializer",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -79,6 +79,10 @@ required = [
   version = "=v2.2.0"
 
 [[constraint]]
+  name = "github.com/google/go-cmp"
+  revision = "2d0692c2e9617365a95b295612ac0d4415ba4627"
+
+[[constraint]]
   name = "github.com/pavel-v-chernykh/keystore-go"
   version = "=v2.1.0"
 

--- a/deploy/catalog_resources/community/1.2.0/kiecloud-operator.1.2.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/community/1.2.0/kiecloud-operator.1.2.0.clusterserviceversion.yaml
@@ -5,12 +5,12 @@ metadata:
   namespace: placeholder
   annotations:
     categories: "Integration & Delivery"
-    capabilities: "Basic Install"
+    capabilities: "Seamless Upgrades"
     certified: "false"
     description: Kie Cloud Operator for deployment and management of RHPAM/RHDM environments.
     repository: https://github.com/kiegroup/kie-cloud-operator
     containerImage: quay.io/kiegroup/kie-cloud-operator:1.2
-    createdAt: 2019-06-03
+    createdAt: 2019-08-21
     support: Red Hat, Inc.
     tectonic-visibility: ocs
     alm-examples: >-

--- a/deploy/catalog_resources/redhat/1.2.0/businessautomation-operator.1.2.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/redhat/1.2.0/businessautomation-operator.1.2.0.clusterserviceversion.yaml
@@ -5,12 +5,12 @@ metadata:
   namespace: placeholder
   annotations:
     categories: "Integration & Delivery"
-    capabilities: "Basic Install"
+    capabilities: "Seamless Upgrades"
     certified: "true"
     description: Business Automation Operator for deployment and management of RHPAM/RHDM environments.
     repository: https://github.com/kiegroup/kie-cloud-operator    
     containerImage: registry.redhat.io/rhpam-7/rhpam75-operator:1.0
-    createdAt: 2019-06-03
+    createdAt: 2019-08-21
     support: Red Hat, Inc.
     tectonic-visibility: ocs
     alm-examples: >-

--- a/deploy/examples/v2/minor_upgrade.yaml
+++ b/deploy/examples/v2/minor_upgrade.yaml
@@ -5,4 +5,5 @@ metadata:
 spec:
   environment: rhpam-trial
   upgrades:
+    enabled: true
     minor: true

--- a/pkg/apis/app/v2/conversion.go
+++ b/pkg/apis/app/v2/conversion.go
@@ -1,0 +1,143 @@
+package v2
+
+import (
+	"encoding/json"
+	"fmt"
+
+	v1 "github.com/kiegroup/kie-cloud-operator/pkg/apis/app/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// SIG feature details - https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/20190425-crd-conversion-webhook.md
+
+// Actual conversion methods
+
+func convertKieAppV1toV2(kieAppV1 *v1.KieApp) (*KieApp, error) {
+	/*
+		items := strings.Split(kieAppV1.Spec, " ")
+		if len(items) != 5 {
+		   return nil, fmt.Errorf("invalid spec string, needs five parts: %s", kieAppV1.Spec)
+		}
+	*/
+	return &KieApp{
+		ObjectMeta: kieAppV1.ObjectMeta,
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: SchemeGroupVersion.String(),
+			Kind:       kieAppV1.Kind,
+		},
+		Spec: KieAppSpec{
+			Version: kieAppV1.Spec.CommonConfig.Version,
+			Upgrades: KieAppUpgrades{
+				Enabled: *kieAppV1.Spec.Upgrades.Patch,
+				Minor:   kieAppV1.Spec.Upgrades.Minor,
+			},
+		},
+	}, nil
+}
+
+func convertKieAppV2toV1(kieAppV2 *KieApp) (*v1.KieApp, error) {
+	return &v1.KieApp{
+		ObjectMeta: kieAppV2.ObjectMeta,
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: v1.SchemeGroupVersion.String(),
+			Kind:       kieAppV2.Kind,
+		},
+		Spec: v1.KieAppSpec{
+			CommonConfig: v1.CommonConfig{
+				Version: kieAppV2.Spec.Version,
+			},
+			Upgrades: v1.KieAppUpgrades{
+				Patch: &kieAppV2.Spec.Upgrades.Enabled,
+				Minor: kieAppV2.Spec.Upgrades.Minor,
+			},
+		},
+	}, nil
+}
+
+func convert(in runtime.RawExtension, version string) (*runtime.RawExtension, error) {
+	inAPIVersion, err := extractAPIVersion(in)
+	if err != nil {
+		return nil, err
+	}
+	switch inAPIVersion {
+	case v1.SchemeGroupVersion.String():
+		var kieAppV1 v1.KieApp
+		if err := json.Unmarshal(in.Raw, &kieAppV1); err != nil {
+			return nil, err
+		}
+		switch version {
+		case v1.SchemeGroupVersion.String():
+			// This should not happened as API server will not call the webhook in this case
+			return &in, nil
+		case SchemeGroupVersion.String():
+			kieAppV2, err := convertKieAppV1toV2(&kieAppV1)
+			if err != nil {
+				return nil, err
+			}
+			raw, err := json.Marshal(kieAppV2)
+			if err != nil {
+				return nil, err
+			}
+			return &runtime.RawExtension{Raw: raw}, nil
+		}
+	case SchemeGroupVersion.String():
+		var kieAppV2 KieApp
+		if err := json.Unmarshal(in.Raw, &kieAppV2); err != nil {
+			return nil, err
+		}
+		switch version {
+		case SchemeGroupVersion.String():
+			// This should not happened as API server will not call the webhook in this case
+			return &in, nil
+		case v1.SchemeGroupVersion.String():
+			kieAppV1, err := convertKieAppV2toV1(&kieAppV2)
+			if err != nil {
+				return nil, err
+			}
+			raw, err := json.Marshal(kieAppV1)
+			if err != nil {
+				return nil, err
+			}
+			return &runtime.RawExtension{Raw: raw}, nil
+		}
+	default:
+		return nil, fmt.Errorf("invalid conversion fromVersion requested: %s", inAPIVersion)
+	}
+	return nil, fmt.Errorf("invalid conversion toVersion requested: %s", version)
+}
+
+func extractAPIVersion(in runtime.RawExtension) (string, error) {
+	object := unstructured.Unstructured{}
+	if err := object.UnmarshalJSON(in.Raw); err != nil {
+		return "", err
+	}
+	return object.GetAPIVersion(), nil
+}
+
+//  ??? move this code and serve via console pod/service... `pkg/controller/kieapp/deploy_ui.go`
+/*
+func serveKieAppConversion(w http.ResponseWriter, r *http.Request) {
+	request, err := readConversionRequest(r)
+	if err != nil {
+		reportError(w, err)
+	}
+	response := ConversionResponse{}
+	response.UID = request.UID
+	converted, err := convert(request.Object, request.APIVersion)
+	if err != nil {
+		reportError(w, err)
+	}
+	response.ConvertedObject = *converted
+	writeConversionResponse(w, response)
+}
+*/
+
+// ADD TO CRD WHEN READY
+//
+//  conversion:
+//    strategy: Webhook
+//    webhookClientConfig:
+//      url: https://console-cr-form/my-webhook-path
+//

--- a/pkg/apis/app/v2/conversion_test.go
+++ b/pkg/apis/app/v2/conversion_test.go
@@ -1,0 +1,57 @@
+package v2
+
+import (
+	"reflect"
+	"testing"
+
+	v1 "github.com/kiegroup/kie-cloud-operator/pkg/apis/app/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestRoundTripFromV1ToV2(t *testing.T) {
+	patch := true
+	testObj := v1.KieApp{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-new-object",
+		},
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "app.kiegroup.org/v1",
+			Kind:       "KieApp",
+		},
+		Spec: v1.KieAppSpec{
+			CommonConfig: v1.CommonConfig{
+				Version: "7.4.0",
+			},
+			Upgrades: v1.KieAppUpgrades{
+				Patch: &patch,
+			},
+		},
+	}
+	testRoundTripFromV1(t, testObj)
+}
+
+func testRoundTripFromV1(t *testing.T, v1Object v1.KieApp) {
+	v2Object, err := convertKieAppV1toV2(&v1Object)
+	if err != nil {
+		t.Fatalf("failed to convert v1 crontab to v2: %v", err)
+	}
+	assert.Equal(t, v1Object.Spec.CommonConfig.Version, v2Object.Spec.Version)
+	assert.Equal(t, v1Object.Spec.Upgrades.Patch, &v2Object.Spec.Upgrades.Enabled)
+
+	v2Object.Spec.Upgrades.Enabled = false
+	v2Object.Spec.Version = "7.4.1"
+
+	v1Object2, err := convertKieAppV2toV1(v2Object)
+	if err != nil {
+		t.Fatalf("failed to convert v2 crontab to v1: %v", err)
+	}
+	if !reflect.DeepEqual(v1Object2, v1Object2) {
+		t.Errorf("round tripping failed for v1 crontab. v1Object: %v, v2Object: %v, v1ObjectConverted: %v",
+			v1Object, v2Object, v1Object2)
+	}
+	assert.Equal(t, v1Object2.Spec.CommonConfig.Version, v2Object.Spec.Version)
+	assert.Equal(t, *v1Object2.Spec.Upgrades.Patch, v2Object.Spec.Upgrades.Enabled)
+
+	assert.Equal(t, v1Object.APIVersion, v1Object2.APIVersion)
+}

--- a/pkg/controller/kieapp/constants/constants.go
+++ b/pkg/controller/kieapp/constants/constants.go
@@ -9,14 +9,14 @@ import (
 const (
 	// CurrentVersion product version supported
 	CurrentVersion = "7.5.0"
-	// PastMicroVersion product version supported
-	PastMicroVersion = "7.4.1"
-	// PastMinorVersion product version supported
-	PastMinorVersion = "7.4.0"
+	// LastMicroVersion product version supported
+	LastMicroVersion = "7.4.1"
+	// LastMinorVersion product version supported
+	LastMinorVersion = "7.4.0"
 )
 
 // SupportedVersions - product versions this operator supports
-var SupportedVersions = []string{CurrentVersion, PastMicroVersion, PastMinorVersion}
+var SupportedVersions = []string{CurrentVersion, LastMicroVersion, LastMinorVersion}
 
 const (
 	// RhpamPrefix RHPAM prefix
@@ -78,7 +78,7 @@ var VersionConstants = map[string]*api.VersionConfigs{
 		DatagridImage:    "datagrid73-openshift",
 		DatagridImageTag: "1.1",
 	},
-	PastMicroVersion: {
+	LastMicroVersion: {
 		APIVersion:       v1.SchemeGroupVersion.Version,
 		ImageTag:         "1.1",
 		BrokerImage:      "amq-broker-73-openshift",
@@ -86,7 +86,7 @@ var VersionConstants = map[string]*api.VersionConfigs{
 		DatagridImage:    "datagrid73-openshift",
 		DatagridImageTag: "1.1",
 	},
-	PastMinorVersion: {
+	LastMinorVersion: {
 		APIVersion:       v1.SchemeGroupVersion.Version,
 		ImageTag:         "1.0",
 		BrokerImage:      "amq-broker-73-openshift",

--- a/pkg/controller/kieapp/defaults/defaults_test.go
+++ b/pkg/controller/kieapp/defaults/defaults_test.go
@@ -370,7 +370,6 @@ func TestRhdmProdImmutableJMSEnvironment(t *testing.T) {
 	assert.True(t, env.Servers[0].Routes[1].Spec.TLS == nil)
 	testAMQEnvs(t, env.Servers[0].DeploymentConfigs[0].Spec.Template.Spec.Containers[0].Env, env.Servers[0].DeploymentConfigs[1].Spec.Template.Spec.Containers[0].Env)
 	assert.Equal(t, fmt.Sprintf("rhdm%s-decisioncentral-openshift", getMinorImageVersion(cr.Spec.Version)), env.Console.DeploymentConfigs[0].Spec.Template.Spec.Containers[0].Image)
-
 }
 
 func TestRhpamProdImmutableEnvironment(t *testing.T) {
@@ -1844,7 +1843,7 @@ func TestDefaultVersioning(t *testing.T) {
 	assert.Equal(t, "test-rhpamcentrmon", env.Console.DeploymentConfigs[0].ObjectMeta.Name)
 	assert.Equal(t, constants.CurrentVersion, cr.Spec.Version)
 	assert.Equal(t, constants.VersionConstants[constants.CurrentVersion].ImageTag, cr.Spec.CommonConfig.ImageTag)
-	assert.True(t, checkVersion(cr))
+	assert.True(t, checkVersion(cr.Spec.Version))
 	assert.Equal(t, fmt.Sprintf("rhpam%s-businesscentral-monitoring-openshift", getMinorImageVersion(constants.CurrentVersion)), env.Console.DeploymentConfigs[0].Spec.Template.Spec.Containers[0].Image)
 }
 
@@ -1881,13 +1880,13 @@ func TestConfigVersioning(t *testing.T) {
 	}
 	_, err := GetEnvironment(cr, test.MockService())
 	assert.Error(t, err, "Incompatible product versions should throw an error")
-	assert.Equal(t, fmt.Sprintf("Product version %s is not supported in operator version %s. The following versions are supported - %s", cr.Spec.Version, version.Version, constants.SupportedVersions), err.Error())
+	assert.Equal(t, fmt.Sprintf("Product version %s is not allowed in operator version %s. The following versions are allowed - %s", cr.Spec.Version, version.Version, constants.SupportedVersions), err.Error())
 	assert.Equal(t, "6.3.1", cr.Spec.Version)
 	major, minor, micro := MajorMinorMicro(cr.Spec.Version)
 	assert.Equal(t, "6", major)
 	assert.Equal(t, "3", minor)
 	assert.Equal(t, "1", micro)
-	assert.False(t, checkVersion(cr))
+	assert.False(t, checkVersion(cr.Spec.Version))
 }
 
 func TestConfigMapNames(t *testing.T) {

--- a/pkg/controller/kieapp/defaults/upgrade.go
+++ b/pkg/controller/kieapp/defaults/upgrade.go
@@ -1,34 +1,37 @@
 package defaults
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
+	"github.com/gobuffalo/packr/v2"
+	"github.com/google/go-cmp/cmp"
 	api "github.com/kiegroup/kie-cloud-operator/pkg/apis/app/v2"
 	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/constants"
 	"github.com/kiegroup/kie-cloud-operator/version"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // checkProductUpgrade ...
 func checkProductUpgrade(cr *api.KieApp) (minor, micro bool, err error) {
-	if checkVersion(cr) {
+	setDefaults(cr)
+	if checkVersion(cr.Spec.Version) {
 		if cr.Spec.Version != constants.CurrentVersion && cr.Spec.Upgrades.Enabled {
 			micro = cr.Spec.Upgrades.Enabled
 			minor = cr.Spec.Upgrades.Minor
 		}
 	} else {
-		err = fmt.Errorf("Product version %s is not supported in operator version %s. The following versions are supported - %s", cr.Spec.Version, version.Version, constants.SupportedVersions)
+		err = fmt.Errorf("Product version %s is not allowed in operator version %s. The following versions are allowed - %s", cr.Spec.Version, version.Version, constants.SupportedVersions)
 	}
 	return minor, micro, err
 }
 
 // checkVersion ...
-func checkVersion(cr *api.KieApp) bool {
-	if cr.Spec.Version == "74" {
-		cr.Spec.Version = "7.4.1"
-	}
+func checkVersion(productVersion string) bool {
 	for _, version := range constants.SupportedVersions {
-		if version == cr.Spec.Version {
+		if version == productVersion {
 			return true
 		}
 	}
@@ -38,7 +41,7 @@ func checkVersion(cr *api.KieApp) bool {
 // getMinorImageVersion ...
 func getMinorImageVersion(productVersion string) string {
 	major, minor, _ := MajorMinorMicro(productVersion)
-	return fmt.Sprintf("%s%s", major, minor)
+	return strings.Join([]string{major, minor}, "")
 }
 
 // MajorMinorMicro ...
@@ -48,4 +51,74 @@ func MajorMinorMicro(productVersion string) (major, minor, micro string) {
 		version = append(version, "0")
 	}
 	return version[0], version[1], version[2]
+}
+
+// getConfigVersionDiffs ...
+func getConfigVersionDiffs(fromVersion, toVersion string, service api.PlatformService) error {
+	if checkVersion(fromVersion) && checkVersion(toVersion) {
+		fromList, toList := getConfigVersionLists(fromVersion, toVersion)
+		diffs := configDiffs(fromList, toList)
+		cmDiffs := diffs
+		// only check against existing configmaps if running via deployment in a cluster
+		if _, depNameSpace, useEmbedded := UseEmbeddedFiles(service); !useEmbedded {
+			cmFromList := map[string][]map[string]string{}
+			for name := range fromList {
+				nameSplit := strings.Split(name, "-")
+				cmName := strings.Join(append([]string{nameSplit[0], fromVersion}, nameSplit[1:]...), "-")
+				// *** need to retrieve cm of same name w/ current version and do compare against default upgrade diffs...
+				currentCM := &corev1.ConfigMap{}
+				if err := service.Get(context.TODO(), types.NamespacedName{Name: cmName, Namespace: depNameSpace}, currentCM); err != nil {
+					return err
+				}
+				cmFromList[name] = append(cmFromList[name], currentCM.Data)
+			}
+			cmDiffs = configDiffs(cmFromList, toList)
+		} else if service.IsMockService() { // test
+			fromList[constants.ConfigMapPrefix] = []map[string]string{{"common.yaml": "changed"}}
+			cmDiffs = configDiffs(fromList, toList)
+		}
+		// if conflicts, stop upgrade
+		// COMPARE NEEDS IMPROVEMENT - more precise comparison? and should maybe show exact differences that conflict.
+		if !cmp.Equal(diffs, cmDiffs) {
+			return fmt.Errorf("Can't upgrade, potential configuration conflicts in your %s ConfigMap(s)", fromVersion)
+		}
+	}
+	return nil
+}
+
+// getConfigVersionLists ...
+func getConfigVersionLists(fromVersion, toVersion string) (configFromList, configToList map[string][]map[string]string) {
+	fromList := map[string][]map[string]string{}
+	toList := map[string][]map[string]string{}
+	if checkVersion(fromVersion) && checkVersion(toVersion) {
+		box := packr.New("config", "../../../../config")
+		if box.HasDir(fromVersion) && box.HasDir(toVersion) {
+			cmList := getCMListfromBox(box)
+			for cmName, cmData := range cmList {
+				cmSplit := strings.Split(cmName, "-")
+				name := strings.Join(append(cmSplit[:1], cmSplit[2:]...), "-")
+				if cmSplit[1] == fromVersion {
+					fromList[name] = cmData
+				}
+				if cmSplit[1] == toVersion {
+					toList[name] = cmData
+				}
+			}
+		}
+	}
+	return fromList, toList
+}
+
+// configDiffs ...
+func configDiffs(cmFromList, cmToList map[string][]map[string]string) map[string]string {
+	configDiffs := map[string]string{}
+	for cmName, fromMapSlice := range cmFromList {
+		if toMapSlice, ok := cmToList[cmName]; ok {
+			diff := cmp.Diff(fromMapSlice, toMapSlice)
+			if diff != "" {
+				configDiffs[cmName] = diff
+			}
+		}
+	}
+	return configDiffs
 }

--- a/vendor/github.com/google/go-cmp/cmp/cmpopts/util_test.go
+++ b/vendor/github.com/google/go-cmp/cmp/cmpopts/util_test.go
@@ -806,7 +806,7 @@ func TestOptions(t *testing.T) {
 		x:     []string{"foo", "Bar", "BAZ"},
 		y:     []string{"Foo", "BAR", "baz"},
 		opts: []cmp.Option{
-			AcyclicTransformer("", func(s string) string { return strings.ToUpper(s) }),
+			AcyclicTransformer("", strings.ToUpper),
 		},
 		wantEqual: true,
 		reason:    "equal because of strings.ToUpper; AcyclicTransformer unnecessary, but check this still works",
@@ -815,7 +815,7 @@ func TestOptions(t *testing.T) {
 		x:     "this is a sentence",
 		y: "this   			is a 			sentence",
 		opts: []cmp.Option{
-			AcyclicTransformer("", func(s string) []string { return strings.Fields(s) }),
+			AcyclicTransformer("", strings.Fields),
 		},
 		wantEqual: true,
 		reason:    "equal because acyclic transformer splits on any contiguous whitespace",

--- a/vendor/github.com/google/go-cmp/cmp/compare_test.go
+++ b/vendor/github.com/google/go-cmp/cmp/compare_test.go
@@ -518,7 +518,7 @@ func comparerTests() []test {
 		y:     map[*pb.Stringer]*pb.Stringer(nil),
 		wantDiff: `
   map[*testprotos.Stringer]*testprotos.Stringer(
-- 	{⟪0xdeadf00f⟫: s"world"},
+- 	{s"hello": s"world"},
 + 	nil,
   )
 `,

--- a/vendor/github.com/google/go-cmp/cmp/internal/value/sort.go
+++ b/vendor/github.com/google/go-cmp/cmp/internal/value/sort.go
@@ -19,7 +19,7 @@ func SortKeys(vs []reflect.Value) []reflect.Value {
 	}
 
 	// Sort the map keys.
-	sort.Slice(vs, func(i, j int) bool { return isLess(vs[i], vs[j]) })
+	sort.SliceStable(vs, func(i, j int) bool { return isLess(vs[i], vs[j]) })
 
 	// Deduplicate keys (fails for NaNs).
 	vs2 := vs[:1]
@@ -42,6 +42,8 @@ func isLess(x, y reflect.Value) bool {
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 		return x.Uint() < y.Uint()
 	case reflect.Float32, reflect.Float64:
+		// NOTE: This does not sort -0 as less than +0
+		// since Go maps treat -0 and +0 as equal keys.
 		fx, fy := x.Float(), y.Float()
 		return fx < fy || math.IsNaN(fx) && !math.IsNaN(fy)
 	case reflect.Complex64, reflect.Complex128:

--- a/vendor/github.com/google/go-cmp/cmp/internal/value/zero.go
+++ b/vendor/github.com/google/go-cmp/cmp/internal/value/zero.go
@@ -4,7 +4,10 @@
 
 package value
 
-import "reflect"
+import (
+	"math"
+	"reflect"
+)
 
 // IsZero reports whether v is the zero value.
 // This does not rely on Interface and so can be used on unexported fields.
@@ -17,9 +20,9 @@ func IsZero(v reflect.Value) bool {
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
 		return v.Uint() == 0
 	case reflect.Float32, reflect.Float64:
-		return v.Float() == 0
+		return math.Float64bits(v.Float()) == 0
 	case reflect.Complex64, reflect.Complex128:
-		return v.Complex() == 0
+		return math.Float64bits(real(v.Complex())) == 0 && math.Float64bits(imag(v.Complex())) == 0
 	case reflect.String:
 		return v.String() == ""
 	case reflect.UnsafePointer:

--- a/vendor/github.com/google/go-cmp/cmp/internal/value/zero_test.go
+++ b/vendor/github.com/google/go-cmp/cmp/internal/value/zero_test.go
@@ -6,6 +6,7 @@ package value
 
 import (
 	"archive/tar"
+	"math"
 	"reflect"
 	"testing"
 )
@@ -32,6 +33,12 @@ func TestIsZero(t *testing.T) {
 		{TestIsZero, false},
 		{[...]int{0, 0, 0}, true},
 		{[...]int{0, 1, 0}, false},
+		{math.Copysign(0, +1), true},
+		{math.Copysign(0, -1), false},
+		{complex(math.Copysign(0, +1), math.Copysign(0, +1)), true},
+		{complex(math.Copysign(0, -1), math.Copysign(0, +1)), false},
+		{complex(math.Copysign(0, +1), math.Copysign(0, -1)), false},
+		{complex(math.Copysign(0, -1), math.Copysign(0, -1)), false},
 	}
 
 	for _, tt := range tests {

--- a/vendor/github.com/google/go-cmp/cmp/report_compare.go
+++ b/vendor/github.com/google/go-cmp/cmp/report_compare.go
@@ -168,7 +168,7 @@ func (opts formatOptions) formatDiffList(recs []reportRecord, k reflect.Kind) te
 				var isZero bool
 				switch opts.DiffMode {
 				case diffIdentical:
-					isZero = value.IsZero(r.Value.ValueX) || value.IsZero(r.Value.ValueX)
+					isZero = value.IsZero(r.Value.ValueX) || value.IsZero(r.Value.ValueY)
 				case diffRemoved:
 					isZero = value.IsZero(r.Value.ValueX)
 				case diffInserted:

--- a/vendor/github.com/google/go-cmp/cmp/report_reflect.go
+++ b/vendor/github.com/google/go-cmp/cmp/report_reflect.go
@@ -208,7 +208,6 @@ func (opts formatOptions) FormatValue(v reflect.Value, m visitedPointers) (out t
 func formatMapKey(v reflect.Value) string {
 	var opts formatOptions
 	opts.TypeMode = elideType
-	opts.AvoidStringer = true
 	opts.ShallowPointers = true
 	s := opts.FormatValue(v, visitedPointers{}).String()
 	return strings.TrimSpace(s)

--- a/vendor/github.com/google/go-cmp/cmp/report_slices.go
+++ b/vendor/github.com/google/go-cmp/cmp/report_slices.go
@@ -90,7 +90,7 @@ func (opts formatOptions) FormatDiffSlice(v *valueNode) textNode {
 			}
 			if r == '\n' {
 				if maxLineLen < i-lastLineIdx {
-					lastLineIdx = i - lastLineIdx
+					maxLineLen = i - lastLineIdx
 				}
 				lastLineIdx = i + 1
 				numLines++
@@ -322,7 +322,7 @@ func coalesceInterveningIdentical(groups []diffStats, windowSize int) []diffStat
 			hadX, hadY := prev.NumRemoved > 0, prev.NumInserted > 0
 			hasX, hasY := next.NumRemoved > 0, next.NumInserted > 0
 			if ((hadX || hasX) && (hadY || hasY)) && curr.NumIdentical <= windowSize {
-				*prev = (*prev).Append(*curr).Append(*next)
+				*prev = prev.Append(*curr).Append(*next)
 				groups = groups[:len(groups)-1] // Truncate off equal group
 				continue
 			}

--- a/vendor/github.com/google/go-cmp/cmp/report_text.go
+++ b/vendor/github.com/google/go-cmp/cmp/report_text.go
@@ -19,6 +19,11 @@ var randBool = rand.New(rand.NewSource(time.Now().Unix())).Intn(2) == 0
 type indentMode int
 
 func (n indentMode) appendIndent(b []byte, d diffMode) []byte {
+	// The output of Diff is documented as being unstable to provide future
+	// flexibility in changing the output for more humanly readable reports.
+	// This logic intentionally introduces instability to the exact output
+	// so that users can detect accidental reliance on stability early on,
+	// rather than much later when an actual change to the format occurs.
 	if flags.Deterministic || randBool {
 		// Use regular spaces (U+0020).
 		switch d {
@@ -360,7 +365,7 @@ func (s diffStats) String() string {
 	// Pluralize the name (adjusting for some obscure English grammar rules).
 	name := s.Name
 	if sum > 1 {
-		name = name + "s"
+		name += "s"
 		if strings.HasSuffix(name, "ys") {
 			name = name[:len(name)-2] + "ies" // e.g., "entrys" => "entries"
 		}


### PR DESCRIPTION
also addresses -
https://issues.jboss.org/browse/KIECLOUD-287
https://issues.jboss.org/browse/KIECLOUD-288

Added initial CRD api conversion code. Can't fully enable until `CustomResourceWebhookConversion` feature is out of OpenShift Tech Preview.

Signed-off-by: tchughesiv <tchughesiv@gmail.com>