### PR TITLE
Full reconcile of resources using shared library

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -59,14 +59,17 @@
   revision = "4dc698c325ee5db4067a01c030d9a473fe1d581f"
 
 [[projects]]
-  digest = "1:4940a6707379ce619f7521dccca2f6c36005b4035cad7403a53ba0ba95a09788"
+  digest = "1:ea0284a0739e4227e5ef0007e4fa94592ebe6a4e710072c943a71a3c4ef02243"
   name = "github.com/RHsyseng/operator-utils"
   packages = [
     "pkg/olm",
+    "pkg/resource",
+    "pkg/resource/compare",
+    "pkg/resource/write",
     "pkg/validation",
   ]
   pruneopts = ""
-  revision = "7b1462f3cd3456e08e0966df5df8fa784f117145"
+  revision = "292d20af5d942f8e20dccaf41556af936d0417e5"
 
 [[projects]]
   branch = "master"
@@ -1413,6 +1416,9 @@
   input-imports = [
     "github.com/RHsyseng/console-cr-form/pkg/web",
     "github.com/RHsyseng/operator-utils/pkg/olm",
+    "github.com/RHsyseng/operator-utils/pkg/resource",
+    "github.com/RHsyseng/operator-utils/pkg/resource/compare",
+    "github.com/RHsyseng/operator-utils/pkg/resource/write",
     "github.com/RHsyseng/operator-utils/pkg/validation",
     "github.com/ghodss/yaml",
     "github.com/go-logr/logr",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -59,17 +59,18 @@
   revision = "4dc698c325ee5db4067a01c030d9a473fe1d581f"
 
 [[projects]]
-  digest = "1:eac3869bf5aecaa80599de546e1f2678a0b56bb140a43fbd87b48bba36fb7114"
+  digest = "1:1f9dbdfc3cd87c8895d3d9412a17603e600f6846d3a70cea6393c4b3ddd8a189"
   name = "github.com/RHsyseng/operator-utils"
   packages = [
     "pkg/olm",
     "pkg/resource",
     "pkg/resource/compare",
     "pkg/resource/write",
+    "pkg/resource/write/hooks",
     "pkg/validation",
   ]
   pruneopts = ""
-  revision = "a345ca9aa8d5f37720bcdda588dc6054f04bad23"
+  revision = "4df1e0b603d2efc9673c3fd532a379148d092fd9"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -59,7 +59,7 @@
   revision = "4dc698c325ee5db4067a01c030d9a473fe1d581f"
 
 [[projects]]
-  digest = "1:ea0284a0739e4227e5ef0007e4fa94592ebe6a4e710072c943a71a3c4ef02243"
+  digest = "1:33e52f3b3d2e7ffff7d9de5efd36cadaa4e8b3543e04666f6cd0e06f725ae51a"
   name = "github.com/RHsyseng/operator-utils"
   packages = [
     "pkg/olm",
@@ -69,7 +69,7 @@
     "pkg/validation",
   ]
   pruneopts = ""
-  revision = "292d20af5d942f8e20dccaf41556af936d0417e5"
+  revision = "67fa4a34c55608d6bf84968af03fb949e220c15c"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -59,7 +59,7 @@
   revision = "4dc698c325ee5db4067a01c030d9a473fe1d581f"
 
 [[projects]]
-  digest = "1:33e52f3b3d2e7ffff7d9de5efd36cadaa4e8b3543e04666f6cd0e06f725ae51a"
+  digest = "1:eac3869bf5aecaa80599de546e1f2678a0b56bb140a43fbd87b48bba36fb7114"
   name = "github.com/RHsyseng/operator-utils"
   packages = [
     "pkg/olm",
@@ -69,7 +69,7 @@
     "pkg/validation",
   ]
   pruneopts = ""
-  revision = "67fa4a34c55608d6bf84968af03fb949e220c15c"
+  revision = "a345ca9aa8d5f37720bcdda588dc6054f04bad23"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -61,7 +61,7 @@ required = [
 [[constraint]]
   name = "github.com/RHsyseng/operator-utils"
   # revision for branch "master"
-  revision = "a345ca9aa8d5f37720bcdda588dc6054f04bad23"
+  revision = "4df1e0b603d2efc9673c3fd532a379148d092fd9"
 
 [[constraint]]
   name = "github.com/RHsyseng/console-cr-form"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -61,7 +61,7 @@ required = [
 [[constraint]]
   name = "github.com/RHsyseng/operator-utils"
   # revision for branch "master"
-  revision = "292d20af5d942f8e20dccaf41556af936d0417e5"
+  revision = "67fa4a34c55608d6bf84968af03fb949e220c15c"
 
 [[constraint]]
   name = "github.com/RHsyseng/console-cr-form"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -61,7 +61,7 @@ required = [
 [[constraint]]
   name = "github.com/RHsyseng/operator-utils"
   # revision for branch "master"
-  revision = "7b1462f3cd3456e08e0966df5df8fa784f117145"
+  revision = "292d20af5d942f8e20dccaf41556af936d0417e5"
 
 [[constraint]]
   name = "github.com/RHsyseng/console-cr-form"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -61,7 +61,7 @@ required = [
 [[constraint]]
   name = "github.com/RHsyseng/operator-utils"
   # revision for branch "master"
-  revision = "67fa4a34c55608d6bf84968af03fb949e220c15c"
+  revision = "a345ca9aa8d5f37720bcdda588dc6054f04bad23"
 
 [[constraint]]
   name = "github.com/RHsyseng/console-cr-form"

--- a/pkg/apis/app/v1/kieapp_types.go
+++ b/pkg/apis/app/v1/kieapp_types.go
@@ -488,6 +488,7 @@ type KieAppStatus struct {
 
 type PlatformService interface {
 	Create(ctx context.Context, obj runtime.Object) error
+	Delete(ctx context.Context, obj runtime.Object, opts ...client.DeleteOptionFunc) error
 	Get(ctx context.Context, key client.ObjectKey, obj runtime.Object) error
 	List(ctx context.Context, opts *client.ListOptions, list runtime.Object) error
 	Update(ctx context.Context, obj runtime.Object) error

--- a/pkg/apis/app/v2/kieapp_types.go
+++ b/pkg/apis/app/v2/kieapp_types.go
@@ -502,6 +502,7 @@ type KieAppStatus struct {
 // PlatformService ...
 type PlatformService interface {
 	Create(ctx context.Context, obj runtime.Object) error
+	Delete(ctx context.Context, obj runtime.Object, opts ...client.DeleteOptionFunc) error
 	Get(ctx context.Context, key client.ObjectKey, obj runtime.Object) error
 	List(ctx context.Context, opts *client.ListOptions, list runtime.Object) error
 	Update(ctx context.Context, obj runtime.Object) error

--- a/pkg/controller/kieapp/deploy_ui.go
+++ b/pkg/controller/kieapp/deploy_ui.go
@@ -44,7 +44,6 @@ func deployConsole(reconciler *Reconciler, operator *appsv1.Deployment) {
 	namespace := os.Getenv(constants.NameSpaceEnv)
 	operatorName = os.Getenv(constants.OpNameEnv)
 	role := getRole(namespace)
-	role.SetOwnerReferences()
 	roleBinding := getRoleBinding(namespace)
 	sa := getServiceAccount(namespace)
 	image := getImage(operator)

--- a/pkg/controller/kieapp/deploy_ui.go
+++ b/pkg/controller/kieapp/deploy_ui.go
@@ -123,6 +123,10 @@ func updateCSVlinks(reconciler *Reconciler, route *routev1.Route, operator *apps
 	}
 	url := fmt.Sprintf("https://%s", found.Spec.Host)
 	csv := reconciler.getCSV(operator)
+	if reflect.DeepEqual(csv, &operatorsv1alpha1.ClusterServiceVersion{}) {
+		log.Info("No ClusterServiceVersion found, likely because no such owner was set on the operator. This might be because the operator was not installed through OLM")
+		return
+	}
 	link := getConsoleLink(csv)
 	if link == nil || link.URL != url {
 		update = true

--- a/pkg/controller/kieapp/deploy_ui.go
+++ b/pkg/controller/kieapp/deploy_ui.go
@@ -4,7 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/RHsyseng/operator-utils/pkg/resource"
+	"github.com/RHsyseng/operator-utils/pkg/resource/compare"
+	"github.com/RHsyseng/operator-utils/pkg/resource/write"
 	"os"
+	"reflect"
 	"strings"
 	"time"
 
@@ -36,87 +40,71 @@ func shouldDeployConsole() bool {
 }
 
 func deployConsole(reconciler *Reconciler, operator *appsv1.Deployment) {
-	log.Debugf("Will deploy operator-ui")
+	log.Debugf("Checking operator-ui deployment")
 	namespace := os.Getenv(constants.NameSpaceEnv)
 	operatorName = os.Getenv(constants.OpNameEnv)
 	role := getRole(namespace)
-	role.SetOwnerReferences(operator.GetOwnerReferences())
-	err := reconciler.Service.Create(context.TODO(), role)
-	if err != nil {
-		if errors.IsAlreadyExists(err) {
-			log.Debug("Could not create role as it already exists", role)
-		} else {
-			log.Error("Failed to create role. ", err)
-			return
-		}
-	}
+	role.SetOwnerReferences()
 	roleBinding := getRoleBinding(namespace)
-	roleBinding.SetOwnerReferences(operator.GetOwnerReferences())
-	err = reconciler.Service.Create(context.TODO(), roleBinding)
-	if err != nil {
-		if errors.IsAlreadyExists(err) {
-			log.Debug("Could not create roleBinding as it already exists", roleBinding)
-		} else {
-			log.Error("Failed to create roleBinding. ", err)
-			return
-		}
-	}
 	sa := getServiceAccount(namespace)
-	sa.SetOwnerReferences(operator.GetOwnerReferences())
-	err = reconciler.Service.Create(context.TODO(), sa)
-	if err != nil {
-		if errors.IsAlreadyExists(err) {
-			log.Debug("Could not create serviceaccount as it already exists", sa)
-		} else {
-			log.Error("Failed to create serviceaccount. ", err)
-			return
-		}
-	}
 	image := getImage(operator)
 	pod := getPod(namespace, image, sa.Name, operator)
-	pod.SetOwnerReferences(operator.GetOwnerReferences())
-	err = reconciler.Service.Create(context.TODO(), pod)
-	if err != nil {
-		if errors.IsAlreadyExists(err) {
-			// Update console pod image
-			podExisting := &corev1.Pod{}
-			if err = reconciler.Service.Get(context.TODO(), types.NamespacedName{Namespace: pod.Namespace, Name: pod.Name}, podExisting); err == nil {
-				if podExisting.Spec.Containers[1].Image != pod.Spec.Containers[1].Image {
-					podExisting.Spec.Containers[1].Image = pod.Spec.Containers[1].Image
-					if err = reconciler.Service.Update(context.TODO(), podExisting); err != nil {
-						log.Error("Could not update console pod image ", pod.Spec.Containers[1].Image)
-					}
-				}
-			}
-			log.Debug("Could not create pod as it already exists", pod)
-		} else {
-			log.Error("Failed to create pod. ", err)
-			return
-		}
-	}
 	service := getService(namespace)
-	service.SetOwnerReferences(operator.GetOwnerReferences())
-	err = reconciler.Service.Create(context.TODO(), service)
-	if err != nil {
-		if errors.IsAlreadyExists(err) {
-			log.Debug("Could not create service as it already exists", service)
-		} else {
-			log.Error("Failed to create service. ", err)
-			return
-		}
-	}
 	route := getRoute(namespace)
-	route.SetOwnerReferences(operator.GetOwnerReferences())
-	err = reconciler.Service.Create(context.TODO(), route)
+	requested := compare.NewMapBuilder().Add(role, roleBinding, sa, pod, service, route).ResourceMap()
+	deployed, err := loadCounterparts(reconciler, requested)
 	if err != nil {
-		if errors.IsAlreadyExists(err) {
-			log.Debug("Could not create route as it already exists", route)
-		} else {
-			log.Error("Failed to create route. ", err)
+		log.Error("Failed to load deployed resources.", err)
+		return
+	}
+	comparator := compare.NewMapComparator()
+	deltas := comparator.Compare(deployed, requested)
+	var hasUpdates bool
+	for resourceType, delta := range deltas {
+		if !delta.HasChanges() {
+			continue
+		}
+		log.Debugf("Will create %d, update %d, and delete %d instances of %v", len(delta.Added), len(delta.Updated), len(delta.Removed), resourceType)
+		added, err := write.AddResources(operator, reconciler.Service.GetScheme(), reconciler.Service, delta.Added)
+		if err != nil {
+			log.Warnf("Got error applying changes %v", err)
 			return
 		}
+		updated, err := write.UpdateResources(operator, deployed[resourceType], reconciler.Service.GetScheme(), reconciler.Service, delta.Updated)
+		if err != nil {
+			log.Warnf("Got error applying changes %v", err)
+			return
+		}
+		removed, err := write.RemoveResources(reconciler.Service, delta.Removed)
+		if err != nil {
+			log.Warnf("Got error applying changes %v", err)
+			return
+		}
+		hasUpdates = hasUpdates || added || updated || removed
 	}
 	updateCSVlinks(reconciler, route, operator)
+}
+
+func loadCounterparts(reconciler *Reconciler, requestedMap map[reflect.Type][]resource.KubernetesResource) (map[reflect.Type][]resource.KubernetesResource, error) {
+	deployedMap := make(map[reflect.Type][]resource.KubernetesResource)
+	for resourceType, requestedArray := range requestedMap {
+		var deployedArray []resource.KubernetesResource
+		for _, requested := range requestedArray {
+			deployed := reflect.New(resourceType).Interface().(resource.KubernetesResource)
+			err := reconciler.Service.Get(context.TODO(), types.NamespacedName{Name: requested.GetName(), Namespace: requested.GetNamespace()}, deployed)
+			if err == nil {
+				deployedArray = append(deployedArray, deployed)
+			} else {
+				if errors.IsNotFound(err) {
+					//Not found, just don't add it to array
+				} else {
+					return nil, err
+				}
+			}
+		}
+		deployedMap[resourceType] = deployedArray
+	}
+	return deployedMap, nil
 }
 
 func updateCSVlinks(reconciler *Reconciler, route *routev1.Route, operator *appsv1.Deployment) {
@@ -254,7 +242,6 @@ func getPod(namespace string, image string, sa string, operator *appsv1.Deployme
 
 func getImage(operator *appsv1.Deployment) string {
 	image := operator.Spec.Template.Spec.Containers[0].Image
-	log.Debugf("Own image retrieved as %v", image)
 	return image
 }
 

--- a/pkg/controller/kieapp/kieapp_controller.go
+++ b/pkg/controller/kieapp/kieapp_controller.go
@@ -90,11 +90,13 @@ func (reconciler *Reconciler) Reconcile(request reconcile.Request) (reconcile.Re
 	if err != nil {
 		return reconcile.Result{}, err
 	}
+
+	writer := write.New().WithOwnerController(instance)
 	//If not all created, then create the missing ones:
 	if len(deployedRoutes) < len(requestedRoutes) {
 		missingRoutes := getMissingRoutes(requestedRoutes, deployedRoutes)
 		log.Debugf("Will create %d routes that were not found", len(missingRoutes))
-		added, err := write.AddResources(instance, reconciler.Service.GetScheme(), reconciler.Service, missingRoutes)
+		added, err := writer.AddResources(reconciler.Service.GetScheme(), reconciler.Service, missingRoutes)
 		if err != nil {
 			return reconcile.Result{}, err
 		} else if added {
@@ -131,15 +133,15 @@ func (reconciler *Reconciler) Reconcile(request reconcile.Request) (reconcile.Re
 			continue
 		}
 		log.Debugf("Will create %d, update %d, and delete %d instances of %v", len(delta.Added), len(delta.Updated), len(delta.Removed), resourceType)
-		added, err := write.AddResources(instance, reconciler.Service.GetScheme(), reconciler.Service, delta.Added)
+		added, err := writer.AddResources(reconciler.Service.GetScheme(), reconciler.Service, delta.Added)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
-		updated, err := write.UpdateResources(instance, deployed[resourceType], reconciler.Service.GetScheme(), reconciler.Service, delta.Updated)
+		updated, err := writer.UpdateResources(deployed[resourceType], reconciler.Service.GetScheme(), reconciler.Service, delta.Updated)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
-		removed, err := write.RemoveResources(reconciler.Service, delta.Removed)
+		removed, err := writer.RemoveResources(reconciler.Service, delta.Removed)
 		if err != nil {
 			return reconcile.Result{}, err
 		}

--- a/pkg/controller/kieapp/kieapp_controller.go
+++ b/pkg/controller/kieapp/kieapp_controller.go
@@ -3,12 +3,15 @@ package kieapp
 import (
 	"context"
 	"fmt"
+	"github.com/RHsyseng/operator-utils/pkg/olm"
+	"github.com/RHsyseng/operator-utils/pkg/resource"
+	"github.com/RHsyseng/operator-utils/pkg/resource/compare"
+	"github.com/RHsyseng/operator-utils/pkg/resource/write"
 	"reflect"
 	"regexp"
 	"strings"
 	"time"
 
-	"github.com/RHsyseng/operator-utils/pkg/olm"
 	api "github.com/kiegroup/kie-cloud-operator/pkg/apis/app/v2"
 	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/constants"
 	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/defaults"
@@ -25,10 +28,8 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -75,24 +76,76 @@ func (reconciler *Reconciler) Reconcile(request reconcile.Request) (reconcile.Re
 		return reconcile.Result{}, err
 	}
 
-	env, rResult, err := reconciler.newEnv(instance)
+	//Obtain in-memory representation of basic environment being requested:
+	env, err := defaults.GetEnvironment(instance, reconciler.Service)
 	if err != nil {
 		reconciler.setFailedStatus(instance, api.ConfigurationErrorReason, err)
-		return rResult, err
+		return reconcile.Result{}, err
 	}
 
-	dcUpdated, err := reconciler.updateDeploymentConfigs(instance, env)
+	//Get requested routes based on environment template:
+	requestedRoutes := getRequestedRoutes(env, instance)
+	//Then check if all these routes are already created:
+	deployedRoutes, err := reconciler.loadRoutes(requestedRoutes)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
-	if dcUpdated && status.SetProvisioning(instance) {
-		return reconciler.UpdateObj(instance)
+	//If not all created, then create the missing ones:
+	if len(deployedRoutes) < len(requestedRoutes) {
+		missingRoutes := getMissingRoutes(requestedRoutes, deployedRoutes)
+		log.Debugf("Will create %d routes that were not found", len(missingRoutes))
+		added, err := write.AddResources(instance, reconciler.Service.GetScheme(), reconciler.Service, missingRoutes)
+		if err != nil {
+			return reconcile.Result{}, err
+		} else if added {
+			//Requeue after a little while to load route and its hostname
+			return reconcile.Result{Requeue: true, RequeueAfter: time.Duration(200) * time.Millisecond}, err
+		}
 	}
-	bcUpdated, err := reconciler.updateBuildConfigs(instance, env)
+
+	//With route hostnames now available, set remaining environment configuration:
+	env = reconciler.setEnvironmentProperties(instance, env, deployedRoutes)
+
+	//Create a list of objects that should be deployed
+	requestedResources := reconciler.getKubernetesResources(instance, env)
+	for index := range requestedResources {
+		requestedResources[index].SetNamespace(instance.Namespace)
+	}
+
+	//Obtain a list of objects that are actually deployed
+	deployed, err := reconciler.getDeployedResources(instance)
 	if err != nil {
+		reconciler.setFailedStatus(instance, api.UnknownReason, err)
 		return reconcile.Result{}, err
 	}
-	if bcUpdated && status.SetProvisioning(instance) {
+	setDeploymentStatus(instance, deployed[reflect.TypeOf(oappsv1.DeploymentConfig{})])
+
+	//Compare what's deployed with what should be deployed
+	requested := compare.NewMapBuilder().Add(requestedResources...).ResourceMap()
+	comparator := compare.NewMapComparator()
+	ignoreSecretDataValues(&comparator)
+	deltas := comparator.Compare(deployed, requested)
+	var hasUpdates bool
+	for resourceType, delta := range deltas {
+		if !delta.HasChanges() {
+			continue
+		}
+		log.Debugf("Will create %d, update %d, and delete %d instances of %v", len(delta.Added), len(delta.Updated), len(delta.Removed), resourceType)
+		added, err := write.AddResources(instance, reconciler.Service.GetScheme(), reconciler.Service, delta.Added)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		updated, err := write.UpdateResources(instance, deployed[resourceType], reconciler.Service.GetScheme(), reconciler.Service, delta.Updated)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		removed, err := write.RemoveResources(reconciler.Service, delta.Removed)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		hasUpdates = hasUpdates || added || updated || removed
+	}
+	if hasUpdates && status.SetProvisioning(instance) {
 		return reconciler.UpdateObj(instance)
 	}
 
@@ -137,100 +190,55 @@ func (reconciler *Reconciler) Reconcile(request reconcile.Request) (reconcile.Re
 	return reconcile.Result{}, nil
 }
 
-func (reconciler *Reconciler) updateDeploymentConfigs(instance *api.KieApp, env api.Environment) (bool, error) {
-	log := log.With("kind", instance.Kind, "name", instance.Name, "namespace", instance.Namespace)
-	listOps := &client.ListOptions{Namespace: instance.Namespace}
-	dcList := &oappsv1.DeploymentConfigList{}
-	err := reconciler.Service.List(context.TODO(), listOps, dcList)
-	if err != nil {
-		log.Warn("Failed to list dc's. ", err)
-		reconciler.setFailedStatus(instance, api.UnknownReason, err)
-		return false, err
-	}
+func setDeploymentStatus(instance *api.KieApp, resources []resource.KubernetesResource) {
 	var dcs []oappsv1.DeploymentConfig
-	for _, dc := range dcList.Items {
-		for _, ownerRef := range dc.GetOwnerReferences() {
-			if ownerRef.UID == instance.UID {
-				dcs = append(dcs, dc)
-				break
-			}
-		}
+	for index := range resources {
+		dc := resources[index].(*oappsv1.DeploymentConfig)
+		dcs = append(dcs, *dc)
 	}
 	instance.Status.Deployments = olm.GetDeploymentConfigStatus(dcs)
-
-	var dcUpdates []oappsv1.DeploymentConfig
-	for _, dc := range dcs {
-		for _, cDc := range env.Console.DeploymentConfigs {
-			if dc.Name == cDc.Name {
-				dcUpdates = reconciler.dcUpdateCheck(dc, cDc, dcUpdates, instance)
-			}
-		}
-		for _, server := range env.Servers {
-			for _, sDc := range server.DeploymentConfigs {
-				if dc.Name == sDc.Name {
-					dcUpdates = reconciler.dcUpdateCheck(dc, sDc, dcUpdates, instance)
-				}
-			}
-		}
-		for _, srDc := range env.SmartRouter.DeploymentConfigs {
-			if dc.Name == srDc.Name {
-				dcUpdates = reconciler.dcUpdateCheck(dc, srDc, dcUpdates, instance)
-			}
-		}
-		for _, other := range env.Others {
-			for _, oDc := range other.DeploymentConfigs {
-				if dc.Name == oDc.Name {
-					dcUpdates = reconciler.dcUpdateCheck(dc, oDc, dcUpdates, instance)
-				}
-			}
-		}
-	}
-	log.Debugf("There are %d updated DCs", len(dcUpdates))
-	if len(dcUpdates) > 0 {
-		for _, uDc := range dcUpdates {
-			_, err := reconciler.UpdateObj(&uDc)
-			if err != nil {
-				reconciler.setFailedStatus(instance, api.DeploymentFailedReason, err)
-				return false, err
-			}
-		}
-		return true, nil
-	}
-	return false, nil
 }
 
-func (reconciler *Reconciler) updateBuildConfigs(instance *api.KieApp, env api.Environment) (bool, error) {
-	log := log.With("kind", instance.Kind, "name", instance.Name, "namespace", instance.Namespace)
-	listOps := &client.ListOptions{Namespace: instance.Namespace}
-	bcList := &buildv1.BuildConfigList{}
-	err := reconciler.Service.List(context.TODO(), listOps, bcList)
-	if err != nil {
-		log.Warn("Failed to list bc's. ", err)
-		reconciler.setFailedStatus(instance, api.UnknownReason, err)
-		return false, err
+func getRequestedRoutes(env api.Environment, instance *api.KieApp) []resource.KubernetesResource {
+	//Derive routes that should be created:
+	objects := filterOmittedObjects(getCustomObjects(env))
+	var requestedRoutes []resource.KubernetesResource
+	for i := range objects {
+		for j := range objects[i].Routes {
+			route := &objects[i].Routes[j]
+			route.SetGroupVersionKind(routev1.SchemeGroupVersion.WithKind("Route"))
+			route.SetNamespace(instance.GetNamespace())
+			requestedRoutes = append(requestedRoutes, route)
+		}
 	}
+	return requestedRoutes
+}
 
-	var bcUpdates []buildv1.BuildConfig
-	for _, bc := range bcList.Items {
-		for _, server := range env.Servers {
-			for _, sBc := range server.BuildConfigs {
-				if bc.Name == sBc.Name {
-					bcUpdates = reconciler.bcUpdateCheck(bc, sBc, bcUpdates, instance)
-				}
-			}
+func getMissingRoutes(requestedRoutes []resource.KubernetesResource, deployedRoutes map[types.NamespacedName]routev1.Route) []resource.KubernetesResource {
+	var missingRoutes []resource.KubernetesResource
+	for _, route := range requestedRoutes {
+		if _, exists := deployedRoutes[shared.GetNamespacedName(route)]; !exists {
+			missingRoutes = append(missingRoutes, route)
 		}
 	}
-	if len(bcUpdates) > 0 {
-		for _, uBc := range bcUpdates {
-			_, err := reconciler.UpdateObj(&uBc)
-			if err != nil {
-				reconciler.setFailedStatus(instance, api.DeploymentFailedReason, err)
-				return false, err
-			}
+	return missingRoutes
+}
+
+func ignoreSecretDataValues(comparator *compare.MapComparator) {
+	secretType := reflect.TypeOf(corev1.Secret{})
+	secretComparator := comparator.Comparator.GetComparator(secretType)
+	newSecretComparator := func(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool {
+		secret1 := deployed.(*corev1.Secret).DeepCopy()
+		secret2 := requested.(*corev1.Secret).DeepCopy()
+		for key := range secret1.Data {
+			secret1.Data[key] = []byte{}
 		}
-		return true, nil
+		for key := range secret2.Data {
+			secret2.Data[key] = []byte{}
+		}
+		return secretComparator(secret1, secret2)
 	}
-	return false, nil
+	comparator.Comparator.SetComparator(secretType, newSecretComparator)
 }
 
 func (reconciler *Reconciler) hasSpecChanges(instance, cached *api.KieApp) bool {
@@ -353,89 +361,30 @@ func (reconciler *Reconciler) createLocalImageTag(tagRefName string, cr *api.Kie
 	return nil
 }
 
-func (reconciler *Reconciler) dcUpdateCheck(current, new oappsv1.DeploymentConfig, dcUpdates []oappsv1.DeploymentConfig, cr *api.KieApp) []oappsv1.DeploymentConfig {
-	log := log.With("kind", current.GetObjectKind().GroupVersionKind().Kind, "name", current.Name, "namespace", current.Namespace)
-	update := false
-	if !reflect.DeepEqual(current.Spec.Template.Labels, new.Spec.Template.Labels) {
-		log.Debug("Changes detected in labels.", " OLD - ", current.Spec.Template.Labels, " NEW - ", new.Spec.Template.Labels)
-		update = true
-	}
-	if current.Spec.Replicas != new.Spec.Replicas {
-		log.Debug("Changes detected in replicas.", " OLD - ", current.Spec.Replicas, " NEW - ", new.Spec.Replicas)
-		update = true
-	}
-
-	cContainer := current.Spec.Template.Spec.Containers[0]
-	nContainer := new.Spec.Template.Spec.Containers[0]
-	if !shared.EnvVarCheck(cContainer.Env, nContainer.Env) {
-		log.Debug("Changes detected in 'Env' config.", " OLD - ", cContainer.Env, " NEW - ", nContainer.Env)
-		update = true
-	}
-	if !reflect.DeepEqual(cContainer.Resources, nContainer.Resources) {
-		log.Debug("Changes detected in 'Resource' config.", " OLD - ", cContainer.Resources, " NEW - ", nContainer.Resources)
-		update = true
-	}
-	if update {
-		dcnew := new
-		err := controllerutil.SetControllerReference(cr, &dcnew, reconciler.Service.GetScheme())
-		if err != nil {
-			log.Error("Error setting controller reference for dc. ", err)
+//loadRoutes attempts to load as many of the specified routes as it can find
+func (reconciler *Reconciler) loadRoutes(requestedRoutes []resource.KubernetesResource) (map[types.NamespacedName]routev1.Route, error) {
+	deployedRoutes := make(map[types.NamespacedName]routev1.Route)
+	for _, requested := range requestedRoutes {
+		namespacedName := shared.GetNamespacedName(requested)
+		deployed := routev1.Route{}
+		err := reconciler.Service.Get(context.TODO(), namespacedName, &deployed)
+		if err == nil {
+			deployedRoutes[namespacedName] = deployed
+		} else if !errors.IsNotFound(err) {
+			return nil, err
 		}
-		dcnew.SetNamespace(current.Namespace)
-		dcnew.SetResourceVersion(current.ResourceVersion)
-		dcnew.SetGroupVersionKind(oappsv1.SchemeGroupVersion.WithKind("DeploymentConfig"))
-
-		dcUpdates = append(dcUpdates, dcnew)
 	}
-	return dcUpdates
+	return deployedRoutes, nil
 }
 
-func (reconciler *Reconciler) bcUpdateCheck(current, new buildv1.BuildConfig, bcUpdates []buildv1.BuildConfig, cr *api.KieApp) []buildv1.BuildConfig {
-	log := log.With("kind", current.GetObjectKind().GroupVersionKind().Kind, "name", current.Name, "namespace", current.Namespace)
-	update := false
-
-	if !reflect.DeepEqual(current.Spec.Source, new.Spec.Source) {
-		log.Debug("Changes detected in 'Source' config.", " OLD - ", current.Spec.Source, " NEW - ", new.Spec.Source)
-		update = true
-	}
-	if !shared.EnvVarCheck(current.Spec.Strategy.SourceStrategy.Env, new.Spec.Strategy.SourceStrategy.Env) {
-		log.Debug("Changes detected in 'Env' config.", " OLD - ", current.Spec.Strategy.SourceStrategy.Env, " NEW - ", new.Spec.Strategy.SourceStrategy.Env)
-		update = true
-	}
-	if !reflect.DeepEqual(current.Spec.Resources, new.Spec.Resources) {
-		log.Debug("Changes detected in 'Resource' config.", " OLD - ", current.Spec.Resources, " NEW - ", new.Spec.Resources)
-		update = true
-	}
-
-	if update {
-		bcnew := new
-		err := controllerutil.SetControllerReference(cr, &bcnew, reconciler.Service.GetScheme())
-		if err != nil {
-			log.Error("Error setting controller reference for bc. ", err)
-		}
-		bcnew.SetNamespace(current.Namespace)
-		bcnew.SetResourceVersion(current.ResourceVersion)
-		bcnew.SetGroupVersionKind(buildv1.SchemeGroupVersion.WithKind("BuildConfig"))
-
-		bcUpdates = append(bcUpdates, bcnew)
-	}
-	return bcUpdates
-}
-
-// newEnv creates an Environment generated from the given KieApp
-func (reconciler *Reconciler) newEnv(cr *api.KieApp) (api.Environment, reconcile.Result, error) {
-	env, err := defaults.GetEnvironment(cr, reconciler.Service)
-	if err != nil {
-		return env, reconcile.Result{}, err
-	}
-
+func (reconciler *Reconciler) setEnvironmentProperties(cr *api.KieApp, env api.Environment, routeMap map[types.NamespacedName]routev1.Route) api.Environment {
 	// console keystore generation
 	if !env.Console.Omit {
 		consoleCN := ""
 		for _, rt := range env.Console.Routes {
 			if checkTLS(rt.Spec.TLS) {
 				// use host of first tls route in env template
-				consoleCN = reconciler.GetRouteHost(rt, cr)
+				consoleCN = reconciler.GetRouteHost(rt, routeMap)
 				cr.Status.ConsoleHost = fmt.Sprintf("https://%s", consoleCN)
 				break
 			}
@@ -464,7 +413,7 @@ func (reconciler *Reconciler) newEnv(cr *api.KieApp) (api.Environment, reconcile
 		for _, rt := range server.Routes {
 			if checkTLS(rt.Spec.TLS) {
 				// use host of first tls route in env template
-				serverCN = reconciler.GetRouteHost(rt, cr)
+				serverCN = reconciler.GetRouteHost(rt, routeMap)
 				break
 			}
 		}
@@ -489,7 +438,7 @@ func (reconciler *Reconciler) newEnv(cr *api.KieApp) (api.Environment, reconcile
 		for _, rt := range env.SmartRouter.Routes {
 			if checkTLS(rt.Spec.TLS) {
 				// use host of first tls route in env template
-				smartCN = reconciler.GetRouteHost(rt, cr)
+				smartCN = reconciler.GetRouteHost(rt, routeMap)
 				break
 			}
 		}
@@ -506,30 +455,35 @@ func (reconciler *Reconciler) newEnv(cr *api.KieApp) (api.Environment, reconcile
 			))
 		}
 	}
-	env = defaults.ConsolidateObjects(env, cr)
+	return defaults.ConsolidateObjects(env, cr)
+}
 
-	rResult, err := reconciler.CreateCustomObjects(env.Console, cr)
-	if err != nil {
-		return env, rResult, err
+func (reconciler *Reconciler) getKubernetesResources(cr *api.KieApp, env api.Environment) []resource.KubernetesResource {
+	var resources []resource.KubernetesResource
+	objects := filterOmittedObjects(getCustomObjects(env))
+	for _, obj := range objects {
+		resources = append(resources, reconciler.getCustomObjectResources(obj, cr)...)
 	}
-	rResult, err = reconciler.CreateCustomObjects(env.SmartRouter, cr)
-	if err != nil {
-		return env, rResult, err
-	}
-	for _, s := range env.Servers {
-		rResult, err = reconciler.CreateCustomObjects(s, cr)
-		if err != nil {
-			return env, rResult, err
+	return resources
+}
+
+func getCustomObjects(env api.Environment) []api.CustomObject {
+	var objects []api.CustomObject
+	objects = append(objects, env.Console)
+	objects = append(objects, env.Servers...)
+	objects = append(objects, env.SmartRouter)
+	objects = append(objects, env.Others...)
+	return objects
+}
+
+func filterOmittedObjects(objects []api.CustomObject) []api.CustomObject {
+	var objs []api.CustomObject
+	for index := range objects {
+		if !objects[index].Omit {
+			objs = append(objs, objects[index])
 		}
 	}
-	for _, o := range env.Others {
-		rResult, err = reconciler.CreateCustomObjects(o, cr)
-		if err != nil {
-			return env, rResult, err
-		}
-	}
-
-	return env, rResult, nil
+	return objs
 }
 
 func generateKeystoreSecret(secretName, keystoreCN string, cr *api.KieApp) corev1.Secret {
@@ -548,12 +502,12 @@ func generateKeystoreSecret(secretName, keystoreCN string, cr *api.KieApp) corev
 	}
 }
 
-// CreateCustomObjects goes through all the different object types in the given CustomObject and creates them, if necessary
-func (reconciler *Reconciler) CreateCustomObjects(object api.CustomObject, cr *api.KieApp) (reconcile.Result, error) {
+// getCustomObjectResources returns all kubernetes resources that need to be created for the given CustomObject
+func (reconciler *Reconciler) getCustomObjectResources(object api.CustomObject, cr *api.KieApp) []resource.KubernetesResource {
+	var allObjects []resource.KubernetesResource
 	if object.Omit {
-		return reconcile.Result{}, nil
+		return allObjects
 	}
-	var allObjects []api.OpenShiftObject
 	for index := range object.PersistentVolumeClaims {
 		object.PersistentVolumeClaims[index].SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("PersistentVolumeClaim"))
 		allObjects = append(allObjects, &object.PersistentVolumeClaims[index])
@@ -615,15 +569,7 @@ func (reconciler *Reconciler) CreateCustomObjects(object api.CustomObject, cr *a
 		}
 		allObjects = append(allObjects, &object.BuildConfigs[index])
 	}
-
-	for _, obj := range allObjects {
-		_, err := reconciler.createCustomObject(obj, cr)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-	}
-
-	return reconcile.Result{}, nil
+	return allObjects
 }
 
 func (reconciler *Reconciler) ensureImageStream(name string, namespace string, cr *api.KieApp) (string, error) {
@@ -655,33 +601,14 @@ func (reconciler *Reconciler) ensureImageStream(name string, namespace string, c
 	return cr.Namespace, nil
 }
 
-// createCustomObject checks for an object's existence before creating it
-func (reconciler *Reconciler) createCustomObject(obj api.OpenShiftObject, cr *api.KieApp) (reconcile.Result, error) {
-	name := obj.GetName()
-	namespace := cr.GetNamespace()
-	log := log.With("kind", obj.GetObjectKind().GroupVersionKind().Kind, "name", name, "namespace", namespace)
-
-	err := controllerutil.SetControllerReference(cr, obj, reconciler.Service.GetScheme())
-	if err != nil {
-		log.Error("Failed to create. ", err)
-		return reconcile.Result{}, err
-	}
-	obj.SetNamespace(namespace)
-	emptyObj := reflect.New(reflect.TypeOf(obj).Elem()).Interface().(runtime.Object)
-	return reconciler.createObj(
-		obj,
-		reconciler.Service.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, emptyObj),
-	)
-}
-
 // createObj creates an object based on the error passed in from a `client.Get`
-func (reconciler *Reconciler) createObj(obj api.OpenShiftObject, err error) (reconcile.Result, error) {
-	log := log.With("kind", obj.GetObjectKind().GroupVersionKind().Kind, "name", obj.GetName(), "namespace", obj.GetNamespace())
+func (reconciler *Reconciler) createObj(object resource.KubernetesResource, err error) (reconcile.Result, error) {
+	log := log.With("kind", object.GetObjectKind().GroupVersionKind().Kind, "name", object.GetName(), "namespace", object.GetNamespace())
 
 	if err != nil && errors.IsNotFound(err) {
 		// Define a new Object
 		log.Info("Creating")
-		err = reconciler.Service.Create(context.TODO(), obj)
+		err = reconciler.Service.Create(context.TODO(), object)
 		if err != nil {
 			log.Warn("Failed to create object. ", err)
 			return reconcile.Result{}, err
@@ -717,42 +644,15 @@ func checkTLS(tls *routev1.TLSConfig) bool {
 }
 
 // GetRouteHost returns the Hostname of the route provided
-func (reconciler *Reconciler) GetRouteHost(route routev1.Route, cr *api.KieApp) string {
-	route.SetGroupVersionKind(routev1.SchemeGroupVersion.WithKind("Route"))
-	log := log.With("kind", route.GetObjectKind().GroupVersionKind().Kind, "name", route.Name, "namespace", route.Namespace)
-	err := controllerutil.SetControllerReference(cr, &route, reconciler.Service.GetScheme())
-	if err != nil {
-		log.Error("Error setting controller reference. ", err)
+func (reconciler *Reconciler) GetRouteHost(route routev1.Route, routeMap map[types.NamespacedName]routev1.Route) string {
+	if found, ok := routeMap[shared.GetNamespacedName(&route)]; ok {
+		return found.Spec.Host
+	} else {
+		return ""
 	}
-	route.SetNamespace(cr.Namespace)
-	found := &routev1.Route{}
-	err = reconciler.Service.Get(context.TODO(), types.NamespacedName{Name: route.Name, Namespace: route.Namespace}, found)
-	if err != nil && errors.IsNotFound(err) {
-		_, err = reconciler.createObj(
-			&route,
-			err,
-		)
-		if err != nil {
-			log.Error("Error creating Route. ", err)
-		}
-	}
-
-	found = &routev1.Route{}
-	for i := 1; i < 60; i++ {
-		time.Sleep(time.Duration(100) * time.Millisecond)
-		err = reconciler.Service.Get(context.TODO(), types.NamespacedName{Name: route.Name, Namespace: route.Namespace}, found)
-		if err == nil {
-			break
-		}
-	}
-	if err != nil {
-		log.Error("Error getting Route. ", err)
-	}
-
-	return found.Spec.Host
 }
 
-// CreateConfigMaps generates & creates necessary versioned ConfigMaps from embedded product files
+// CreateConfigMaps generates & creates necessary ConfigMaps from embedded files
 func (reconciler *Reconciler) CreateConfigMaps(myDep *appsv1.Deployment) {
 	configMaps := defaults.ConfigMapsFromFile(myDep, myDep.Namespace, reconciler.Service.GetScheme())
 	for _, configMap := range configMaps {
@@ -784,6 +684,7 @@ func (reconciler *Reconciler) CreateConfigMaps(myDep *appsv1.Deployment) {
 						// if backup configmap and existing backup have different data
 						if !reflect.DeepEqual(existingCM.Data, existingBackupCM.Data) || !reflect.DeepEqual(existingCM.BinaryData, existingBackupCM.BinaryData) {
 							existingBackupCM.Data = existingCM.Data
+						_:
 							reconciler.UpdateObj(existingBackupCM)
 						}
 					}
@@ -799,12 +700,11 @@ func (reconciler *Reconciler) createConfigMap(obj api.OpenShiftObject) (*corev1.
 	err := reconciler.Service.Get(context.TODO(), types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, emptyObj)
 	if errors.IsNotFound(err) {
 		// attempt creation of configmap if doesn't exist
+	_:
 		reconciler.createObj(obj, err)
 		return &corev1.ConfigMap{}, false
 	} else if err != nil {
-		if err != nil {
-			log.Error(err)
-		}
+		log.Error(err)
 		return &corev1.ConfigMap{}, false
 	}
 	return emptyObj, true
@@ -847,6 +747,252 @@ func (reconciler *Reconciler) checkKieServerConfigMap(instance *api.KieApp, env 
 			}
 		}
 	}
+}
+
+func (reconciler *Reconciler) getDeployedResources(instance *api.KieApp) (map[reflect.Type][]resource.KubernetesResource, error) {
+	log := log.With("kind", instance.Kind, "name", instance.Name, "namespace", instance.Namespace)
+	resourceMap := make(map[reflect.Type][]resource.KubernetesResource)
+
+	listOps := &client.ListOptions{Namespace: instance.Namespace}
+
+	dcList := &oappsv1.DeploymentConfigList{}
+	err := reconciler.Service.List(context.TODO(), listOps, dcList)
+	if err != nil {
+		log.Warn("Failed to list DCs. ", err)
+		return nil, err
+	}
+	var dcs []resource.KubernetesResource
+	for index := range dcList.Items {
+		dc := dcList.Items[index]
+		for _, ownerRef := range dc.GetOwnerReferences() {
+			if ownerRef.UID == instance.UID {
+				dcs = append(dcs, &dc)
+				break
+			}
+		}
+	}
+	resourceMap[reflect.TypeOf(oappsv1.DeploymentConfig{})] = dcs
+
+	pvcList := &corev1.PersistentVolumeClaimList{}
+	err = reconciler.Service.List(context.TODO(), listOps, pvcList)
+	if err != nil {
+		log.Warn("Failed to list PersistentVolumeClaims. ", err)
+		return nil, err
+	}
+	var pvcs []resource.KubernetesResource
+	for index := range pvcList.Items {
+		pvc := pvcList.Items[index]
+		for _, ownerRef := range pvc.GetOwnerReferences() {
+			if ownerRef.UID == instance.UID {
+				pvcs = append(pvcs, &pvc)
+				break
+			}
+		}
+	}
+	resourceMap[reflect.TypeOf(corev1.PersistentVolumeClaim{})] = pvcs
+
+	saList := &corev1.ServiceAccountList{}
+	err = reconciler.Service.List(context.TODO(), listOps, saList)
+	if err != nil {
+		log.Warn("Failed to list ServiceAccounts. ", err)
+		return nil, err
+	}
+	var sas []resource.KubernetesResource
+	for index := range saList.Items {
+		sa := saList.Items[index]
+		for _, ownerRef := range sa.GetOwnerReferences() {
+			if ownerRef.UID == instance.UID {
+				sas = append(sas, &sa)
+				break
+			}
+		}
+	}
+	resourceMap[reflect.TypeOf(corev1.ServiceAccount{})] = sas
+
+	//secretList := &corev1.SecretList{}
+	var secrets []resource.KubernetesResource
+	//err = reconciler.Service.List(context.TODO(), listOps, secretList) //TODO: can't list secrets due bug:
+	// https://github.com/kubernetes-sigs/controller-runtime/issues/362
+	// multiple group-version-kinds associated with type *api.SecretList, refusing to guess at one
+	// Will work around by loading known secrets instead
+
+	for _, res := range dcs {
+		dc := res.(*oappsv1.DeploymentConfig)
+		for _, volume := range dc.Spec.Template.Spec.Volumes {
+			if volume.Secret != nil {
+				name := volume.Secret.SecretName
+				secret := &corev1.Secret{}
+				err := reconciler.Service.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: instance.GetNamespace()}, secret)
+				if err != nil && !errors.IsNotFound(err) {
+					log.Warn("Failed to load Secret", err)
+					return nil, err
+				}
+				secrets = append(secrets, secret)
+			}
+		}
+	}
+	//if err != nil {
+	//	log.Warn("Failed to list Secrets. ", err)
+	//	return nil, err
+	//}
+	//for index := range secretList.Items {
+	//	secret := secretList.Items[index]
+	//	for _, ownerRef := range secret.GetOwnerReferences() {
+	//		if ownerRef.UID == instance.UID {
+	//			secrets = append(secrets, &secret)
+	//			break
+	//		}
+	//	}
+	//}
+	resourceMap[reflect.TypeOf(corev1.Secret{})] = secrets
+
+	roleList := &rbacv1.RoleList{}
+	err = reconciler.Service.List(context.TODO(), listOps, roleList)
+	if err != nil {
+		log.Warn("Failed to list roles. ", err)
+		return nil, err
+	}
+	var roles []resource.KubernetesResource
+	for index := range roleList.Items {
+		role := roleList.Items[index]
+		for _, ownerRef := range role.GetOwnerReferences() {
+			if ownerRef.UID == instance.UID {
+				roles = append(roles, &role)
+				break
+			}
+		}
+	}
+	resourceMap[reflect.TypeOf(rbacv1.Role{})] = roles
+
+	roleBindingList := &rbacv1.RoleBindingList{}
+	err = reconciler.Service.List(context.TODO(), listOps, roleBindingList)
+	if err != nil {
+		log.Warn("Failed to list roleBindings. ", err)
+		return nil, err
+	}
+	var roleBindings []resource.KubernetesResource
+	for index := range roleBindingList.Items {
+		roleBinding := roleBindingList.Items[index]
+		for _, ownerRef := range roleBinding.GetOwnerReferences() {
+			if ownerRef.UID == instance.UID {
+				roleBindings = append(roleBindings, &roleBinding)
+				break
+			}
+		}
+	}
+	resourceMap[reflect.TypeOf(rbacv1.RoleBinding{})] = roleBindings
+
+	serviceList := &corev1.ServiceList{}
+	err = reconciler.Service.List(context.TODO(), listOps, serviceList)
+	if err != nil {
+		log.Warn("Failed to list services. ", err)
+		return nil, err
+	}
+	var services []resource.KubernetesResource
+	for index := range serviceList.Items {
+		service := serviceList.Items[index]
+		for _, ownerRef := range service.GetOwnerReferences() {
+			if ownerRef.UID == instance.UID {
+				services = append(services, &service)
+				break
+			}
+		}
+	}
+	resourceMap[reflect.TypeOf(corev1.Service{})] = services
+
+	statefulSetList := &appsv1.StatefulSetList{}
+	err = reconciler.Service.List(context.TODO(), listOps, statefulSetList)
+	if err != nil {
+		log.Warn("Failed to list statefulSets. ", err)
+		return nil, err
+	}
+	var statefulSets []resource.KubernetesResource
+	for index := range statefulSetList.Items {
+		statefulSet := statefulSetList.Items[index]
+		for _, ownerRef := range statefulSet.GetOwnerReferences() {
+			if ownerRef.UID == instance.UID {
+				statefulSets = append(statefulSets, &statefulSet)
+				break
+			}
+		}
+	}
+	resourceMap[reflect.TypeOf(appsv1.StatefulSet{})] = statefulSets
+
+	RouteList := &routev1.RouteList{}
+	err = reconciler.Service.List(context.TODO(), listOps, RouteList)
+	if err != nil {
+		log.Warn("Failed to list routes. ", err)
+		return nil, err
+	}
+	var routes []resource.KubernetesResource
+	for index := range RouteList.Items {
+		route := RouteList.Items[index]
+		for _, ownerRef := range route.GetOwnerReferences() {
+			if ownerRef.UID == instance.UID {
+				routes = append(routes, &route)
+				break
+			}
+		}
+	}
+	resourceMap[reflect.TypeOf(routev1.Route{})] = routes
+
+	imageStreamList := &oimagev1.ImageStreamList{}
+	err = reconciler.Service.List(context.TODO(), listOps, imageStreamList)
+	if err != nil {
+		log.Warn("Failed to list imageStreams. ", err)
+		return nil, err
+	}
+	var imageStreams []resource.KubernetesResource
+	for index := range imageStreamList.Items {
+		imageStream := imageStreamList.Items[index]
+		for _, ownerRef := range imageStream.GetOwnerReferences() {
+			if ownerRef.UID == instance.UID {
+				imageStreams = append(imageStreams, &imageStream)
+				break
+			}
+		}
+	}
+	resourceMap[reflect.TypeOf(oimagev1.ImageStream{})] = imageStreams
+
+	buildConfigList := &buildv1.BuildConfigList{}
+	err = reconciler.Service.List(context.TODO(), listOps, buildConfigList)
+	if err != nil {
+		log.Warn("Failed to list buildConfigs. ", err)
+		return nil, err
+	}
+	var buildConfigs []resource.KubernetesResource
+	for index := range buildConfigList.Items {
+		buildConfig := buildConfigList.Items[index]
+		for _, ownerRef := range buildConfig.GetOwnerReferences() {
+			if ownerRef.UID == instance.UID {
+				buildConfigs = append(buildConfigs, &buildConfig)
+				break
+			}
+		}
+	}
+	resourceMap[reflect.TypeOf(buildv1.BuildConfig{})] = buildConfigs
+
+	return resourceMap, nil
+}
+
+func (reconciler *Reconciler) getDeployedRoutes(instance *api.KieApp) ([]resource.KubernetesResource, error) {
+	RouteList := &routev1.RouteList{}
+	err := reconciler.Service.List(context.TODO(), &client.ListOptions{Namespace: instance.Namespace}, RouteList)
+	if err != nil {
+		log.Warn("Failed to list routes. ", err)
+		return nil, err
+	}
+	var routes []resource.KubernetesResource
+	for index := range RouteList.Items {
+		route := RouteList.Items[index]
+		for _, ownerRef := range route.GetOwnerReferences() {
+			if ownerRef.UID == instance.UID {
+				routes = append(routes, &route)
+				break
+			}
+		}
+	}
+	return routes, nil
 }
 
 func (reconciler *Reconciler) getCSV(operator *appsv1.Deployment) *operatorsv1alpha1.ClusterServiceVersion {

--- a/pkg/controller/kieapp/kieapp_controller_test.go
+++ b/pkg/controller/kieapp/kieapp_controller_test.go
@@ -45,9 +45,12 @@ func TestGenerateSecret(t *testing.T) {
 	mockService.GetSchemeFunc = func() *runtime.Scheme {
 		return scheme
 	}
-	reconciler := &Reconciler{mockService}
-	env, _, err = reconciler.newEnv(cr)
-	assert.Nil(t, err, "Error creating a new environment")
+	env, err = defaults.GetEnvironment(cr, mockService)
+	assert.Nil(t, err, "Error getting a new environment")
+	reconciler := Reconciler{
+		Service: mockService,
+	}
+	env = reconciler.setEnvironmentProperties(cr, env)
 	assert.Len(t, env.Console.Secrets, 1, "One secret should be generated for the trial workbench")
 	for _, server := range env.Servers {
 		assert.Len(t, server.Secrets, 1, "One secret should be generated for each trial kieserver")
@@ -101,8 +104,7 @@ func TestSpecifySecret(t *testing.T) {
 	mockService.GetSchemeFunc = func() *runtime.Scheme {
 		return scheme
 	}
-	reconciler := &Reconciler{mockService}
-	env, _, err = reconciler.newEnv(cr)
+	env, err = defaults.GetEnvironment(cr, mockService)
 	assert.Nil(t, err, "Error creating a new environment")
 	assert.Len(t, env.Console.Secrets, 0, "Zero secrets should be generated for the trial workbench")
 	assert.Len(t, env.Servers[0].Secrets, 0, "Zero secrets should be generated for the trial kieserver")
@@ -140,9 +142,10 @@ func TestConsoleHost(t *testing.T) {
 	mockService.GetSchemeFunc = func() *runtime.Scheme {
 		return scheme
 	}
-	reconciler := &Reconciler{mockService}
-	_, _, err = reconciler.newEnv(cr)
+	env, err := defaults.GetEnvironment(cr, mockService)
 	assert.Nil(t, err, "Error creating a new environment")
+	reconciler := &Reconciler{Service: mockService}
+	reconciler.setEnvironmentProperties(cr, env)
 	assert.Equal(t, fmt.Sprintf("http://%s", cr.Spec.CommonConfig.ApplicationName), cr.Status.ConsoleHost, "spec.commonConfig.consoleHost should be URL from the resulting workbench route host")
 }
 

--- a/pkg/controller/kieapp/kieapp_controller_test.go
+++ b/pkg/controller/kieapp/kieapp_controller_test.go
@@ -282,7 +282,7 @@ func TestStatusDeploymentsProgression(t *testing.T) {
 	reconciler := Reconciler{Service: service}
 	result, err := reconciler.Reconcile(reconcile.Request{NamespacedName: crNamespacedName})
 	assert.Nil(t, err)
-	assert.Equal(t, reconcile.Result{Requeue: true, RequeueAfter: time.Duration(200) * time.Millisecond}, result, "Routes should be created, requeued for hostname detection before other resources are created")
+	assert.Equal(t, reconcile.Result{Requeue: true, RequeueAfter: time.Duration(500) * time.Millisecond}, result, "Routes should be created, requeued for hostname detection before other resources are created")
 
 	result, err = reconciler.Reconcile(reconcile.Request{NamespacedName: crNamespacedName})
 	assert.Equal(t, reconcile.Result{Requeue: true}, result, "All other resources created, custom Resource status set to provisioning, and requeued")

--- a/pkg/controller/kieapp/shared/utils.go
+++ b/pkg/controller/kieapp/shared/utils.go
@@ -7,6 +7,8 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"math/big"
 	"math/rand"
 	"time"
@@ -165,4 +167,11 @@ func EnvVarCheck(dst, src []corev1.EnvVar) bool {
 		}
 	}
 	return true
+}
+
+func GetNamespacedName(object metav1.Object) types.NamespacedName {
+	return types.NamespacedName{
+		Name:      object.GetName(),
+		Namespace: object.GetNamespace(),
+	}
 }

--- a/pkg/controller/kieapp/test/mock_service.go
+++ b/pkg/controller/kieapp/test/mock_service.go
@@ -2,8 +2,9 @@ package test
 
 import (
 	"context"
-
 	api "github.com/kiegroup/kie-cloud-operator/pkg/apis/app/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
 	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/logs"
 	oappsv1 "github.com/openshift/api/apps/v1"
 	buildv1 "github.com/openshift/api/build/v1"
@@ -15,7 +16,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientv1 "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var log = logs.GetLogger("kieapp.test")
@@ -24,6 +24,7 @@ type MockPlatformService struct {
 	Client              clientv1.Client
 	scheme              *runtime.Scheme
 	CreateFunc          func(ctx context.Context, obj runtime.Object) error
+	DeleteFunc          func(ctx context.Context, obj runtime.Object, opts ...clientv1.DeleteOptionFunc) error
 	GetFunc             func(ctx context.Context, key clientv1.ObjectKey, obj runtime.Object) error
 	ListFunc            func(ctx context.Context, opts *clientv1.ListOptions, list runtime.Object) error
 	UpdateFunc          func(ctx context.Context, obj runtime.Object) error
@@ -38,7 +39,7 @@ func MockService() *MockPlatformService {
 }
 
 func MockServiceWithExtraScheme(objs ...runtime.Object) *MockPlatformService {
-	registerObjs := []runtime.Object{&api.KieApp{}, &api.KieAppList{}, &corev1.PersistentVolumeClaim{}, &corev1.ServiceAccount{}, &corev1.Secret{}, &rbacv1.Role{}, &rbacv1.RoleBinding{}, &oappsv1.DeploymentConfig{}, &corev1.Service{}, &appsv1.StatefulSet{}, &routev1.Route{}, &oimagev1.ImageStream{}, &buildv1.BuildConfig{}, &oappsv1.DeploymentConfigList{}, &buildv1.BuildConfigList{}}
+	registerObjs := []runtime.Object{&api.KieApp{}, &api.KieAppList{}, &corev1.PersistentVolumeClaim{}, &corev1.ServiceAccount{}, &corev1.Secret{}, &rbacv1.Role{}, &rbacv1.RoleBinding{}, &oappsv1.DeploymentConfig{}, &corev1.Service{}, &appsv1.StatefulSet{}, &routev1.Route{}, &oimagev1.ImageStream{}, &buildv1.BuildConfig{}, &oappsv1.DeploymentConfigList{}, &buildv1.BuildConfigList{}, &corev1.PersistentVolumeClaimList{}, &corev1.ServiceAccountList{}, &rbacv1.RoleList{}, &rbacv1.RoleBindingList{}, &corev1.ServiceList{}, &appsv1.StatefulSetList{}, &routev1.RouteList{}, &oimagev1.ImageStreamList{}}
 	registerObjs = append(registerObjs, objs...)
 	api.SchemeBuilder.Register(registerObjs...)
 	scheme, _ := api.SchemeBuilder.Build()
@@ -50,6 +51,9 @@ func MockServiceWithExtraScheme(objs ...runtime.Object) *MockPlatformService {
 		scheme: scheme,
 		CreateFunc: func(ctx context.Context, obj runtime.Object) error {
 			return client.Create(ctx, obj)
+		},
+		DeleteFunc: func(ctx context.Context, obj runtime.Object, opts ...clientv1.DeleteOptionFunc) error {
+			return client.Delete(ctx, obj, opts...)
 		},
 		GetFunc: func(ctx context.Context, key clientv1.ObjectKey, obj runtime.Object) error {
 			return client.Get(ctx, key, obj)
@@ -77,6 +81,10 @@ func MockServiceWithExtraScheme(objs ...runtime.Object) *MockPlatformService {
 
 func (service *MockPlatformService) Create(ctx context.Context, obj runtime.Object) error {
 	return service.CreateFunc(ctx, obj)
+}
+
+func (service *MockPlatformService) Delete(ctx context.Context, obj runtime.Object, opts ...clientv1.DeleteOptionFunc) error {
+	return service.DeleteFunc(ctx, obj, opts...)
 }
 
 func (service *MockPlatformService) Get(ctx context.Context, key clientv1.ObjectKey, obj runtime.Object) error {

--- a/pkg/controller/kube_service.go
+++ b/pkg/controller/kube_service.go
@@ -36,6 +36,10 @@ func (service *KubernetesPlatformService) Create(ctx context.Context, obj runtim
 	return service.client.Create(ctx, obj)
 }
 
+func (service *KubernetesPlatformService) Delete(ctx context.Context, obj runtime.Object, opts ...clientv1.DeleteOptionFunc) error {
+	return service.client.Delete(ctx, obj, opts...)
+}
+
 func (service *KubernetesPlatformService) Get(ctx context.Context, key clientv1.ObjectKey, obj runtime.Object) error {
 	return service.client.Get(ctx, key, obj)
 }

--- a/vendor/github.com/RHsyseng/operator-utils/Gopkg.lock
+++ b/vendor/github.com/RHsyseng/operator-utils/Gopkg.lock
@@ -34,6 +34,14 @@
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:ac425d784b13d49b37a5bbed3ce022677f8f3073b216f05d6adcb9303e27fa0f"
+  name = "github.com/evanphx/json-patch"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "026c730a0dcc5d11f93f1cf1cc65b01247ea7b6f"
+  version = "v4.5.0"
+
+[[projects]]
   digest = "1:2cd7915ab26ede7d95b8749e6b1f933f1c6d5398030684e6505940a10f31cfda"
   name = "github.com/ghodss/yaml"
   packages = ["."]
@@ -249,9 +257,12 @@
   version = "1.0.1"
 
 [[projects]]
-  digest = "1:94b521dc449e4a6758c681e35f3b97a4a5699090dccd9c25eba0fb0bcf60f48b"
+  digest = "1:cc18cf101cc07b176fcf6d04137d267afbd9b88c9c3dbe0dde3ddae072992a6e"
   name = "github.com/openshift/api"
-  packages = ["apps/v1"]
+  packages = [
+    "apps/v1",
+    "route/v1",
+  ]
   pruneopts = "UT"
   revision = "0d921e363e951d89f583292c60d013c318df64dc"
   version = "v3.9.0"
@@ -520,10 +531,11 @@
   version = "kubernetes-1.14.1"
 
 [[projects]]
-  digest = "1:3710e0b4d199b54c41e8489c7ee6360fcdda1cdb84c34d96224ecc7287225535"
+  digest = "1:72b7cb4419164da285783acc5bd4a306df21bd05a05fe59c98e1139cb196d5bb"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
+    "dynamic",
     "kubernetes/scheme",
     "pkg/apis/clientauthentication",
     "pkg/apis/clientauthentication/v1alpha1",
@@ -532,6 +544,7 @@
     "plugin/pkg/client/auth/exec",
     "rest",
     "rest/watch",
+    "restmapper",
     "tools/auth",
     "tools/clientcmd",
     "tools/clientcmd/api",
@@ -566,10 +579,13 @@
   revision = "c55fbcfc754a5b2ec2fbae8fb9dcac36bdba6a12"
 
 [[projects]]
-  digest = "1:82101051647e269ded57707ffeca1154c873c7cefc40985647f17224e0b412fb"
+  digest = "1:f281493889e2ca62ab6fed2ae3c7a277a1143ff2f944f519ff5126719e1f3d08"
   name = "sigs.k8s.io/controller-runtime"
   packages = [
+    "pkg/client",
+    "pkg/client/apiutil",
     "pkg/client/config",
+    "pkg/controller/controllerutil",
     "pkg/internal/log",
     "pkg/log",
     "pkg/log/zap",
@@ -597,14 +613,20 @@
     "github.com/go-openapi/validate",
     "github.com/googleapis/gnostic/OpenAPIv2",
     "github.com/openshift/api/apps/v1",
+    "github.com/openshift/api/route/v1",
     "github.com/pkg/errors",
     "github.com/stretchr/testify/assert",
     "k8s.io/api/apps/v1",
+    "k8s.io/api/core/v1",
+    "k8s.io/api/rbac/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
+    "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/version",
     "k8s.io/client-go/discovery",
     "k8s.io/client-go/rest",
+    "sigs.k8s.io/controller-runtime/pkg/client",
     "sigs.k8s.io/controller-runtime/pkg/client/config",
+    "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil",
     "sigs.k8s.io/controller-runtime/pkg/runtime/log",
   ]
   solver-name = "gps-cdcl"

--- a/vendor/github.com/RHsyseng/operator-utils/Gopkg.lock
+++ b/vendor/github.com/RHsyseng/operator-utils/Gopkg.lock
@@ -257,10 +257,11 @@
   version = "1.0.1"
 
 [[projects]]
-  digest = "1:cc18cf101cc07b176fcf6d04137d267afbd9b88c9c3dbe0dde3ddae072992a6e"
+  digest = "1:cd1052701c9640c2d3d594ab729243a2a03315a970586c060861b28f98922909"
   name = "github.com/openshift/api"
   packages = [
     "apps/v1",
+    "build/v1",
     "route/v1",
   ]
   pruneopts = "UT"
@@ -487,7 +488,7 @@
   revision = "1d1b8b084b3057162613acc6cba8af4e30dc2ec4"
 
 [[projects]]
-  digest = "1:78f6a824d205c6cb0d011cce241407646b773cb57ee27e8c7e027753b4111075"
+  digest = "1:81683bf6c1b4aecdc3ff5691254983eeab14705d3bca1cb2db10656d4ff347ce"
   name = "k8s.io/apimachinery"
   packages = [
     "pkg/api/errors",
@@ -515,15 +516,18 @@
     "pkg/util/framer",
     "pkg/util/intstr",
     "pkg/util/json",
+    "pkg/util/mergepatch",
     "pkg/util/naming",
     "pkg/util/net",
     "pkg/util/runtime",
     "pkg/util/sets",
+    "pkg/util/strategicpatch",
     "pkg/util/validation",
     "pkg/util/validation/field",
     "pkg/util/yaml",
     "pkg/version",
     "pkg/watch",
+    "third_party/forked/golang/json",
     "third_party/forked/golang/reflect",
   ]
   pruneopts = "UT"
@@ -531,7 +535,7 @@
   version = "kubernetes-1.14.1"
 
 [[projects]]
-  digest = "1:72b7cb4419164da285783acc5bd4a306df21bd05a05fe59c98e1139cb196d5bb"
+  digest = "1:c460475440532e591371b7171acffd908aa16a7a75c82ab6b1d631bcd3c3120d"
   name = "k8s.io/client-go"
   packages = [
     "discovery",
@@ -545,6 +549,7 @@
     "rest",
     "rest/watch",
     "restmapper",
+    "testing",
     "tools/auth",
     "tools/clientcmd",
     "tools/clientcmd/api",
@@ -572,6 +577,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:22abb5d4204ab1a0dcc9cda64906a31c43965ff5159e8b9f766c9d2a162dbed5"
+  name = "k8s.io/kube-openapi"
+  packages = ["pkg/util/proto"]
+  pruneopts = "UT"
+  revision = "743ec37842bffe49dd4221d9026f30fb1d5adbc4"
+
+[[projects]]
+  branch = "master"
   digest = "1:8b40227d4bf8b431fdab4f9026e6e346f00ac3be5662af367a183f78c57660b3"
   name = "k8s.io/utils"
   packages = ["integer"]
@@ -579,14 +592,16 @@
   revision = "c55fbcfc754a5b2ec2fbae8fb9dcac36bdba6a12"
 
 [[projects]]
-  digest = "1:f281493889e2ca62ab6fed2ae3c7a277a1143ff2f944f519ff5126719e1f3d08"
+  digest = "1:9324f3733f2ac874864c360a030b335cb0786dd91a2b36156f146da2b2dad140"
   name = "sigs.k8s.io/controller-runtime"
   packages = [
     "pkg/client",
     "pkg/client/apiutil",
     "pkg/client/config",
+    "pkg/client/fake",
     "pkg/controller/controllerutil",
     "pkg/internal/log",
+    "pkg/internal/objectutil",
     "pkg/log",
     "pkg/log/zap",
     "pkg/runtime/log",
@@ -613,6 +628,7 @@
     "github.com/go-openapi/validate",
     "github.com/googleapis/gnostic/OpenAPIv2",
     "github.com/openshift/api/apps/v1",
+    "github.com/openshift/api/build/v1",
     "github.com/openshift/api/route/v1",
     "github.com/pkg/errors",
     "github.com/stretchr/testify/assert",
@@ -621,11 +637,13 @@
     "k8s.io/api/rbac/v1",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/runtime",
+    "k8s.io/apimachinery/pkg/types",
     "k8s.io/apimachinery/pkg/version",
     "k8s.io/client-go/discovery",
     "k8s.io/client-go/rest",
     "sigs.k8s.io/controller-runtime/pkg/client",
     "sigs.k8s.io/controller-runtime/pkg/client/config",
+    "sigs.k8s.io/controller-runtime/pkg/client/fake",
     "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil",
     "sigs.k8s.io/controller-runtime/pkg/runtime/log",
   ]

--- a/vendor/github.com/RHsyseng/operator-utils/pkg/resource/compare/defaults.go
+++ b/vendor/github.com/RHsyseng/operator-utils/pkg/resource/compare/defaults.go
@@ -1,0 +1,315 @@
+package compare
+
+import (
+	"github.com/RHsyseng/operator-utils/pkg/resource"
+	oappsv1 "github.com/openshift/api/apps/v1"
+	routev1 "github.com/openshift/api/route/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"reflect"
+)
+
+type resourceComparator struct {
+	defaultCompareFunc func(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool
+	compareFuncMap     map[reflect.Type]func(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool
+}
+
+func (this *resourceComparator) SetDefaultComparator(compFunc func(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool) {
+	this.defaultCompareFunc = compFunc
+}
+
+func (this *resourceComparator) GetDefaultComparator() func(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool {
+	return this.defaultCompareFunc
+}
+
+func (this *resourceComparator) SetComparator(resourceType reflect.Type, compFunc func(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool) {
+	this.compareFuncMap[resourceType] = compFunc
+}
+
+func (this *resourceComparator) GetComparator(resourceType reflect.Type) func(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool {
+	return this.compareFuncMap[resourceType]
+}
+
+func (this *resourceComparator) Compare(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool {
+	compareFunc := this.GetDefaultComparator()
+	type1 := reflect.ValueOf(deployed).Elem().Type()
+	type2 := reflect.ValueOf(requested).Elem().Type()
+	if type1 == type2 {
+		if comparator, exists := this.compareFuncMap[type1]; exists {
+			compareFunc = comparator
+		}
+	}
+	return compareFunc(deployed, requested)
+}
+
+func defaultMap() map[reflect.Type]func(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool {
+	equalsMap := make(map[reflect.Type]func(resource.KubernetesResource, resource.KubernetesResource) bool)
+	equalsMap[reflect.TypeOf(oappsv1.DeploymentConfig{})] = equalDeploymentConfigs
+	equalsMap[reflect.TypeOf(corev1.Service{})] = equalServices
+	equalsMap[reflect.TypeOf(routev1.Route{})] = equalRoutes
+	equalsMap[reflect.TypeOf(rbacv1.Role{})] = equalRoles
+	equalsMap[reflect.TypeOf(rbacv1.RoleBinding{})] = equalRoleBindings
+	equalsMap[reflect.TypeOf(corev1.ServiceAccount{})] = equalServiceAccounts
+	equalsMap[reflect.TypeOf(corev1.Secret{})] = equalSecrets
+	return equalsMap
+}
+
+func equalDeploymentConfigs(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool {
+	dc1 := deployed.(*oappsv1.DeploymentConfig)
+	dc2 := requested.(*oappsv1.DeploymentConfig)
+
+	//Removed generated fields from deployed version, when not specified in requested item
+	dc1 = dc1.DeepCopy()
+	if dc2.Spec.Strategy.RecreateParams == nil {
+		dc1.Spec.Strategy.RecreateParams = nil
+	}
+	if dc2.Spec.Strategy.ActiveDeadlineSeconds == nil {
+		dc1.Spec.Strategy.ActiveDeadlineSeconds = nil
+	}
+	if dc1.Spec.Strategy.RollingParams != nil && dc2.Spec.Strategy.RollingParams != nil {
+		if dc2.Spec.Strategy.RollingParams.UpdatePeriodSeconds == nil {
+			dc1.Spec.Strategy.RollingParams.UpdatePeriodSeconds = nil
+		}
+		if dc2.Spec.Strategy.RollingParams.IntervalSeconds == nil {
+			dc1.Spec.Strategy.RollingParams.IntervalSeconds = nil
+		}
+		if dc2.Spec.Strategy.RollingParams.TimeoutSeconds == nil {
+			dc1.Spec.Strategy.RollingParams.TimeoutSeconds = nil
+		}
+	}
+	if dc2.Spec.RevisionHistoryLimit == nil {
+		dc1.Spec.RevisionHistoryLimit = nil
+	}
+	if dc1.Spec.Template != nil && dc2.Spec.Template != nil {
+		for i := range dc1.Spec.Template.Spec.Volumes {
+			if len(dc2.Spec.Template.Spec.Volumes) <= i {
+				return false
+			}
+			volSrc1 := dc1.Spec.Template.Spec.Volumes[i].VolumeSource
+			volSrc2 := dc2.Spec.Template.Spec.Volumes[i].VolumeSource
+			if volSrc1.Secret != nil && volSrc2.Secret != nil && volSrc2.Secret.DefaultMode == nil {
+				volSrc1.Secret.DefaultMode = nil
+			}
+		}
+		if dc2.Spec.Template.Spec.RestartPolicy == "" {
+			dc1.Spec.Template.Spec.RestartPolicy = ""
+		}
+		if dc2.Spec.Template.Spec.DNSPolicy == "" {
+			dc1.Spec.Template.Spec.DNSPolicy = ""
+		}
+		if dc2.Spec.Template.Spec.DeprecatedServiceAccount == "" {
+			dc1.Spec.Template.Spec.DeprecatedServiceAccount = ""
+		}
+		if dc2.Spec.Template.Spec.SecurityContext == nil {
+			dc1.Spec.Template.Spec.SecurityContext = nil
+		}
+		if dc2.Spec.Template.Spec.SchedulerName == "" {
+			dc1.Spec.Template.Spec.SchedulerName = ""
+		}
+		for i := range dc1.Spec.Template.Spec.Containers {
+			if len(dc2.Spec.Template.Spec.Containers) <= i {
+				return false
+			}
+			probe1 := dc1.Spec.Template.Spec.Containers[i].LivenessProbe
+			probe2 := dc2.Spec.Template.Spec.Containers[i].LivenessProbe
+			if probe1 != nil && probe2 != nil {
+				if probe2.FailureThreshold == 0 {
+					probe1.FailureThreshold = probe2.FailureThreshold
+				}
+				if probe2.SuccessThreshold == 0 {
+					probe1.SuccessThreshold = probe2.SuccessThreshold
+				}
+			}
+			probe1 = dc1.Spec.Template.Spec.Containers[i].ReadinessProbe
+			probe2 = dc2.Spec.Template.Spec.Containers[i].ReadinessProbe
+			if probe1 != nil && probe2 != nil {
+				if probe2.FailureThreshold == 0 {
+					probe1.FailureThreshold = probe2.FailureThreshold
+				}
+				if probe2.SuccessThreshold == 0 {
+					probe1.SuccessThreshold = probe2.SuccessThreshold
+				}
+			}
+			if dc2.Spec.Template.Spec.Containers[i].TerminationMessagePath == "" {
+				dc1.Spec.Template.Spec.Containers[i].TerminationMessagePath = ""
+			}
+			if dc2.Spec.Template.Spec.Containers[i].TerminationMessagePolicy == "" {
+				dc1.Spec.Template.Spec.Containers[i].TerminationMessagePolicy = ""
+			}
+			for j := range dc1.Spec.Template.Spec.Containers[i].Env {
+				if len(dc2.Spec.Template.Spec.Containers[i].Env) <= j {
+					return false
+				}
+				valueFrom := dc2.Spec.Template.Spec.Containers[i].Env[j].ValueFrom
+				if valueFrom != nil && valueFrom.FieldRef != nil && valueFrom.FieldRef.APIVersion == "" {
+					valueFrom1 := dc1.Spec.Template.Spec.Containers[i].Env[j].ValueFrom
+					if valueFrom1 != nil && valueFrom1.FieldRef != nil {
+						valueFrom1.FieldRef.APIVersion = ""
+					}
+				}
+			}
+		}
+	}
+
+	var pairs [][2]interface{}
+	pairs = append(pairs, [2]interface{}{dc1.Name, dc2.Name})
+	pairs = append(pairs, [2]interface{}{dc1.Namespace, dc2.Namespace})
+	pairs = append(pairs, [2]interface{}{dc1.Labels, dc2.Labels})
+	pairs = append(pairs, [2]interface{}{dc1.Annotations, dc2.Annotations})
+	pairs = append(pairs, [2]interface{}{dc1.Spec, dc2.Spec})
+	return EqualPairs(pairs)
+}
+
+func equalServices(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool {
+	service1 := deployed.(*corev1.Service)
+	service2 := requested.(*corev1.Service)
+
+	//Removed generated fields from deployed version, when not specified in requested item
+	service1 = service1.DeepCopy()
+
+	//Removed potentially generated annotations for cert request
+	delete(service1.Annotations, "service.alpha.openshift.io/serving-cert-signed-by")
+	delete(service1.Annotations, "service.beta.openshift.io/serving-cert-signed-by")
+	if service2.Spec.ClusterIP == "" {
+		service1.Spec.ClusterIP = ""
+	}
+	if service2.Spec.Type == "" {
+		service1.Spec.Type = ""
+	}
+	if service2.Spec.SessionAffinity == "" {
+		service1.Spec.SessionAffinity = ""
+	}
+	for _, port2 := range service2.Spec.Ports {
+		if found, port1 := findServicePort(port2, service1.Spec.Ports); found {
+			if port2.Protocol == "" {
+				port1.Protocol = ""
+			}
+		}
+	}
+
+	var pairs [][2]interface{}
+	pairs = append(pairs, [2]interface{}{service1.Name, service2.Name})
+	pairs = append(pairs, [2]interface{}{service1.Namespace, service2.Namespace})
+	pairs = append(pairs, [2]interface{}{service1.Labels, service2.Labels})
+	pairs = append(pairs, [2]interface{}{service1.Annotations, service2.Annotations})
+	pairs = append(pairs, [2]interface{}{service1.Spec, service2.Spec})
+	return EqualPairs(pairs)
+}
+
+func findServicePort(port corev1.ServicePort, ports []corev1.ServicePort) (bool, *corev1.ServicePort) {
+	for index, candidate := range ports {
+		if port.Name == candidate.Name {
+			return true, &ports[index]
+		}
+	}
+	return false, &corev1.ServicePort{}
+}
+
+func equalRoutes(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool {
+	route1 := deployed.(*routev1.Route)
+	route2 := requested.(*routev1.Route)
+	route1 = route1.DeepCopy()
+
+	//Removed generated fields from deployed version, that are not specified in requested item
+	delete(route1.GetAnnotations(), "openshift.io/host.generated")
+	if route2.Spec.Host == "" {
+		route1.Spec.Host = ""
+	}
+	if route2.Spec.To.Kind == "" {
+		route1.Spec.To.Kind = ""
+	}
+	if route2.Spec.To.Name == "" {
+		route1.Spec.To.Name = ""
+	}
+	if route2.Spec.To.Weight == nil {
+		route1.Spec.To.Weight = nil
+	}
+	if route2.Spec.WildcardPolicy == "" {
+		route1.Spec.WildcardPolicy = ""
+	}
+
+	var pairs [][2]interface{}
+	pairs = append(pairs, [2]interface{}{route1.Name, route2.Name})
+	pairs = append(pairs, [2]interface{}{route1.Namespace, route2.Namespace})
+	pairs = append(pairs, [2]interface{}{route1.Labels, route2.Labels})
+	pairs = append(pairs, [2]interface{}{route1.Annotations, route2.Annotations})
+	pairs = append(pairs, [2]interface{}{route1.Spec, route2.Spec})
+	return EqualPairs(pairs)
+}
+
+func equalRoles(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool {
+	role1 := deployed.(*rbacv1.Role)
+	role2 := requested.(*rbacv1.Role)
+	var pairs [][2]interface{}
+	pairs = append(pairs, [2]interface{}{role1.Name, role2.Name})
+	pairs = append(pairs, [2]interface{}{role1.Namespace, role2.Namespace})
+	pairs = append(pairs, [2]interface{}{role1.Labels, role2.Labels})
+	pairs = append(pairs, [2]interface{}{role1.Annotations, role2.Annotations})
+	pairs = append(pairs, [2]interface{}{role1.Rules, role2.Rules})
+	return EqualPairs(pairs)
+}
+
+func equalServiceAccounts(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool {
+	sa1 := deployed.(*corev1.ServiceAccount)
+	sa2 := requested.(*corev1.ServiceAccount)
+	var pairs [][2]interface{}
+	pairs = append(pairs, [2]interface{}{sa1.Name, sa2.Name})
+	pairs = append(pairs, [2]interface{}{sa1.Namespace, sa2.Namespace})
+	pairs = append(pairs, [2]interface{}{sa1.Labels, sa2.Labels})
+	pairs = append(pairs, [2]interface{}{sa1.Annotations, sa2.Annotations})
+	return EqualPairs(pairs)
+}
+
+func equalRoleBindings(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool {
+	binding1 := deployed.(*rbacv1.RoleBinding)
+	binding2 := requested.(*rbacv1.RoleBinding)
+	var pairs [][2]interface{}
+	pairs = append(pairs, [2]interface{}{binding1.Name, binding2.Name})
+	pairs = append(pairs, [2]interface{}{binding1.Namespace, binding2.Namespace})
+	pairs = append(pairs, [2]interface{}{binding1.Labels, binding2.Labels})
+	pairs = append(pairs, [2]interface{}{binding1.Annotations, binding2.Annotations})
+	pairs = append(pairs, [2]interface{}{binding1.Subjects, binding2.Subjects})
+	pairs = append(pairs, [2]interface{}{binding1.RoleRef.Name, binding2.RoleRef.Name})
+	return EqualPairs(pairs)
+}
+
+func equalSecrets(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool {
+	secret1 := deployed.(*corev1.Secret)
+	secret2 := requested.(*corev1.Secret)
+	var pairs [][2]interface{}
+	pairs = append(pairs, [2]interface{}{secret1.Name, secret2.Name})
+	pairs = append(pairs, [2]interface{}{secret1.Namespace, secret2.Namespace})
+	pairs = append(pairs, [2]interface{}{secret1.Labels, secret2.Labels})
+	pairs = append(pairs, [2]interface{}{secret1.Annotations, secret2.Annotations})
+	pairs = append(pairs, [2]interface{}{secret1.Data, secret2.Data})
+	pairs = append(pairs, [2]interface{}{secret1.StringData, secret2.StringData})
+	return EqualPairs(pairs)
+}
+
+func deepEquals(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool {
+	struct1 := reflect.ValueOf(deployed).Elem().Type()
+	if field1, found1 := struct1.FieldByName("Spec"); found1 {
+		struct2 := reflect.ValueOf(requested).Elem().Type()
+		if field2, found2 := struct2.FieldByName("Spec"); found2 {
+			return Equals(field1, field2)
+		}
+	}
+	return Equals(deployed, requested)
+}
+
+func EqualPairs(objects [][2]interface{}) bool {
+	for index := range objects {
+		if !Equals(objects[index][0], objects[index][1]) {
+			return false
+		}
+	}
+	return true
+}
+
+func Equals(deployed interface{}, requested interface{}) bool {
+	equal := reflect.DeepEqual(deployed, requested)
+	if !equal {
+		logger.Info("Objects are not equal", "deployed", deployed, "requested", requested)
+	}
+	return equal
+}

--- a/vendor/github.com/RHsyseng/operator-utils/pkg/resource/compare/defaults.go
+++ b/vendor/github.com/RHsyseng/operator-utils/pkg/resource/compare/defaults.go
@@ -3,9 +3,11 @@ package compare
 import (
 	"github.com/RHsyseng/operator-utils/pkg/resource"
 	oappsv1 "github.com/openshift/api/apps/v1"
+	buildv1 "github.com/openshift/api/build/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"reflect"
 )
 
@@ -51,6 +53,7 @@ func defaultMap() map[reflect.Type]func(deployed resource.KubernetesResource, re
 	equalsMap[reflect.TypeOf(rbacv1.RoleBinding{})] = equalRoleBindings
 	equalsMap[reflect.TypeOf(corev1.ServiceAccount{})] = equalServiceAccounts
 	equalsMap[reflect.TypeOf(corev1.Secret{})] = equalSecrets
+	equalsMap[reflect.TypeOf(buildv1.BuildConfig{})] = equalBuildConfigs
 	return equalsMap
 }
 
@@ -60,11 +63,17 @@ func equalDeploymentConfigs(deployed resource.KubernetesResource, requested reso
 
 	//Removed generated fields from deployed version, when not specified in requested item
 	dc1 = dc1.DeepCopy()
+	triggerBasedImage := make(map[string]bool)
 	if dc2.Spec.Strategy.RecreateParams == nil {
 		dc1.Spec.Strategy.RecreateParams = nil
 	}
 	if dc2.Spec.Strategy.ActiveDeadlineSeconds == nil {
 		dc1.Spec.Strategy.ActiveDeadlineSeconds = nil
+	}
+	if dc2.Spec.Strategy.RollingParams == nil && dc2.Spec.Strategy.Type == "" && dc1.Spec.Strategy.Type == oappsv1.DeploymentStrategyTypeRolling {
+		//This looks like a default generated strategy that should be ignored
+		dc1.Spec.Strategy.Type = ""
+		dc1.Spec.Strategy.RollingParams = nil
 	}
 	if dc1.Spec.Strategy.RollingParams != nil && dc2.Spec.Strategy.RollingParams != nil {
 		if dc2.Spec.Strategy.RollingParams.UpdatePeriodSeconds == nil {
@@ -76,13 +85,41 @@ func equalDeploymentConfigs(deployed resource.KubernetesResource, requested reso
 		if dc2.Spec.Strategy.RollingParams.TimeoutSeconds == nil {
 			dc1.Spec.Strategy.RollingParams.TimeoutSeconds = nil
 		}
+		if dc2.Spec.Strategy.RollingParams.MaxUnavailable == nil {
+			dc1.Spec.Strategy.RollingParams.MaxUnavailable = nil
+		}
+		if dc2.Spec.Strategy.RollingParams.MaxSurge == nil {
+			dc1.Spec.Strategy.RollingParams.MaxSurge = nil
+		}
 	}
 	if dc2.Spec.RevisionHistoryLimit == nil {
 		dc1.Spec.RevisionHistoryLimit = nil
 	}
+	if len(dc1.Spec.Triggers) == 1 && len(dc2.Spec.Triggers) == 0 {
+		defaultTrigger := oappsv1.DeploymentTriggerPolicy{Type: oappsv1.DeploymentTriggerOnConfigChange}
+		if dc1.Spec.Triggers[0] == defaultTrigger {
+			//Remove default generated trigger
+			dc1.Spec.Triggers = nil
+		}
+	}
+	for i := range dc1.Spec.Triggers {
+		if len(dc2.Spec.Triggers) <= i {
+			logger.Info("No matching trigger found in requested DC", "deployed.DC.trigger", dc1.Spec.Triggers[i])
+			return false
+		}
+		if dc1.Spec.Triggers[i].ImageChangeParams != nil && dc2.Spec.Triggers[i].ImageChangeParams != nil {
+			if dc2.Spec.Triggers[i].ImageChangeParams.LastTriggeredImage == "" {
+				dc1.Spec.Triggers[i].ImageChangeParams.LastTriggeredImage = ""
+			}
+			for _, containerName := range dc2.Spec.Triggers[i].ImageChangeParams.ContainerNames {
+				triggerBasedImage[containerName] = true
+			}
+		}
+	}
 	if dc1.Spec.Template != nil && dc2.Spec.Template != nil {
 		for i := range dc1.Spec.Template.Spec.Volumes {
 			if len(dc2.Spec.Template.Spec.Volumes) <= i {
+				logger.Info("No matching volume found in requested DC", "deployed.DC.volume", dc1.Spec.Template.Spec.Volumes[i])
 				return false
 			}
 			volSrc1 := dc1.Spec.Template.Spec.Volumes[i].VolumeSource
@@ -97,6 +134,7 @@ func equalDeploymentConfigs(deployed resource.KubernetesResource, requested reso
 		if dc2.Spec.Template.Spec.DNSPolicy == "" {
 			dc1.Spec.Template.Spec.DNSPolicy = ""
 		}
+		//noinspection GoDeprecation
 		if dc2.Spec.Template.Spec.DeprecatedServiceAccount == "" {
 			dc1.Spec.Template.Spec.DeprecatedServiceAccount = ""
 		}
@@ -106,50 +144,13 @@ func equalDeploymentConfigs(deployed resource.KubernetesResource, requested reso
 		if dc2.Spec.Template.Spec.SchedulerName == "" {
 			dc1.Spec.Template.Spec.SchedulerName = ""
 		}
-		for i := range dc1.Spec.Template.Spec.Containers {
-			if len(dc2.Spec.Template.Spec.Containers) <= i {
-				return false
-			}
-			probe1 := dc1.Spec.Template.Spec.Containers[i].LivenessProbe
-			probe2 := dc2.Spec.Template.Spec.Containers[i].LivenessProbe
-			if probe1 != nil && probe2 != nil {
-				if probe2.FailureThreshold == 0 {
-					probe1.FailureThreshold = probe2.FailureThreshold
-				}
-				if probe2.SuccessThreshold == 0 {
-					probe1.SuccessThreshold = probe2.SuccessThreshold
-				}
-			}
-			probe1 = dc1.Spec.Template.Spec.Containers[i].ReadinessProbe
-			probe2 = dc2.Spec.Template.Spec.Containers[i].ReadinessProbe
-			if probe1 != nil && probe2 != nil {
-				if probe2.FailureThreshold == 0 {
-					probe1.FailureThreshold = probe2.FailureThreshold
-				}
-				if probe2.SuccessThreshold == 0 {
-					probe1.SuccessThreshold = probe2.SuccessThreshold
-				}
-			}
-			if dc2.Spec.Template.Spec.Containers[i].TerminationMessagePath == "" {
-				dc1.Spec.Template.Spec.Containers[i].TerminationMessagePath = ""
-			}
-			if dc2.Spec.Template.Spec.Containers[i].TerminationMessagePolicy == "" {
-				dc1.Spec.Template.Spec.Containers[i].TerminationMessagePolicy = ""
-			}
-			for j := range dc1.Spec.Template.Spec.Containers[i].Env {
-				if len(dc2.Spec.Template.Spec.Containers[i].Env) <= j {
-					return false
-				}
-				valueFrom := dc2.Spec.Template.Spec.Containers[i].Env[j].ValueFrom
-				if valueFrom != nil && valueFrom.FieldRef != nil && valueFrom.FieldRef.APIVersion == "" {
-					valueFrom1 := dc1.Spec.Template.Spec.Containers[i].Env[j].ValueFrom
-					if valueFrom1 != nil && valueFrom1.FieldRef != nil {
-						valueFrom1.FieldRef.APIVersion = ""
-					}
-				}
-			}
+		ignoreGenerateContainerValues(dc1.Spec.Template.Spec.Containers, dc2.Spec.Template.Spec.Containers, triggerBasedImage)
+		ignoreGenerateContainerValues(dc1.Spec.Template.Spec.InitContainers, dc2.Spec.Template.Spec.InitContainers, triggerBasedImage)
+		if dc2.Spec.Template.Spec.TerminationGracePeriodSeconds == nil {
+			dc1.Spec.Template.Spec.TerminationGracePeriodSeconds = nil
 		}
 	}
+	ignoreEmptyMaps(dc1, dc2)
 
 	var pairs [][2]interface{}
 	pairs = append(pairs, [2]interface{}{dc1.Name, dc2.Name})
@@ -157,7 +158,66 @@ func equalDeploymentConfigs(deployed resource.KubernetesResource, requested reso
 	pairs = append(pairs, [2]interface{}{dc1.Labels, dc2.Labels})
 	pairs = append(pairs, [2]interface{}{dc1.Annotations, dc2.Annotations})
 	pairs = append(pairs, [2]interface{}{dc1.Spec, dc2.Spec})
-	return EqualPairs(pairs)
+	equal := EqualPairs(pairs)
+	if !equal {
+		logger.Info("Resources are not equal", "deployed", deployed, "requested", requested)
+	}
+	return equal
+}
+
+func ignoreGenerateContainerValues(containers1 []corev1.Container, containers2 []corev1.Container, triggerBasedImage map[string]bool) {
+	for i := range containers1 {
+		if len(containers2) <= i {
+			logger.Info("No matching container found in requested resource", "deployed container", containers1[i])
+			return
+		}
+		if containers2[i].ImagePullPolicy == "" && containers1[i].ImagePullPolicy == corev1.PullAlways {
+			containers1[i].ImagePullPolicy = ""
+		}
+		probes1 := []*corev1.Probe{containers1[i].LivenessProbe, containers1[i].ReadinessProbe}
+		probes2 := []*corev1.Probe{containers2[i].LivenessProbe, containers2[i].ReadinessProbe}
+		for index := range probes1 {
+			probe1 := probes1[index]
+			probe2 := probes2[index]
+			if probe1 != nil && probe2 != nil {
+				if probe2.FailureThreshold == 0 {
+					probe1.FailureThreshold = probe2.FailureThreshold
+				}
+				if probe2.SuccessThreshold == 0 {
+					probe1.SuccessThreshold = probe2.SuccessThreshold
+				}
+				if probe2.PeriodSeconds == 0 {
+					probe1.PeriodSeconds = probe2.PeriodSeconds
+				}
+				if probe2.TimeoutSeconds == 0 {
+					probe1.TimeoutSeconds = probe2.TimeoutSeconds
+				}
+			}
+		}
+		if containers2[i].TerminationMessagePath == "" {
+			containers1[i].TerminationMessagePath = ""
+		}
+		if containers2[i].TerminationMessagePolicy == "" {
+			containers1[i].TerminationMessagePolicy = ""
+		}
+		for j := range containers1[i].Env {
+			if len(containers2[i].Env) <= j {
+				return
+			}
+			valueFrom := containers2[i].Env[j].ValueFrom
+			if valueFrom != nil && valueFrom.FieldRef != nil && valueFrom.FieldRef.APIVersion == "" {
+				valueFrom1 := containers1[i].Env[j].ValueFrom
+				if valueFrom1 != nil && valueFrom1.FieldRef != nil {
+					valueFrom1.FieldRef.APIVersion = ""
+				}
+			}
+		}
+		if triggerBasedImage[containers1[i].Name] {
+			//Image is being derived from the ImageChange trigger, so this image field is auto-generated after deployment
+			containers1[i].Image = containers2[i].Image
+		}
+	}
+
 }
 
 func equalServices(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool {
@@ -186,6 +246,7 @@ func equalServices(deployed resource.KubernetesResource, requested resource.Kube
 			}
 		}
 	}
+	ignoreEmptyMaps(service1, service2)
 
 	var pairs [][2]interface{}
 	pairs = append(pairs, [2]interface{}{service1.Name, service2.Name})
@@ -193,7 +254,11 @@ func equalServices(deployed resource.KubernetesResource, requested resource.Kube
 	pairs = append(pairs, [2]interface{}{service1.Labels, service2.Labels})
 	pairs = append(pairs, [2]interface{}{service1.Annotations, service2.Annotations})
 	pairs = append(pairs, [2]interface{}{service1.Spec, service2.Spec})
-	return EqualPairs(pairs)
+	equal := EqualPairs(pairs)
+	if !equal {
+		logger.Info("Resources are not equal", "deployed", deployed, "requested", requested)
+	}
+	return equal
 }
 
 func findServicePort(port corev1.ServicePort, ports []corev1.ServicePort) (bool, *corev1.ServicePort) {
@@ -227,6 +292,7 @@ func equalRoutes(deployed resource.KubernetesResource, requested resource.Kubern
 	if route2.Spec.WildcardPolicy == "" {
 		route1.Spec.WildcardPolicy = ""
 	}
+	ignoreEmptyMaps(route1, route2)
 
 	var pairs [][2]interface{}
 	pairs = append(pairs, [2]interface{}{route1.Name, route2.Name})
@@ -234,7 +300,11 @@ func equalRoutes(deployed resource.KubernetesResource, requested resource.Kubern
 	pairs = append(pairs, [2]interface{}{route1.Labels, route2.Labels})
 	pairs = append(pairs, [2]interface{}{route1.Annotations, route2.Annotations})
 	pairs = append(pairs, [2]interface{}{route1.Spec, route2.Spec})
-	return EqualPairs(pairs)
+	equal := EqualPairs(pairs)
+	if !equal {
+		logger.Info("Resources are not equal", "deployed", deployed, "requested", requested)
+	}
+	return equal
 }
 
 func equalRoles(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool {
@@ -246,7 +316,11 @@ func equalRoles(deployed resource.KubernetesResource, requested resource.Kuberne
 	pairs = append(pairs, [2]interface{}{role1.Labels, role2.Labels})
 	pairs = append(pairs, [2]interface{}{role1.Annotations, role2.Annotations})
 	pairs = append(pairs, [2]interface{}{role1.Rules, role2.Rules})
-	return EqualPairs(pairs)
+	equal := EqualPairs(pairs)
+	if !equal {
+		logger.Info("Resources are not equal", "deployed", deployed, "requested", requested)
+	}
+	return equal
 }
 
 func equalServiceAccounts(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool {
@@ -257,7 +331,11 @@ func equalServiceAccounts(deployed resource.KubernetesResource, requested resour
 	pairs = append(pairs, [2]interface{}{sa1.Namespace, sa2.Namespace})
 	pairs = append(pairs, [2]interface{}{sa1.Labels, sa2.Labels})
 	pairs = append(pairs, [2]interface{}{sa1.Annotations, sa2.Annotations})
-	return EqualPairs(pairs)
+	equal := EqualPairs(pairs)
+	if !equal {
+		logger.Info("Resources are not equal", "deployed", deployed, "requested", requested)
+	}
+	return equal
 }
 
 func equalRoleBindings(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool {
@@ -270,7 +348,11 @@ func equalRoleBindings(deployed resource.KubernetesResource, requested resource.
 	pairs = append(pairs, [2]interface{}{binding1.Annotations, binding2.Annotations})
 	pairs = append(pairs, [2]interface{}{binding1.Subjects, binding2.Subjects})
 	pairs = append(pairs, [2]interface{}{binding1.RoleRef.Name, binding2.RoleRef.Name})
-	return EqualPairs(pairs)
+	equal := EqualPairs(pairs)
+	if !equal {
+		logger.Info("Resources are not equal", "deployed", deployed, "requested", requested)
+	}
+	return equal
 }
 
 func equalSecrets(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool {
@@ -283,7 +365,69 @@ func equalSecrets(deployed resource.KubernetesResource, requested resource.Kuber
 	pairs = append(pairs, [2]interface{}{secret1.Annotations, secret2.Annotations})
 	pairs = append(pairs, [2]interface{}{secret1.Data, secret2.Data})
 	pairs = append(pairs, [2]interface{}{secret1.StringData, secret2.StringData})
-	return EqualPairs(pairs)
+	equal := EqualPairs(pairs)
+	if !equal {
+		logger.Info("Resources are not equal", "deployed", deployed, "requested", requested)
+	}
+	return equal
+}
+
+func equalBuildConfigs(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool {
+	bc1 := deployed.(*buildv1.BuildConfig)
+	bc2 := requested.(*buildv1.BuildConfig)
+
+	//Removed generated fields from deployed version, when not specified in requested item
+	bc1 = bc1.DeepCopy()
+	bc2 = bc2.DeepCopy()
+	if bc2.Spec.RunPolicy == "" {
+		bc1.Spec.RunPolicy = ""
+	}
+	for i := range bc1.Spec.Triggers {
+		if len(bc1.Spec.Triggers) <= i {
+			return false
+		}
+		trigger1 := bc1.Spec.Triggers[i]
+		trigger2 := bc2.Spec.Triggers[i]
+		webHooks1 := []*buildv1.WebHookTrigger{trigger1.BitbucketWebHook, trigger1.GenericWebHook, trigger1.GitHubWebHook, trigger1.GitLabWebHook}
+		webHooks2 := []*buildv1.WebHookTrigger{trigger2.BitbucketWebHook, trigger2.GenericWebHook, trigger2.GitHubWebHook, trigger2.GitLabWebHook}
+		for index := range webHooks1 {
+			if webHooks1[index] != nil && webHooks2[index] != nil {
+				//noinspection GoDeprecation
+				if webHooks1[index].Secret != "" && webHooks2[index].Secret != "" {
+					webHooks1[index].Secret = ""
+					webHooks2[index].Secret = ""
+				}
+				if webHooks1[index].SecretReference != nil && webHooks2[index].SecretReference != nil {
+					webHooks1[index].SecretReference = nil
+					webHooks2[index].SecretReference = nil
+				}
+			}
+		}
+		if trigger2.ImageChange != nil && trigger1.ImageChange != nil {
+			if trigger2.ImageChange.LastTriggeredImageID == "" {
+				trigger1.ImageChange.LastTriggeredImageID = ""
+			}
+		}
+	}
+	if bc2.Spec.SuccessfulBuildsHistoryLimit == nil {
+		bc1.Spec.SuccessfulBuildsHistoryLimit = nil
+	}
+	if bc2.Spec.FailedBuildsHistoryLimit == nil {
+		bc1.Spec.FailedBuildsHistoryLimit = nil
+	}
+	ignoreEmptyMaps(bc1, bc2)
+
+	var pairs [][2]interface{}
+	pairs = append(pairs, [2]interface{}{bc1.Name, bc2.Name})
+	pairs = append(pairs, [2]interface{}{bc1.Namespace, bc2.Namespace})
+	pairs = append(pairs, [2]interface{}{bc1.Labels, bc2.Labels})
+	pairs = append(pairs, [2]interface{}{bc1.Annotations, bc2.Annotations})
+	pairs = append(pairs, [2]interface{}{bc1.Spec, bc2.Spec})
+	equal := EqualPairs(pairs)
+	if !equal {
+		logger.Info("Resources are not equal", "deployed", deployed, "requested", requested)
+	}
+	return equal
 }
 
 func deepEquals(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool {
@@ -312,4 +456,13 @@ func Equals(deployed interface{}, requested interface{}) bool {
 		logger.Info("Objects are not equal", "deployed", deployed, "requested", requested)
 	}
 	return equal
+}
+
+func ignoreEmptyMaps(deployed metav1.Object, requested metav1.Object) {
+	if requested.GetAnnotations() == nil && deployed.GetAnnotations() != nil && len(deployed.GetAnnotations()) == 0 {
+		deployed.SetAnnotations(nil)
+	}
+	if requested.GetLabels() == nil && deployed.GetLabels() != nil && len(deployed.GetLabels()) == 0 {
+		deployed.SetLabels(nil)
+	}
 }

--- a/vendor/github.com/RHsyseng/operator-utils/pkg/resource/compare/defaults_test.go
+++ b/vendor/github.com/RHsyseng/operator-utils/pkg/resource/compare/defaults_test.go
@@ -1,0 +1,58 @@
+package compare
+
+import (
+	utils "github.com/RHsyseng/operator-utils/pkg/resource/test"
+	oappsv1 "github.com/openshift/api/apps/v1"
+	routev1 "github.com/openshift/api/route/v1"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"reflect"
+	"testing"
+)
+
+func TestCompareRoutes(t *testing.T) {
+	routes := utils.GetRoutes(2)
+	routes[0].Status = routev1.RouteStatus{
+		Ingress: []routev1.RouteIngress{
+			{
+				Host: "localhost",
+			},
+		},
+	}
+	routes[1].Name = routes[0].Name
+
+	assert.False(t, reflect.DeepEqual(routes[0], routes[1]), "Inconsequential differences between two routes should make equality test fail")
+	assert.True(t, deepEquals(&routes[0], &routes[1]), "Expected resources to be deemed equal")
+	assert.True(t, equalRoutes(&routes[0], &routes[1]), "Expected resources to be deemed equal based on route comparator")
+}
+
+func TestCompareServices(t *testing.T) {
+	services := utils.GetServices(2)
+	services[0].Status = corev1.ServiceStatus{
+		LoadBalancer: corev1.LoadBalancerStatus{
+			Ingress: []corev1.LoadBalancerIngress{
+				{
+					IP:       "127.0.0.1",
+					Hostname: "localhost",
+				},
+			},
+		},
+	}
+	services[1].Name = services[0].Name
+
+	assert.False(t, reflect.DeepEqual(services[0], services[1]), "Inconsequential differences between two services should make equality test fail")
+	assert.True(t, deepEquals(&services[0], &services[1]), "Expected resources to be deemed equal")
+	assert.True(t, equalServices(&services[0], &services[1]), "Expected resources to be deemed equal based on service comparator")
+}
+
+func TestCompareDeploymentConfigs(t *testing.T) {
+	dcs := utils.GetDeploymentConfigs(2)
+	dcs[1].Name = dcs[0].Name
+	dcs[1].Status = oappsv1.DeploymentConfigStatus{
+		ReadyReplicas: 1,
+	}
+
+	assert.False(t, reflect.DeepEqual(dcs[0], dcs[1]), "Inconsequential differences between two DCs should make equality test fail")
+	assert.True(t, deepEquals(&dcs[0], &dcs[1]), "Expected resources to be deemed equal")
+	assert.True(t, equalDeploymentConfigs(&dcs[0], &dcs[1]), "Expected resources to be deemed equal based on DC comparator")
+}

--- a/vendor/github.com/RHsyseng/operator-utils/pkg/resource/compare/defaults_test.go
+++ b/vendor/github.com/RHsyseng/operator-utils/pkg/resource/compare/defaults_test.go
@@ -3,6 +3,7 @@ package compare
 import (
 	utils "github.com/RHsyseng/operator-utils/pkg/resource/test"
 	oappsv1 "github.com/openshift/api/apps/v1"
+	obuildv1 "github.com/openshift/api/build/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -55,4 +56,111 @@ func TestCompareDeploymentConfigs(t *testing.T) {
 	assert.False(t, reflect.DeepEqual(dcs[0], dcs[1]), "Inconsequential differences between two DCs should make equality test fail")
 	assert.True(t, deepEquals(&dcs[0], &dcs[1]), "Expected resources to be deemed equal")
 	assert.True(t, equalDeploymentConfigs(&dcs[0], &dcs[1]), "Expected resources to be deemed equal based on DC comparator")
+}
+
+func TestCompareEmptyAnnotations(t *testing.T) {
+	routes := utils.GetRoutes(2)
+	routes[1].Name = routes[0].Name
+	routes[0].Annotations = make(map[string]string)
+	routes[0].Annotations["openshift.io/host.generated"] = "true"
+	routes[1].Annotations = nil
+	assert.True(t, equalRoutes(&routes[0], &routes[1]), "Routes should be considered equal")
+}
+
+func TestCompareDeploymentConfigLastTriggeredImage(t *testing.T) {
+	dcs := utils.GetDeploymentConfigs(2)
+	dcs[1].Name = dcs[0].Name
+	dcs[0].Spec.Triggers = []oappsv1.DeploymentTriggerPolicy{
+		{
+			ImageChangeParams: &oappsv1.DeploymentTriggerImageChangeParams{
+				Automatic:          false,
+				ContainerNames:     nil,
+				From:               corev1.ObjectReference{},
+				LastTriggeredImage: "some generated value",
+			},
+		},
+	}
+	dcs[1].Spec.Triggers = []oappsv1.DeploymentTriggerPolicy{
+		{
+			ImageChangeParams: &oappsv1.DeploymentTriggerImageChangeParams{
+				Automatic:      false,
+				ContainerNames: nil,
+				From:           corev1.ObjectReference{},
+			},
+		},
+	}
+	assert.True(t, equalDeploymentConfigs(&dcs[0], &dcs[1]), "Expected resources to be deemed equal based on DC comparator")
+}
+
+func TestCompareDeploymentConfigImageChange(t *testing.T) {
+	dcs := utils.GetDeploymentConfigs(2)
+	dcs[1].Name = dcs[0].Name
+	dcs[0].Spec.Triggers = []oappsv1.DeploymentTriggerPolicy{
+		{
+			ImageChangeParams: &oappsv1.DeploymentTriggerImageChangeParams{
+				Automatic: false,
+				ContainerNames: []string{
+					"container1",
+					"container2",
+				},
+				From: corev1.ObjectReference{
+					Kind:      "ImageStreamTag",
+					Namespace: "namespace",
+					Name:      "image",
+				},
+			},
+		},
+	}
+	dcs[0].Spec.Template.Spec.Containers = []corev1.Container{
+		{
+			Name:  "container1",
+			Image: "some generated value",
+		},
+	}
+	dcs[1].Spec.Triggers = []oappsv1.DeploymentTriggerPolicy{
+		{
+			ImageChangeParams: &oappsv1.DeploymentTriggerImageChangeParams{
+				Automatic: false,
+				ContainerNames: []string{
+					"container1",
+					"container2",
+				},
+				From: corev1.ObjectReference{
+					Kind:      "ImageStreamTag",
+					Namespace: "namespace",
+					Name:      "image",
+				},
+			},
+		},
+	}
+	dcs[1].Spec.Template.Spec.Containers = []corev1.Container{
+		{
+			Name:  "container1",
+			Image: "image",
+		},
+	}
+	assert.True(t, equalDeploymentConfigs(&dcs[0], &dcs[1]), "Expected resources to be deemed equal based on DC comparator")
+}
+
+func TestCompareBuildConfigWebHooks(t *testing.T) {
+	bcs := utils.GetBuildConfigs(2)
+	bcs[1].Name = bcs[0].Name
+	bcs[0].Spec.RunPolicy = obuildv1.BuildRunPolicySerial
+	bcs[0].Spec.Triggers = []obuildv1.BuildTriggerPolicy{
+		{
+			GitLabWebHook: &obuildv1.WebHookTrigger{
+				AllowEnv:        false,
+				SecretReference: &obuildv1.SecretLocalReference{Name: "dafsaf"},
+			},
+		},
+	}
+	bcs[1].Spec.Triggers = []obuildv1.BuildTriggerPolicy{
+		{
+			GitLabWebHook: &obuildv1.WebHookTrigger{
+				AllowEnv:        false,
+				SecretReference: &obuildv1.SecretLocalReference{Name: "eqwrer"},
+			},
+		},
+	}
+	assert.True(t, equalBuildConfigs(&bcs[0], &bcs[1]), "Expected resources to be deemed equal based on BC comparator")
 }

--- a/vendor/github.com/RHsyseng/operator-utils/pkg/resource/compare/map.go
+++ b/vendor/github.com/RHsyseng/operator-utils/pkg/resource/compare/map.go
@@ -1,0 +1,68 @@
+package compare
+
+import (
+	"github.com/RHsyseng/operator-utils/pkg/resource"
+	"reflect"
+	logs "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+var logger = logs.Log.WithName("comparator")
+
+type MapComparator struct {
+	Comparator ResourceComparator
+}
+
+func NewMapComparator() MapComparator {
+	return MapComparator{
+		Comparator: DefaultComparator(),
+	}
+}
+
+func (this *MapComparator) Compare(deployed map[reflect.Type][]resource.KubernetesResource, requested map[reflect.Type][]resource.KubernetesResource) map[reflect.Type]ResourceDelta {
+	delta := make(map[reflect.Type]ResourceDelta)
+	for deployedType, deployedArray := range deployed {
+		requestedArray := requested[deployedType]
+		delta[deployedType] = this.compareArrays(deployedType, deployedArray, requestedArray)
+	}
+	for requestedType, requestedArray := range requested {
+		if _, ok := deployed[requestedType]; !ok {
+			//Item type in request does not exist in deployed set, needs to be added:
+			delta[requestedType] = ResourceDelta{Added: requestedArray}
+		}
+	}
+	return delta
+}
+
+func (this *MapComparator) compareArrays(resourceType reflect.Type, deployed []resource.KubernetesResource, requested []resource.KubernetesResource) ResourceDelta {
+	deployedMap := getObjectMap(deployed)
+	requestedMap := getObjectMap(requested)
+	var added []resource.KubernetesResource
+	var updated []resource.KubernetesResource
+	var removed []resource.KubernetesResource
+	for name, requestedObject := range requestedMap {
+		deployedObject := deployedMap[name]
+		if deployedObject == nil {
+			added = append(added, requestedObject)
+		} else if !this.Comparator.Compare(deployedObject, requestedObject) {
+			updated = append(updated, requestedObject)
+		}
+	}
+	for name, deployedObject := range deployedMap {
+		if requestedMap[name] == nil {
+			removed = append(removed, deployedObject)
+		}
+	}
+	return ResourceDelta{
+		Added:   added,
+		Updated: updated,
+		Removed: removed,
+	}
+}
+
+func getObjectMap(objects []resource.KubernetesResource) map[string]resource.KubernetesResource {
+	objectMap := make(map[string]resource.KubernetesResource)
+	for index := range objects {
+		objectMap[objects[index].GetName()] = objects[index]
+	}
+	return objectMap
+}

--- a/vendor/github.com/RHsyseng/operator-utils/pkg/resource/compare/test/external_test.go
+++ b/vendor/github.com/RHsyseng/operator-utils/pkg/resource/compare/test/external_test.go
@@ -1,0 +1,117 @@
+package test
+
+import (
+	"github.com/RHsyseng/operator-utils/pkg/resource"
+	"github.com/RHsyseng/operator-utils/pkg/resource/compare"
+	"github.com/RHsyseng/operator-utils/pkg/resource/test"
+	oappsv1 "github.com/openshift/api/apps/v1"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"reflect"
+	"testing"
+)
+
+func TestCompareServices(t *testing.T) {
+	svcs := test.GetServices(2)
+	svcs[0].Status = corev1.ServiceStatus{
+		LoadBalancer: corev1.LoadBalancerStatus{
+			Ingress: []corev1.LoadBalancerIngress{
+				{
+					IP:       "127.0.0.1",
+					Hostname: "localhost",
+				},
+			},
+		},
+	}
+	svcs[1].Name = svcs[0].Name
+
+	assert.False(t, reflect.DeepEqual(svcs[0], svcs[1]), "Inconsequential differences between two services should make equality test fail")
+	assert.True(t, compare.SimpleComparator().Compare(&svcs[0], &svcs[1]), "Expected resources to be deemed equal")
+	assert.True(t, compare.DefaultComparator().Compare(&svcs[0], &svcs[1]), "Expected resources to be deemed equal based on service comparator")
+}
+
+func TestCompareDeploymentConfigs(t *testing.T) {
+	dcs := test.GetDeploymentConfigs(2)
+	dcs[1].Name = dcs[0].Name
+	dcs[1].Status = oappsv1.DeploymentConfigStatus{
+		ReadyReplicas: 1,
+	}
+
+	assert.False(t, reflect.DeepEqual(dcs[0], dcs[1]), "Inconsequential differences between two DCs should make equality test fail")
+	assert.True(t, compare.SimpleComparator().Compare(&dcs[0], &dcs[1]), "Expected resources to be deemed equal")
+	assert.True(t, compare.DefaultComparator().Compare(&dcs[0], &dcs[1]), "Expected resources to be deemed equal based on DC comparator")
+}
+
+func TestCompareCombined(t *testing.T) {
+	dcs := test.GetDeploymentConfigs(6)
+	dc1a := dcs[0]
+	dc1b := dcs[1]
+	dc2a := dcs[2]
+	dc2b := dcs[3]
+	dc3a := dcs[4]
+	dc4b := dcs[5]
+	dc1a.Name = "dc1"
+	dc1b.Name = "dc1"
+	dc2a.Name = "dc2"
+	dc2b.Name = "dc2"
+	dc3a.Name = "dc3"
+	dc4b.Name = "dc4"
+	dc1b.Status = oappsv1.DeploymentConfigStatus{
+		Replicas: 2,
+	}
+	dc2b.Spec.Replicas = 2
+
+	svcs := test.GetServices(6)
+	service1a := svcs[0]
+	service1b := svcs[1]
+	service2a := svcs[2]
+	service2b := svcs[3]
+	service3a := svcs[4]
+	service4b := svcs[5]
+	service1a.Name = "service1"
+	service1b.Name = "service1"
+	service2a.Name = "service2"
+	service2b.Name = "service2"
+	service3a.Name = "service3"
+	service4b.Name = "service4"
+	service1b.Status = corev1.ServiceStatus{
+		LoadBalancer: corev1.LoadBalancerStatus{
+			Ingress: []corev1.LoadBalancerIngress{
+				{
+					IP:       "127.0.0.1",
+					Hostname: "localhost",
+				},
+			},
+		},
+	}
+	service2b.Spec = corev1.ServiceSpec{
+		ClusterIP: "127.0.0.1",
+	}
+
+	serviceType := reflect.TypeOf(corev1.Service{})
+	dcType := reflect.TypeOf(oappsv1.DeploymentConfig{})
+	deployed := map[reflect.Type][]resource.KubernetesResource{
+		dcType:      {&dc1a, &dc2a, &dc3a},
+		serviceType: {&service1a, &service2a, &service3a},
+	}
+	requested := map[reflect.Type][]resource.KubernetesResource{
+		dcType:      {&dc1b, &dc2b, &dc4b},
+		serviceType: {&service1b, &service2b, &service4b},
+	}
+
+	mapComparator := compare.NewMapComparator()
+	deltaMap := mapComparator.Compare(deployed, requested)
+
+	assert.Len(t, deltaMap[serviceType].Added, 1, "Expected 1 added service")
+	assert.Equal(t, deltaMap[serviceType].Added[0].GetName(), "service4", "Expected added service called service4")
+	assert.Len(t, deltaMap[serviceType].Updated, 1, "Expected 1 updated service")
+	assert.Equal(t, deltaMap[serviceType].Updated[0].GetName(), "service2", "Expected added service called service2")
+	assert.Len(t, deltaMap[serviceType].Removed, 1, "Expected 1 removed service")
+	assert.Equal(t, deltaMap[serviceType].Removed[0].GetName(), "service3", "Expected added service called service3")
+	assert.Len(t, deltaMap[dcType].Added, 1, "Expected 1 added dc")
+	assert.Equal(t, deltaMap[dcType].Added[0].GetName(), "dc4", "Expected added dc called dc4")
+	assert.Len(t, deltaMap[dcType].Updated, 1, "Expected 1 updated dc")
+	assert.Equal(t, deltaMap[dcType].Updated[0].GetName(), "dc2", "Expected updated dc called dc2")
+	assert.Len(t, deltaMap[dcType].Removed, 1, "Expected 1 removed dc")
+	assert.Equal(t, deltaMap[dcType].Removed[0].GetName(), "dc3", "Expected removed dc called dc3")
+}

--- a/vendor/github.com/RHsyseng/operator-utils/pkg/resource/compare/test/utils_test.go
+++ b/vendor/github.com/RHsyseng/operator-utils/pkg/resource/compare/test/utils_test.go
@@ -22,3 +22,13 @@ func TestMapBuilder(t *testing.T) {
 	assert.Len(t, resMap[reflect.TypeOf(corev1.Service{})], 1, "Expect map to have 1 service")
 	assert.Len(t, resMap[reflect.TypeOf(oappsv1.DeploymentConfig{})], 1, "Expect map to have 1 deployment config")
 }
+
+func TestNilResources(t *testing.T) {
+	mapBuilder := compare.NewMapBuilder()
+	mapBuilder.Add(nil)
+	assert.Len(t, mapBuilder.ResourceMap(), 0, "Expect map to have zero entries")
+	dcPtr := &oappsv1.DeploymentConfig{}
+	dcPtr = nil
+	mapBuilder.Add(dcPtr)
+	assert.Len(t, mapBuilder.ResourceMap(), 0, "Expect map to have zero entries")
+}

--- a/vendor/github.com/RHsyseng/operator-utils/pkg/resource/compare/test/utils_test.go
+++ b/vendor/github.com/RHsyseng/operator-utils/pkg/resource/compare/test/utils_test.go
@@ -2,17 +2,23 @@ package test
 
 import (
 	"github.com/RHsyseng/operator-utils/pkg/resource/compare"
+	oappsv1 "github.com/openshift/api/apps/v1"
+	routev1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"reflect"
 	"testing"
 )
 
 func TestEmptyArray(t *testing.T) {
 	builder := compare.NewMapBuilder()
-	assert.Empty(t, builder.Map(), "Expected empty map")
+	assert.Empty(t, builder.ResourceMap(), "Expected empty map")
 }
 
-//
-//func TestSameTypeItems(t *testing.T) {
-//	builder := compare.NewMapBuilder()
-//
-//}
+func TestMapBuilder(t *testing.T) {
+	resMap := compare.NewMapBuilder().Add(&routev1.Route{}, &routev1.Route{}, &corev1.Service{}).Add(&oappsv1.DeploymentConfig{}).ResourceMap()
+	assert.Len(t, resMap, 3, "Expect map to have 3 entries")
+	assert.Len(t, resMap[reflect.TypeOf(routev1.Route{})], 2, "Expect map to have 2 routes")
+	assert.Len(t, resMap[reflect.TypeOf(corev1.Service{})], 1, "Expect map to have 1 service")
+	assert.Len(t, resMap[reflect.TypeOf(oappsv1.DeploymentConfig{})], 1, "Expect map to have 1 deployment config")
+}

--- a/vendor/github.com/RHsyseng/operator-utils/pkg/resource/compare/test/utils_test.go
+++ b/vendor/github.com/RHsyseng/operator-utils/pkg/resource/compare/test/utils_test.go
@@ -1,0 +1,18 @@
+package test
+
+import (
+	"github.com/RHsyseng/operator-utils/pkg/resource/compare"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestEmptyArray(t *testing.T) {
+	builder := compare.NewMapBuilder()
+	assert.Empty(t, builder.Map(), "Expected empty map")
+}
+
+//
+//func TestSameTypeItems(t *testing.T) {
+//	builder := compare.NewMapBuilder()
+//
+//}

--- a/vendor/github.com/RHsyseng/operator-utils/pkg/resource/compare/types.go
+++ b/vendor/github.com/RHsyseng/operator-utils/pkg/resource/compare/types.go
@@ -11,6 +11,19 @@ type ResourceDelta struct {
 	Removed []resource.KubernetesResource
 }
 
+func (delta *ResourceDelta) HasChanges() bool {
+	if len(delta.Added) > 0 {
+		return true
+	}
+	if len(delta.Updated) > 0 {
+		return true
+	}
+	if len(delta.Removed) > 0 {
+		return true
+	}
+	return false
+}
+
 type ResourceComparator interface {
 	SetDefaultComparator(compFunc func(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool)
 	GetDefaultComparator() func(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool

--- a/vendor/github.com/RHsyseng/operator-utils/pkg/resource/compare/types.go
+++ b/vendor/github.com/RHsyseng/operator-utils/pkg/resource/compare/types.go
@@ -1,0 +1,34 @@
+package compare
+
+import (
+	"github.com/RHsyseng/operator-utils/pkg/resource"
+	"reflect"
+)
+
+type ResourceDelta struct {
+	Added   []resource.KubernetesResource
+	Updated []resource.KubernetesResource
+	Removed []resource.KubernetesResource
+}
+
+type ResourceComparator interface {
+	SetDefaultComparator(compFunc func(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool)
+	GetDefaultComparator() func(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool
+	SetComparator(resourceType reflect.Type, compFunc func(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool)
+	GetComparator(resourceType reflect.Type) func(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool
+	Compare(deployed resource.KubernetesResource, requested resource.KubernetesResource) bool
+}
+
+func DefaultComparator() ResourceComparator {
+	return &resourceComparator{
+		deepEquals,
+		defaultMap(),
+	}
+}
+
+func SimpleComparator() ResourceComparator {
+	return &resourceComparator{
+		deepEquals,
+		make(map[reflect.Type]func(resource.KubernetesResource, resource.KubernetesResource) bool),
+	}
+}

--- a/vendor/github.com/RHsyseng/operator-utils/pkg/resource/compare/utils.go
+++ b/vendor/github.com/RHsyseng/operator-utils/pkg/resource/compare/utils.go
@@ -20,6 +20,9 @@ func (this *mapBuilder) ResourceMap() map[reflect.Type][]resource.KubernetesReso
 
 func (this *mapBuilder) Add(resources ...resource.KubernetesResource) *mapBuilder {
 	for index := range resources {
+		if resources[index] == nil || reflect.ValueOf(resources[index]).IsNil() {
+			continue
+		}
 		resourceType := reflect.ValueOf(resources[index]).Elem().Type()
 		this.resourceMap[resourceType] = append(this.resourceMap[resourceType], resources[index])
 	}

--- a/vendor/github.com/RHsyseng/operator-utils/pkg/resource/compare/utils.go
+++ b/vendor/github.com/RHsyseng/operator-utils/pkg/resource/compare/utils.go
@@ -14,28 +14,14 @@ func NewMapBuilder() *mapBuilder {
 	return this
 }
 
-func (this *mapBuilder) Map() map[reflect.Type][]resource.KubernetesResource {
+func (this *mapBuilder) ResourceMap() map[reflect.Type][]resource.KubernetesResource {
 	return this.resourceMap
 }
 
-func (this *mapBuilder) SameTypeItems(items ...resource.KubernetesResource) *mapBuilder {
-	if len(items) == 0 {
-		return this
+func (this *mapBuilder) Add(resources ...resource.KubernetesResource) *mapBuilder {
+	for index := range resources {
+		resourceType := reflect.ValueOf(resources[index]).Elem().Type()
+		this.resourceMap[resourceType] = append(this.resourceMap[resourceType], resources[index])
 	}
-	resourceType := reflect.ValueOf(items[0]).Elem().Type()
-	this.resourceMap[resourceType] = append(this.resourceMap[resourceType], items...)
-	return this
-}
-
-func (this *mapBuilder) DisparateTypeItems(items ...resource.KubernetesResource) *mapBuilder {
-	for index := range items {
-		this.Item(items[index])
-	}
-	return this
-}
-
-func (this *mapBuilder) Item(item resource.KubernetesResource) *mapBuilder {
-	resourceType := reflect.ValueOf(item).Elem().Type()
-	this.resourceMap[resourceType] = append(this.resourceMap[resourceType], item)
 	return this
 }

--- a/vendor/github.com/RHsyseng/operator-utils/pkg/resource/compare/utils.go
+++ b/vendor/github.com/RHsyseng/operator-utils/pkg/resource/compare/utils.go
@@ -1,0 +1,41 @@
+package compare
+
+import (
+	"github.com/RHsyseng/operator-utils/pkg/resource"
+	"reflect"
+)
+
+type mapBuilder struct {
+	resourceMap map[reflect.Type][]resource.KubernetesResource
+}
+
+func NewMapBuilder() *mapBuilder {
+	this := &mapBuilder{resourceMap: make(map[reflect.Type][]resource.KubernetesResource)}
+	return this
+}
+
+func (this *mapBuilder) Map() map[reflect.Type][]resource.KubernetesResource {
+	return this.resourceMap
+}
+
+func (this *mapBuilder) SameTypeItems(items ...resource.KubernetesResource) *mapBuilder {
+	if len(items) == 0 {
+		return this
+	}
+	resourceType := reflect.ValueOf(items[0]).Elem().Type()
+	this.resourceMap[resourceType] = append(this.resourceMap[resourceType], items...)
+	return this
+}
+
+func (this *mapBuilder) DisparateTypeItems(items ...resource.KubernetesResource) *mapBuilder {
+	for index := range items {
+		this.Item(items[index])
+	}
+	return this
+}
+
+func (this *mapBuilder) Item(item resource.KubernetesResource) *mapBuilder {
+	resourceType := reflect.ValueOf(item).Elem().Type()
+	this.resourceMap[resourceType] = append(this.resourceMap[resourceType], item)
+	return this
+}

--- a/vendor/github.com/RHsyseng/operator-utils/pkg/resource/test/utils.go
+++ b/vendor/github.com/RHsyseng/operator-utils/pkg/resource/test/utils.go
@@ -3,6 +3,7 @@ package test
 import (
 	"fmt"
 	oappsv1 "github.com/openshift/api/apps/v1"
+	buildv1 "github.com/openshift/api/build/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -42,13 +43,25 @@ func GetDeploymentConfigs(count int) []oappsv1.DeploymentConfig {
 		dc := oappsv1.DeploymentConfig{
 			TypeMeta:   metav1.TypeMeta{},
 			ObjectMeta: metav1.ObjectMeta{},
-			Spec:       oappsv1.DeploymentConfigSpec{},
+			Spec: oappsv1.DeploymentConfigSpec{
+				Template: &corev1.PodTemplateSpec{},
+			},
 			Status: oappsv1.DeploymentConfigStatus{
 				ReadyReplicas: 0,
 			},
 		}
 		dc.Name = fmt.Sprintf("%s%d", "dc", (i + 1))
 		slice = append(slice, dc)
+	}
+	return slice
+}
+
+func GetBuildConfigs(count int) []buildv1.BuildConfig {
+	var slice []buildv1.BuildConfig
+	for i := 0; i < count; i++ {
+		bc := buildv1.BuildConfig{}
+		bc.Name = fmt.Sprintf("%s%d", "bc", (i + 1))
+		slice = append(slice, bc)
 	}
 	return slice
 }

--- a/vendor/github.com/RHsyseng/operator-utils/pkg/resource/test/utils.go
+++ b/vendor/github.com/RHsyseng/operator-utils/pkg/resource/test/utils.go
@@ -1,0 +1,54 @@
+package test
+
+import (
+	"fmt"
+	oappsv1 "github.com/openshift/api/apps/v1"
+	routev1 "github.com/openshift/api/route/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func GetRoutes(count int) []routev1.Route {
+	var slice []routev1.Route
+	for i := 0; i < count; i++ {
+		rte := routev1.Route{
+			TypeMeta: metav1.TypeMeta{},
+			Spec:     routev1.RouteSpec{},
+			Status:   routev1.RouteStatus{},
+		}
+		rte.Name = fmt.Sprintf("%s%d", "rte", (i + 1))
+		slice = append(slice, rte)
+	}
+	return slice
+}
+
+func GetServices(count int) []corev1.Service {
+	var slice []corev1.Service
+	for i := 0; i < count; i++ {
+		svc := corev1.Service{
+			TypeMeta: metav1.TypeMeta{},
+			Spec:     corev1.ServiceSpec{},
+			Status:   corev1.ServiceStatus{},
+		}
+		svc.Name = fmt.Sprintf("%s%d", "svc", (i + 1))
+		slice = append(slice, svc)
+	}
+	return slice
+}
+
+func GetDeploymentConfigs(count int) []oappsv1.DeploymentConfig {
+	var slice []oappsv1.DeploymentConfig
+	for i := 0; i < count; i++ {
+		dc := oappsv1.DeploymentConfig{
+			TypeMeta:   metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{},
+			Spec:       oappsv1.DeploymentConfigSpec{},
+			Status: oappsv1.DeploymentConfigStatus{
+				ReadyReplicas: 0,
+			},
+		}
+		dc.Name = fmt.Sprintf("%s%d", "dc", (i + 1))
+		slice = append(slice, dc)
+	}
+	return slice
+}

--- a/vendor/github.com/RHsyseng/operator-utils/pkg/resource/test/utils_test.go
+++ b/vendor/github.com/RHsyseng/operator-utils/pkg/resource/test/utils_test.go
@@ -1,0 +1,15 @@
+package test
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestDeploymentConfigGeneration(t *testing.T) {
+	dcs := GetDeploymentConfigs(3)
+	assert.Len(t, dcs, 3, "Expected 3 DCs in the array")
+	for i := 0; i < len(dcs); i++ {
+		assert.Equal(t, fmt.Sprintf("%s%d", "dc", (i+1)), dcs[i].Name, "DeploymentConfig name does not have the expected value")
+	}
+}

--- a/vendor/github.com/RHsyseng/operator-utils/pkg/resource/types.go
+++ b/vendor/github.com/RHsyseng/operator-utils/pkg/resource/types.go
@@ -1,0 +1,11 @@
+package resource
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type KubernetesResource interface {
+	metav1.Object
+	runtime.Object
+}

--- a/vendor/github.com/RHsyseng/operator-utils/pkg/resource/types_test.go
+++ b/vendor/github.com/RHsyseng/operator-utils/pkg/resource/types_test.go
@@ -1,0 +1,21 @@
+package resource
+
+import (
+	oappsv1 "github.com/openshift/api/apps/v1"
+	routev1 "github.com/openshift/api/route/v1"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"testing"
+)
+
+func TestInterfaceAssignability(t *testing.T) {
+	assert.True(t, isAssignable(&routev1.Route{}), "Expected Route to implement KubernetesResource")
+	assert.True(t, isAssignable(&corev1.Service{}), "Expected Service to implement KubernetesResource")
+	assert.False(t, isAssignable(&corev1.Volume{}), "Expected Volume to NOT implement KubernetesResource")
+	assert.True(t, isAssignable(&oappsv1.DeploymentConfig{}), "Expected DeploymentConfig to implement KubernetesResource")
+}
+
+func isAssignable(object interface{}) bool {
+	_, assignable := interface{}(object).(KubernetesResource)
+	return assignable
+}

--- a/vendor/github.com/RHsyseng/operator-utils/pkg/resource/write/hooks/update_hooks.go
+++ b/vendor/github.com/RHsyseng/operator-utils/pkg/resource/write/hooks/update_hooks.go
@@ -1,0 +1,50 @@
+package hooks
+
+import (
+	"github.com/RHsyseng/operator-utils/pkg/resource"
+	corev1 "k8s.io/api/core/v1"
+	"reflect"
+)
+
+type hookFunc = func(existing resource.KubernetesResource, requested resource.KubernetesResource) error
+
+type UpdateHookMap struct {
+	DefaultHook hookFunc
+	HookMap     map[reflect.Type]hookFunc
+}
+
+func DefaultUpdateHooks() *UpdateHookMap {
+	hookMap := make(map[reflect.Type]func(existing resource.KubernetesResource, requested resource.KubernetesResource) error)
+	hookMap[reflect.TypeOf(corev1.Service{})] = serviceHook
+	return &UpdateHookMap{
+		DefaultHook: defaultHook,
+		HookMap:     hookMap,
+	}
+}
+
+func (this *UpdateHookMap) Trigger(existing resource.KubernetesResource, requested resource.KubernetesResource) error {
+	function := this.HookMap[reflect.ValueOf(existing).Elem().Type()]
+	if function == nil {
+		function = this.DefaultHook
+	}
+	return function(existing, requested)
+}
+
+func defaultHook(existing resource.KubernetesResource, requested resource.KubernetesResource) error {
+	requested.SetResourceVersion(existing.GetResourceVersion())
+	requested.GetObjectKind().SetGroupVersionKind(existing.GetObjectKind().GroupVersionKind())
+	return nil
+}
+
+func serviceHook(existing resource.KubernetesResource, requested resource.KubernetesResource) error {
+	existingService := existing.(*corev1.Service)
+	requestedService := requested.(*corev1.Service)
+	if requestedService.Spec.ClusterIP == "" {
+		requestedService.Spec.ClusterIP = existingService.Spec.ClusterIP
+	}
+	err := defaultHook(existing, requested)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/vendor/github.com/RHsyseng/operator-utils/pkg/resource/write/writer.go
+++ b/vendor/github.com/RHsyseng/operator-utils/pkg/resource/write/writer.go
@@ -23,11 +23,12 @@ func AddResources(owner resource.KubernetesResource, scheme *runtime.Scheme, wri
 		if err != nil {
 			return added, err
 		}
+		added = true
 	}
 	return added, nil
 }
 
-// AddResources finds the updated counterpart for each of the provided resources in the existing array and uses it to set resource version and GVK
+// UpdateResources finds the updated counterpart for each of the provided resources in the existing array and uses it to set resource version and GVK
 // It also sets ownership to the provided owner, and then uses the writer to update them
 // the boolean result is true if any changes were made
 func UpdateResources(owner resource.KubernetesResource, existing []resource.KubernetesResource, scheme *runtime.Scheme, writer clientv1.Writer, resources []resource.KubernetesResource) (bool, error) {
@@ -54,6 +55,7 @@ func UpdateResources(owner resource.KubernetesResource, existing []resource.Kube
 		if err != nil {
 			return updated, err
 		}
+		updated = true
 	}
 	return updated, nil
 }
@@ -67,6 +69,7 @@ func RemoveResources(writer clientv1.Writer, resources []resource.KubernetesReso
 		if err != nil {
 			return removed, err
 		}
+		removed = true
 	}
 	return removed, nil
 }

--- a/vendor/github.com/RHsyseng/operator-utils/pkg/resource/write/writer.go
+++ b/vendor/github.com/RHsyseng/operator-utils/pkg/resource/write/writer.go
@@ -1,0 +1,72 @@
+package write
+
+import (
+	"context"
+	"github.com/RHsyseng/operator-utils/pkg/resource"
+	newerror "github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientv1 "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// AddResources sets ownership for provided resources to the provided owner, and then uses the writer to create them
+// the boolean result is true if any changes were made
+func AddResources(owner resource.KubernetesResource, scheme *runtime.Scheme, writer clientv1.Writer, resources []resource.KubernetesResource) (bool, error) {
+	var added bool
+	for index := range resources {
+		requested := resources[index]
+		err := controllerutil.SetControllerReference(owner, requested, scheme)
+		if err != nil {
+			return added, err
+		}
+		err = writer.Create(context.TODO(), requested)
+		if err != nil {
+			return added, err
+		}
+	}
+	return added, nil
+}
+
+// AddResources finds the updated counterpart for each of the provided resources in the existing array and uses it to set resource version and GVK
+// It also sets ownership to the provided owner, and then uses the writer to update them
+// the boolean result is true if any changes were made
+func UpdateResources(owner resource.KubernetesResource, existing []resource.KubernetesResource, scheme *runtime.Scheme, writer clientv1.Writer, resources []resource.KubernetesResource) (bool, error) {
+	var updated bool
+	for index := range resources {
+		requested := resources[index]
+		var counterpart resource.KubernetesResource
+		for _, candidate := range existing {
+			if candidate.GetNamespace() == requested.GetNamespace() && candidate.GetName() == requested.GetName() {
+				counterpart = candidate
+				break
+			}
+		}
+		if counterpart == nil {
+			return updated, newerror.New("Failed to find a deployed counterpart to resource being updated")
+		}
+		requested.SetResourceVersion(counterpart.GetResourceVersion())
+		requested.GetObjectKind().SetGroupVersionKind(counterpart.GetObjectKind().GroupVersionKind())
+		err := controllerutil.SetControllerReference(owner, requested, scheme)
+		if err != nil {
+			return updated, err
+		}
+		err = writer.Update(context.TODO(), requested)
+		if err != nil {
+			return updated, err
+		}
+	}
+	return updated, nil
+}
+
+// RemoveResources removes each of the provided resources using the provided writer
+// the boolean result is true if any changes were made
+func RemoveResources(writer clientv1.Writer, resources []resource.KubernetesResource) (bool, error) {
+	var removed bool
+	for index := range resources {
+		err := writer.Delete(context.TODO(), resources[index])
+		if err != nil {
+			return removed, err
+		}
+	}
+	return removed, nil
+}

--- a/vendor/github.com/RHsyseng/operator-utils/pkg/resource/write/writer_test.go
+++ b/vendor/github.com/RHsyseng/operator-utils/pkg/resource/write/writer_test.go
@@ -1,0 +1,22 @@
+package write
+
+import (
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestFluentAPI(t *testing.T) {
+	noOwnership := New()
+	assert.Nil(t, noOwnership.ownerRefs, "Do not expect ownerRefs to be set")
+	assert.Nil(t, noOwnership.ownerController, "Do not expect ownerController to be set")
+
+	ownerRefs := New().WithOwnerController(&corev1.Service{})
+	assert.Nil(t, ownerRefs.ownerRefs, "Do not expect ownerRefs to be set")
+	assert.NotNil(t, ownerRefs.ownerController, "Expect ownerController to be set")
+
+	controler := New().WithOwnerReferences(v1.OwnerReference{})
+	assert.NotNil(t, controler.ownerRefs, "Expect ownerRefs to be set")
+	assert.Nil(t, controler.ownerController, "Do not expect ownerController to be set")
+}

--- a/vendor/github.com/RHsyseng/operator-utils/pkg/resource/write/writer_test.go
+++ b/vendor/github.com/RHsyseng/operator-utils/pkg/resource/write/writer_test.go
@@ -1,9 +1,14 @@
 package write
 
 import (
+	"context"
+	"github.com/RHsyseng/operator-utils/pkg/resource"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"testing"
 )
 
@@ -19,4 +24,75 @@ func TestFluentAPI(t *testing.T) {
 	controler := New().WithOwnerReferences(v1.OwnerReference{})
 	assert.NotNil(t, controler.ownerRefs, "Expect ownerRefs to be set")
 	assert.Nil(t, controler.ownerController, "Do not expect ownerController to be set")
+}
+
+func TestCreateService(t *testing.T) {
+	scheme := getScheme(t)
+	client := fake.NewFakeClientWithScheme(scheme)
+	requestedService := corev1.Service{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "service1",
+			Namespace: "namespace",
+		},
+		Spec: corev1.ServiceSpec{
+			SessionAffinity: corev1.ServiceAffinityClientIP,
+		},
+	}
+	requestedService.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Service"))
+	added, err := New().AddResources(scheme, client, []resource.KubernetesResource{&requestedService})
+	assert.Nil(t, err, "Expect no errors creating a simple object")
+	assert.True(t, added, "Object should be added")
+
+	existingService := corev1.Service{}
+	err = client.Get(context.TODO(), types.NamespacedName{Name: "service1", Namespace: "namespace"}, &existingService)
+	assert.Nil(t, err, "Expect no errors loading existing object")
+	assert.Equal(t, requestedService, existingService)
+}
+
+func TestUpdateService(t *testing.T) {
+	scheme := getScheme(t)
+	clusterIP := "1.2.3.4"
+	client := fake.NewFakeClientWithScheme(scheme)
+	requestedService := corev1.Service{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "service1",
+			Namespace: "namespace",
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP:       clusterIP,
+			SessionAffinity: corev1.ServiceAffinityClientIP,
+		},
+	}
+	requestedService.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Service"))
+	added, err := New().AddResources(scheme, client, []resource.KubernetesResource{&requestedService})
+	assert.Nil(t, err, "Expect no errors creating a simple object")
+	assert.True(t, added, "Object should be added")
+
+	updatedService := corev1.Service{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "service1",
+			Namespace: "namespace",
+		},
+		Spec: corev1.ServiceSpec{
+			SessionAffinity: corev1.ServiceAffinityNone,
+		},
+	}
+	updatedService.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Service"))
+	updated, err := New().UpdateResources([]resource.KubernetesResource{&requestedService}, scheme, client, []resource.KubernetesResource{&updatedService})
+	assert.Nil(t, err, "Expect no errors updating object")
+	assert.True(t, updated, "Object should be updated")
+
+	existingService := corev1.Service{}
+	err = client.Get(context.TODO(), types.NamespacedName{Name: "service1", Namespace: "namespace"}, &existingService)
+	assert.Nil(t, err, "Expect no errors loading existing object")
+	//Update call should set the existing ClusterIP on the object before writing it:
+	updatedService.Spec.ClusterIP = clusterIP
+	assert.Equal(t, updatedService, existingService, "Expected Cluster IP to be set on the updating object")
+}
+
+func getScheme(t *testing.T) *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	err := corev1.SchemeBuilder.AddToScheme(scheme)
+	assert.Nil(t, err, "Expect no errors building scheme")
+	return scheme
 }


### PR DESCRIPTION
Use new operator-utils functionality to do a full reconcile of requested and existing resources

Remaining items:
- Pass unit tests
- Refactor route hostname so update happens automatically as hostname is set