### PR TITLE
Reserve CSV upgrades for 1.2.1 / 7.5.1 release

### DIFF
--- a/deploy/catalog_resources/community/1.1.1/kiecloud-operator.1.1.1.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/community/1.1.1/kiecloud-operator.1.1.1.clusterserviceversion.yaml
@@ -159,10 +159,7 @@ spec:
           spec:
             replicas: 1
             strategy:
-              type: RollingUpdate
-              rollingUpdate:
-                maxSurge: 1
-                maxUnavailable: 1
+              type: Recreate
             selector:
               matchLabels:
                 name: kie-cloud-operator

--- a/deploy/catalog_resources/community/1.2.0/kiecloud-operator.1.2.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/community/1.2.0/kiecloud-operator.1.2.0.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: placeholder
   annotations:
     categories: "Integration & Delivery"
-    capabilities: "Seamless Upgrades"
+    capabilities: "Basic Install"
     certified: "false"
     description: Kie Cloud Operator for deployment and management of RHPAM/RHDM environments.
     repository: https://github.com/kiegroup/kie-cloud-operator
@@ -31,7 +31,6 @@ spec:
     - automation
     - operator
   version: 1.2.0
-  replaces: kiecloud-operator.1.1.1
   maturity: stable
   maintainers:
     - name: Red Hat, Inc.

--- a/deploy/catalog_resources/redhat/1.1.1/businessautomation-operator.1.1.1.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/redhat/1.1.1/businessautomation-operator.1.1.1.clusterserviceversion.yaml
@@ -159,10 +159,7 @@ spec:
           spec:
             replicas: 1
             strategy:
-              type: RollingUpdate
-              rollingUpdate:
-                maxSurge: 1
-                maxUnavailable: 1
+              type: Recreate
             selector:
               matchLabels:
                 name: business-automation-operator

--- a/deploy/catalog_resources/redhat/1.2.0/businessautomation-operator.1.2.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/redhat/1.2.0/businessautomation-operator.1.2.0.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: placeholder
   annotations:
     categories: "Integration & Delivery"
-    capabilities: "Seamless Upgrades"
+    capabilities: "Basic Install"
     certified: "true"
     description: Business Automation Operator for deployment and management of RHPAM/RHDM environments.
     repository: https://github.com/kiegroup/kie-cloud-operator    
@@ -31,7 +31,6 @@ spec:
     - automation
     - operator
   version: 1.2.0
-  replaces: businessautomation-operator.1.1.1
   maturity: stable
   maintainers:
     - name: Red Hat, Inc.


### PR DESCRIPTION
Given the 1.1.1 / 7.4.1 release didn't get RollingUpdate changes which allows for CSV upgrades... we can't start allowing csv upgrades until the next release. In fact, we don't want the user to even attempt an upgrade as OLM will throw errors and just stall in progress.

/assign @bmozaffa 

Signed-off-by: tchughesiv <tchughesiv@gmail.com>