### PR TITLE
[RHPAM-2354] OutOfMemoryError on Datagrid cause issues on project import indexing

### DIFF
--- a/config/7.5.0/envs/rhdm-authoring-ha.yaml
+++ b/config/7.5.0/envs/rhdm-authoring-ha.yaml
@@ -277,10 +277,11 @@ others:
                     timeoutSeconds: 10
                   resources:
                     limits:
-                      memory: "512Mi"
+                      cpu: "1000m"
+                      memory: "2Gi"
                     requests:
-                      cpu: "0.5"
-                      memory: "512Mi"
+                      cpu: "1000m"
+                      memory: "2Gi"
                   volumeMounts:
                     - mountPath: /opt/datagrid/standalone/data
                       name: srv-data

--- a/config/7.5.0/envs/rhpam-authoring-ha.yaml
+++ b/config/7.5.0/envs/rhpam-authoring-ha.yaml
@@ -277,10 +277,11 @@ others:
                     timeoutSeconds: 10
                   resources:
                     limits:
-                      memory: "512Mi"
+                      cpu: "1000m"
+                      memory: "2Gi"
                     requests:
-                      cpu: "0.5"
-                      memory: "512Mi"
+                      cpu: "1000m"
+                      memory: "2Gi"
                   volumeMounts:
                     - mountPath: /opt/datagrid/standalone/data
                       name: srv-data

--- a/pkg/controller/kieapp/constants/constants.go
+++ b/pkg/controller/kieapp/constants/constants.go
@@ -76,7 +76,7 @@ var VersionConstants = map[string]*api.VersionConfigs{
 		BrokerImage:      "amq-broker-73-openshift",
 		BrokerImageTag:   "7.3",
 		DatagridImage:    "datagrid73-openshift",
-		DatagridImageTag: "1.1",
+		DatagridImageTag: "1.2",
 	},
 	LastMicroVersion: {
 		APIVersion:       v1.SchemeGroupVersion.Version,


### PR DESCRIPTION
[RHPAM-2354] OutOfMemoryError on Datagrid cause issues on project import indexing
https://issues.jboss.org/browse/RHPAM-2354

Signed-off-by: David Ward <dward@redhat.com>