### PR TITLE
[KIECLOUD-328] required changes to build meta information for CPaaS

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -37,7 +37,7 @@ osbs:
           - x86_64
   repository:
     name: containers/rhpam-7-operator-openshift
-    branch: rhpam-7.5-openshift-rhel8
+    branch: rhba-7.5-openshift-rhel-8
 run:
   entrypoint:
     - "/usr/local/bin/entrypoint"


### PR DESCRIPTION
[KIECLOUD-328] required changes to build meta information for CPaaS
https://issues.jboss.org/browse/KIECLOUD-328

Signed-off-by: David Ward <dward@redhat.com>

This PR is intended for RHDM / RHPAM version 7.5.1
The PR for 7.5.0 is https://github.com/kiegroup/kie-cloud-operator/pull/275