### PR TITLE
move away from role wildcard rules

### DIFF
--- a/config/7.5.0/common.yaml
+++ b/config/7.5.0/common.yaml
@@ -767,14 +767,31 @@ others:
         rules:
           - apiGroups:
               - ""
-              - app.kiegroup.org
-              - apps.openshift.io
-              - image.openshift.io
-              - route.openshift.io
             resources:
-              - "*"
+              - configmaps
+              - serviceaccounts
             verbs:
-              - "*"
+              - create
+              - delete
+              - deletecollection
+              - get
+              - list
+              - patch
+              - update
+              - watch
+          - apiGroups:
+              - apps.openshift.io
+            resources:
+              - deploymentconfigs
+            verbs:
+              - create
+              - delete
+              - deletecollection
+              - get
+              - list
+              - patch
+              - update
+              - watch
 
     serviceAccounts:
       - metadata:

--- a/config/7.5.1/common.yaml
+++ b/config/7.5.1/common.yaml
@@ -767,14 +767,31 @@ others:
         rules:
           - apiGroups:
               - ""
-              - app.kiegroup.org
-              - apps.openshift.io
-              - image.openshift.io
-              - route.openshift.io
             resources:
-              - "*"
+              - configmaps
+              - serviceaccounts
             verbs:
-              - "*"
+              - create
+              - delete
+              - deletecollection
+              - get
+              - list
+              - patch
+              - update
+              - watch
+          - apiGroups:
+              - apps.openshift.io
+            resources:
+              - deploymentconfigs
+            verbs:
+              - create
+              - delete
+              - deletecollection
+              - get
+              - list
+              - patch
+              - update
+              - watch
 
     serviceAccounts:
       - metadata:

--- a/config/7.6.0/common.yaml
+++ b/config/7.6.0/common.yaml
@@ -837,14 +837,31 @@ others:
         rules:
           - apiGroups:
               - ""
-              - app.kiegroup.org
-              - apps.openshift.io
-              - image.openshift.io
-              - route.openshift.io
             resources:
-              - "*"
+              - configmaps
+              - serviceaccounts
             verbs:
-              - "*"
+              - create
+              - delete
+              - deletecollection
+              - get
+              - list
+              - patch
+              - update
+              - watch
+          - apiGroups:
+              - apps.openshift.io
+            resources:
+              - deploymentconfigs
+            verbs:
+              - create
+              - delete
+              - deletecollection
+              - get
+              - list
+              - patch
+              - update
+              - watch
 
     serviceAccounts:
       - metadata:

--- a/deploy/catalog_resources/community/1.3.0/kiecloud-operator.1.3.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/community/1.3.0/kiecloud-operator.1.3.0.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Integration & Delivery
     certified: "false"
     containerImage: quay.io/kiegroup/kie-cloud-operator:1.3.0
-    createdAt: "2019-10-31 09:41:17"
+    createdAt: "2019-11-06 16:25:19"
     description: Kie Cloud Operator for deployment and management of RHPAM/RHDM environments.
     repository: https://github.com/kiegroup/kie-cloud-operator
     support: Red Hat, Inc.
@@ -153,17 +153,117 @@ spec:
       - rules:
         - apiGroups:
           - ""
+          resources:
+          - configmaps
+          - pods
+          - services
+          - serviceaccounts
+          - persistentvolumeclaims
+          - secrets
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - apps
+          resources:
+          - deployments
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - build.openshift.io
+          resources:
+          - buildconfigs
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - image.openshift.io
+          resources:
+          - imagestreams
+          - imagestreamtags
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - app.kiegroup.org
           resources:
-          - '*'
+          - kieapps
+          - kieapps/finalizers
           verbs:
-          - '*'
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
         - apiGroups:
           - monitoring.coreos.com
           resources:
@@ -176,7 +276,11 @@ spec:
           resources:
           - clusterserviceversions
           verbs:
-          - '*'
+          - get
+          - list
+          - patch
+          - update
+          - watch
         - apiGroups:
           - apps
           resourceNames:

--- a/deploy/catalog_resources/redhat/1.3.0/businessautomation-operator.1.3.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/redhat/1.3.0/businessautomation-operator.1.3.0.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Integration & Delivery
     certified: "true"
     containerImage: registry.redhat.io/rhpam-7/rhpam-rhel8-operator:7.6.0
-    createdAt: "2019-10-31 09:41:17"
+    createdAt: "2019-11-06 16:25:19"
     description: Business Automation Operator for deployment and management of RHPAM/RHDM
       environments.
     repository: https://github.com/kiegroup/kie-cloud-operator
@@ -155,17 +155,117 @@ spec:
       - rules:
         - apiGroups:
           - ""
+          resources:
+          - configmaps
+          - pods
+          - services
+          - serviceaccounts
+          - persistentvolumeclaims
+          - secrets
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - apps
+          resources:
+          - deployments
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - build.openshift.io
+          resources:
+          - buildconfigs
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - image.openshift.io
+          resources:
+          - imagestreams
+          - imagestreamtags
+          verbs:
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - app.kiegroup.org
           resources:
-          - '*'
+          - kieapps
+          - kieapps/finalizers
           verbs:
-          - '*'
+          - create
+          - delete
+          - deletecollection
+          - get
+          - list
+          - patch
+          - update
+          - watch
         - apiGroups:
           - monitoring.coreos.com
           resources:
@@ -178,7 +278,11 @@ spec:
           resources:
           - clusterserviceversions
           verbs:
-          - '*'
+          - get
+          - list
+          - patch
+          - update
+          - watch
         - apiGroups:
           - apps
           resourceNames:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -5,17 +5,117 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  resources:
+  - configmaps
+  - pods
+  - services
+  - serviceaccounts
+  - persistentvolumeclaims
+  - secrets
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - apps
+  resources:
+  - deployments
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - apps.openshift.io
+  resources:
+  - deploymentconfigs
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  - roles
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - build.openshift.io
+  resources:
+  - buildconfigs
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - image.openshift.io
+  resources:
+  - imagestreams
+  - imagestreamtags
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - app.kiegroup.org
   resources:
-  - '*'
+  - kieapps
+  - kieapps/finalizers
   verbs:
-  - '*'
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -28,7 +128,11 @@ rules:
   resources:
   - clusterserviceversions
   verbs:
-  - '*'
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - apps
   resourceNames:

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -19,6 +19,17 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+var Verbs = []string{
+	"create",
+	"delete",
+	"deletecollection",
+	"get",
+	"list",
+	"patch",
+	"update",
+	"watch",
+}
+
 func GetDeployment(operatorName, repository, context, imageName, tag, imagePullPolicy string) *appsv1.Deployment {
 	registryName := strings.Join([]string{repository, context, imageName}, "/")
 	image := strings.Join([]string{registryName, tag}, ":")
@@ -114,16 +125,83 @@ func GetRole(operatorName string) *rbacv1.Role {
 			{
 				APIGroups: []string{
 					"",
+				},
+				Resources: []string{
+					"configmaps",
+					"pods",
+					"services",
+					"serviceaccounts",
+					"persistentvolumeclaims",
+					"secrets",
+				},
+				Verbs: Verbs,
+			},
+			{
+				APIGroups: []string{
 					appsv1.SchemeGroupVersion.Group,
+				},
+				Resources: []string{
+					"deployments",
+					"statefulsets",
+				},
+				Verbs: Verbs,
+			},
+			{
+				APIGroups: []string{
 					oappsv1.SchemeGroupVersion.Group,
+				},
+				Resources: []string{
+					"deploymentconfigs",
+				},
+				Verbs: Verbs,
+			},
+			{
+				APIGroups: []string{
 					rbacv1.SchemeGroupVersion.Group,
+				},
+				Resources: []string{
+					"rolebindings",
+					"roles",
+				},
+				Verbs: Verbs,
+			},
+			{
+				APIGroups: []string{
 					routev1.SchemeGroupVersion.Group,
+				},
+				Resources: []string{
+					"routes",
+				},
+				Verbs: Verbs,
+			},
+			{
+				APIGroups: []string{
 					buildv1.SchemeGroupVersion.Group,
+				},
+				Resources: []string{
+					"buildconfigs",
+				},
+				Verbs: Verbs,
+			},
+			{
+				APIGroups: []string{
 					oimagev1.SchemeGroupVersion.Group,
+				},
+				Resources: []string{
+					"imagestreams",
+					"imagestreamtags",
+				},
+				Verbs: Verbs,
+			},
+			{
+				APIGroups: []string{
 					api.SchemeGroupVersion.Group,
 				},
-				Resources: []string{"*"},
-				Verbs:     []string{"*"},
+				Resources: []string{
+					"kieapps",
+					"kieapps/finalizers",
+				},
+				Verbs: Verbs,
 			},
 			{
 				APIGroups: []string{
@@ -137,7 +215,13 @@ func GetRole(operatorName string) *rbacv1.Role {
 					csvv1.SchemeGroupVersion.Group,
 				},
 				Resources: []string{"clusterserviceversions"},
-				Verbs:     []string{"*"},
+				Verbs: []string{
+					"get",
+					"list",
+					"patch",
+					"update",
+					"watch",
+				},
 			},
 			{
 				APIGroups: []string{

--- a/pkg/controller/kieapp/deploy_ui.go
+++ b/pkg/controller/kieapp/deploy_ui.go
@@ -4,16 +4,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/RHsyseng/operator-utils/pkg/resource"
-	"github.com/RHsyseng/operator-utils/pkg/resource/compare"
-	"github.com/RHsyseng/operator-utils/pkg/resource/read"
-	"github.com/RHsyseng/operator-utils/pkg/resource/write"
 	"os"
 	"reflect"
 	"strings"
 	"time"
 
+	"github.com/RHsyseng/operator-utils/pkg/resource"
+	"github.com/RHsyseng/operator-utils/pkg/resource/compare"
+	"github.com/RHsyseng/operator-utils/pkg/resource/read"
+	"github.com/RHsyseng/operator-utils/pkg/resource/write"
 	api "github.com/kiegroup/kie-cloud-operator/pkg/apis/app/v2"
+	"github.com/kiegroup/kie-cloud-operator/pkg/components"
 	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/constants"
 	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/shared"
 	routev1 "github.com/openshift/api/route/v1"
@@ -313,8 +314,8 @@ func getRole(namespace string) *rbacv1.Role {
 		Rules: []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{api.SchemeGroupVersion.Group},
-				Resources: []string{"*"},
-				Verbs:     []string{"*"},
+				Resources: []string{"kieapps"},
+				Verbs:     components.Verbs,
 			},
 		},
 	}


### PR DESCRIPTION
The reason for this is to further restrict the permissions we're allotting to our operator/product. This should allow us to offer dedicated users a way to deploy our operator/product at some point.

But also, this allows us to know what we really need. My initial testing has been successful.

Signed-off-by: tchughesiv <tchughesiv@gmail.com>