### PR TITLE
simplify versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Push the operator bundle to your quay application repository as follows:
 
 ```bash
 REGISTRY_NS=<registry namespace in quay.io>
-operator-courier push deploy/catalog_resources/community ${REGISTRY_NS} kiecloud-operator 1.2.1 "basic XXXXXXXXX"
+operator-courier push deploy/catalog_resources/community ${REGISTRY_NS} kiecloud-operator $(go run getversion.go -operator) "basic XXXXXXXXX"
 ```
 
 If pushing to another quay repository, replace _kiegroup_ with your username or other namespace. Also note that the push command does not overwrite an existing repository, and it needs to be deleted before a new version can be built and uploaded. Once the bundle has been uploaded, create an [Operator Source](https://github.com/operator-framework/community-operators/blob/master/docs/testing-operators.md#linking-the-quay-application-repository-to-your-openshift-40-cluster) to load your operator bundle in OpenShift.

--- a/getversion.go
+++ b/getversion.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/constants"
+	"github.com/kiegroup/kie-cloud-operator/version"
+)
+
+var (
+	operator = flag.Bool("operator", false, "get current operator version")
+	product  = flag.Bool("product", false, "get current product version")
+)
+
+func main() {
+	flag.Parse()
+	if !*operator && !*product {
+		fmt.Println("Operator version is " + version.Version)
+		fmt.Println("Product version is " + constants.CurrentVersion)
+	}
+	if *operator {
+		fmt.Println(version.Version)
+	}
+	if *product {
+		fmt.Println(constants.CurrentVersion)
+	}
+}

--- a/hack/go-build.sh
+++ b/hack/go-build.sh
@@ -1,9 +1,8 @@
 #!/bin/sh
 REPO=https://github.com/kiegroup/kie-cloud-operator
-BRANCH=1.2.1
+BRANCH=$(go run getversion.go -operator)
 REGISTRY=quay.io/kiegroup
 IMAGE=kie-cloud-operator
-TAG=1.2.1
 TAR=${BRANCH}.tar.gz
 URL=${REPO}/archive/${TAR}
 CFLAGS="docker"
@@ -18,7 +17,7 @@ if [[ -z ${CI} ]]; then
     echo
     echo Now building operator:
     echo
-    operator-sdk build ${REGISTRY}/${IMAGE}:${TAG}
+    operator-sdk build ${REGISTRY}/${IMAGE}:${BRANCH}
     if [[ ${1} == "rhel" ]]; then
         if [[ ${LOCAL} != true ]]; then
             CFLAGS="osbs"

--- a/pkg/controller/kieapp/deploy_ui_test.go
+++ b/pkg/controller/kieapp/deploy_ui_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gobuffalo/packr/v2"
 	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/constants"
 	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/test"
+	"github.com/kiegroup/kie-cloud-operator/version"
 	routev1 "github.com/openshift/api/route/v1"
 	operators "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/stretchr/testify/assert"
@@ -23,8 +24,8 @@ import (
 func TestUpdateLink(t *testing.T) {
 	service := test.MockServiceWithExtraScheme(&operators.ClusterServiceVersion{}, &appsv1.Deployment{}, &corev1.Pod{})
 
-	box := packr.New("CSV", "../../../deploy/catalog_resources/redhat/1.2.1")
-	bytes, err := box.Find("businessautomation-operator.1.2.1.clusterserviceversion.yaml")
+	box := packr.New("CSV", "../../../deploy/catalog_resources/redhat/"+version.Version)
+	bytes, err := box.Find("businessautomation-operator." + version.Version + ".clusterserviceversion.yaml")
 	assert.Nil(t, err, "Error reading CSV file")
 	csv := &operators.ClusterServiceVersion{}
 	err = yaml.Unmarshal(bytes, csv)
@@ -70,8 +71,8 @@ func TestUpdateLink(t *testing.T) {
 func TestUpdateExistingLink(t *testing.T) {
 	service := test.MockServiceWithExtraScheme(&operators.ClusterServiceVersion{}, &appsv1.Deployment{}, &corev1.Pod{})
 
-	box := packr.New("CSV", "../../../deploy/catalog_resources/redhat/1.2.1")
-	bytes, err := box.Find("businessautomation-operator.1.2.1.clusterserviceversion.yaml")
+	box := packr.New("CSV", "../../../deploy/catalog_resources/redhat/"+version.Version)
+	bytes, err := box.Find("businessautomation-operator." + version.Version + ".clusterserviceversion.yaml")
 	assert.Nil(t, err, "Error reading CSV file")
 	csv := &operators.ClusterServiceVersion{}
 	err = yaml.Unmarshal(bytes, csv)


### PR DESCRIPTION
Added getversion.go ...
```bash
$ go run getversion.go 
Operator version is 1.2.1
Product version is 7.5.1
```

/assign @bmozaffa 

Signed-off-by: tchughesiv <tchughesiv@gmail.com>