### PR TITLE
[RHPAM-2602] fix configmap difference errors during 1.3.0 upgrades

### DIFF
--- a/config/7.5.0/common.yaml
+++ b/config/7.5.0/common.yaml
@@ -767,45 +767,14 @@ others:
         rules:
           - apiGroups:
               - ""
-            resources:
-              - configmaps
-              - serviceaccounts
-              - pods
-            verbs:
-              - create
-              - delete
-              - deletecollection
-              - get
-              - list
-              - patch
-              - update
-              - watch
-          - apiGroups:
+              - app.kiegroup.org
               - apps.openshift.io
-            resources:
-              - deploymentconfigs
-            verbs:
-              - create
-              - delete
-              - deletecollection
-              - get
-              - list
-              - patch
-              - update
-              - watch
-          - apiGroups:
+              - image.openshift.io
               - route.openshift.io
             resources:
-              - routes
+              - "*"
             verbs:
-              - create
-              - delete
-              - deletecollection
-              - get
-              - list
-              - patch
-              - update
-              - watch
+              - "*"
 
     serviceAccounts:
       - metadata:

--- a/config/7.5.1/common.yaml
+++ b/config/7.5.1/common.yaml
@@ -767,45 +767,14 @@ others:
         rules:
           - apiGroups:
               - ""
-            resources:
-              - configmaps
-              - serviceaccounts
-              - pods
-            verbs:
-              - create
-              - delete
-              - deletecollection
-              - get
-              - list
-              - patch
-              - update
-              - watch
-          - apiGroups:
+              - app.kiegroup.org
               - apps.openshift.io
-            resources:
-              - deploymentconfigs
-            verbs:
-              - create
-              - delete
-              - deletecollection
-              - get
-              - list
-              - patch
-              - update
-              - watch
-          - apiGroups:
+              - image.openshift.io
               - route.openshift.io
             resources:
-              - routes
+              - "*"
             verbs:
-              - create
-              - delete
-              - deletecollection
-              - get
-              - list
-              - patch
-              - update
-              - watch
+              - "*"
 
     serviceAccounts:
       - metadata:

--- a/deploy/catalog_resources/community/1.3.0/kiecloud-operator.1.3.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/community/1.3.0/kiecloud-operator.1.3.0.clusterserviceversion.yaml
@@ -153,119 +153,17 @@ spec:
       - rules:
         - apiGroups:
           - ""
-          resources:
-          - configmaps
-          - pods
-          - services
-          - serviceaccounts
-          - persistentvolumeclaims
-          - secrets
-          verbs:
-          - create
-          - delete
-          - deletecollection
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
           - apps
-          resources:
-          - deployments
-          - deployments/finalizers
-          - replicasets
-          - statefulsets
-          verbs:
-          - create
-          - delete
-          - deletecollection
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
           - apps.openshift.io
-          resources:
-          - deploymentconfigs
-          verbs:
-          - create
-          - delete
-          - deletecollection
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
           - rbac.authorization.k8s.io
-          resources:
-          - rolebindings
-          - roles
-          verbs:
-          - create
-          - delete
-          - deletecollection
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
           - route.openshift.io
-          resources:
-          - routes
-          verbs:
-          - create
-          - delete
-          - deletecollection
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
           - build.openshift.io
-          resources:
-          - buildconfigs
-          verbs:
-          - create
-          - delete
-          - deletecollection
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
           - image.openshift.io
-          resources:
-          - imagestreams
-          - imagestreamtags
-          verbs:
-          - create
-          - delete
-          - deletecollection
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
           - app.kiegroup.org
           resources:
-          - kieapps
-          - kieapps/finalizers
+          - '*'
           verbs:
-          - create
-          - delete
-          - deletecollection
-          - get
-          - list
-          - patch
-          - update
-          - watch
+          - '*'
         - apiGroups:
           - monitoring.coreos.com
           resources:
@@ -278,11 +176,15 @@ spec:
           resources:
           - clusterserviceversions
           verbs:
-          - get
-          - list
-          - patch
+          - '*'
+        - apiGroups:
+          - apps
+          resourceNames:
+          - kie-cloud-operator
+          resources:
+          - deployments/finalizers
+          verbs:
           - update
-          - watch
         serviceAccountName: kie-cloud-operator
     strategy: deployment
   installModes:

--- a/deploy/catalog_resources/redhat/1.3.0/businessautomation-operator.1.3.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/redhat/1.3.0/businessautomation-operator.1.3.0.clusterserviceversion.yaml
@@ -155,119 +155,17 @@ spec:
       - rules:
         - apiGroups:
           - ""
-          resources:
-          - configmaps
-          - pods
-          - services
-          - serviceaccounts
-          - persistentvolumeclaims
-          - secrets
-          verbs:
-          - create
-          - delete
-          - deletecollection
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
           - apps
-          resources:
-          - deployments
-          - deployments/finalizers
-          - replicasets
-          - statefulsets
-          verbs:
-          - create
-          - delete
-          - deletecollection
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
           - apps.openshift.io
-          resources:
-          - deploymentconfigs
-          verbs:
-          - create
-          - delete
-          - deletecollection
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
           - rbac.authorization.k8s.io
-          resources:
-          - rolebindings
-          - roles
-          verbs:
-          - create
-          - delete
-          - deletecollection
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
           - route.openshift.io
-          resources:
-          - routes
-          verbs:
-          - create
-          - delete
-          - deletecollection
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
           - build.openshift.io
-          resources:
-          - buildconfigs
-          verbs:
-          - create
-          - delete
-          - deletecollection
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
           - image.openshift.io
-          resources:
-          - imagestreams
-          - imagestreamtags
-          verbs:
-          - create
-          - delete
-          - deletecollection
-          - get
-          - list
-          - patch
-          - update
-          - watch
-        - apiGroups:
           - app.kiegroup.org
           resources:
-          - kieapps
-          - kieapps/finalizers
+          - '*'
           verbs:
-          - create
-          - delete
-          - deletecollection
-          - get
-          - list
-          - patch
-          - update
-          - watch
+          - '*'
         - apiGroups:
           - monitoring.coreos.com
           resources:
@@ -280,11 +178,15 @@ spec:
           resources:
           - clusterserviceversions
           verbs:
-          - get
-          - list
-          - patch
+          - '*'
+        - apiGroups:
+          - apps
+          resourceNames:
+          - business-automation-operator
+          resources:
+          - deployments/finalizers
+          verbs:
           - update
-          - watch
         serviceAccountName: business-automation-operator
     strategy: deployment
   installModes:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -5,119 +5,17 @@ metadata:
 rules:
 - apiGroups:
   - ""
-  resources:
-  - configmaps
-  - pods
-  - services
-  - serviceaccounts
-  - persistentvolumeclaims
-  - secrets
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - apps
-  resources:
-  - deployments
-  - deployments/finalizers
-  - replicasets
-  - statefulsets
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - apps.openshift.io
-  resources:
-  - deploymentconfigs
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - rbac.authorization.k8s.io
-  resources:
-  - rolebindings
-  - roles
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - route.openshift.io
-  resources:
-  - routes
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - build.openshift.io
-  resources:
-  - buildconfigs
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - image.openshift.io
-  resources:
-  - imagestreams
-  - imagestreamtags
-  verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
   - app.kiegroup.org
   resources:
-  - kieapps
-  - kieapps/finalizers
+  - '*'
   verbs:
-  - create
-  - delete
-  - deletecollection
-  - get
-  - list
-  - patch
-  - update
-  - watch
+  - '*'
 - apiGroups:
   - monitoring.coreos.com
   resources:
@@ -130,8 +28,12 @@ rules:
   resources:
   - clusterserviceversions
   verbs:
-  - get
-  - list
-  - patch
+  - '*'
+- apiGroups:
+  - apps
+  resourceNames:
+  - kie-cloud-operator
+  resources:
+  - deployments/finalizers
+  verbs:
   - update
-  - watch


### PR DESCRIPTION
revert prior version product role configs so that upgrades occur correctly. use more permissive role for operator deployment until 7.5.x rolls off in operator 1.4.0.

/assign @bmozaffa @sutaakar 

Signed-off-by: tchughesiv <tchughesiv@gmail.com>