### PR TITLE
[RHPAM-2634] Remote Server is lot from the controller after Kie Server scale down and scale up

### DIFF
--- a/config/7.7.0/common.yaml
+++ b/config/7.7.0/common.yaml
@@ -104,7 +104,7 @@ console:
                   - name: KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
                     value: "true"
                   - name: KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL
-                    value: "60000"
+                    value: "5000"
                   - name: KIE_WORKBENCH_CONTROLLER_OPENSHIFT_ENABLED
                     value: "true"
                   ## OpenShift Enhancement END


### PR DESCRIPTION
Align changes with Templates for bug fixing.

Related JIRA link:
https://issues.redhat.com/projects/RHPAM/issues/RHPAM-2634

Related PRs
https://github.com/jboss-container-images/jboss-kie-modules/pull/346
https://github.com/jboss-container-images/rhpam-7-openshift-image/pull/411
https://github.com/kiegroup/kie-cloud-operator/pull/343

Signed-off-by: Evan Zhang <evan.zhang@redhat.com>