### PR TITLE
[RHPAM-2658] Define value as byte

### DIFF
--- a/deploy/catalog_resources/community/1.2.0/kiecloud-operator.1.2.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/community/1.2.0/kiecloud-operator.1.2.0.clusterserviceversion.yaml
@@ -94,13 +94,15 @@ spec:
         specDescriptors:
           - description: Set true to enable automatic micro version product upgrades, it is disabled by default.
             displayName: Enable Upgrades
-            value: false
+            value:
+              - false
             path: upgrades.enabled
             x-descriptors:
               - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
           - description: Set true to enable automatic minor product version upgrades, it is disabled by default. Requires spec.upgrades.enabled to be true.
             displayName: Include minor version upgrades
-            value: false
+            value:
+              - false
             path: upgrades.minor
             x-descriptors:
               - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"

--- a/deploy/catalog_resources/community/1.2.0/kiecloud-operator.1.2.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/community/1.2.0/kiecloud-operator.1.2.0.clusterserviceversion.yaml
@@ -94,15 +94,11 @@ spec:
         specDescriptors:
           - description: Set true to enable automatic micro version product upgrades, it is disabled by default.
             displayName: Enable Upgrades
-            value:
-              - false
             path: upgrades.enabled
             x-descriptors:
               - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
           - description: Set true to enable automatic minor product version upgrades, it is disabled by default. Requires spec.upgrades.enabled to be true.
             displayName: Include minor version upgrades
-            value:
-              - false
             path: upgrades.minor
             x-descriptors:
               - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"

--- a/deploy/catalog_resources/community/1.2.1/kiecloud-operator.1.2.1.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/community/1.2.1/kiecloud-operator.1.2.1.clusterserviceversion.yaml
@@ -63,16 +63,12 @@ spec:
           it is disabled by default.
         displayName: Enable Upgrades
         path: upgrades.enabled
-        value:
-          - false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Set true to enable automatic minor product version upgrades,
           it is disabled by default. Requires spec.upgrades.enabled to be true.
         displayName: Include minor version upgrades
         path: upgrades.minor
-        value:
-          - false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Environment deployed.

--- a/deploy/catalog_resources/community/1.2.1/kiecloud-operator.1.2.1.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/community/1.2.1/kiecloud-operator.1.2.1.clusterserviceversion.yaml
@@ -63,14 +63,16 @@ spec:
           it is disabled by default.
         displayName: Enable Upgrades
         path: upgrades.enabled
-        value: false
+        value:
+          - false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Set true to enable automatic minor product version upgrades,
           it is disabled by default. Requires spec.upgrades.enabled to be true.
         displayName: Include minor version upgrades
         path: upgrades.minor
-        value: false
+        value:
+          - false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Environment deployed.

--- a/deploy/catalog_resources/community/1.3.0/kiecloud-operator.1.3.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/community/1.3.0/kiecloud-operator.1.3.0.clusterserviceversion.yaml
@@ -63,16 +63,12 @@ spec:
           it is disabled by default.
         displayName: Enable Upgrades
         path: upgrades.enabled
-        value:
-          - false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Set true to enable automatic minor product version upgrades,
           it is disabled by default. Requires spec.upgrades.enabled to be true.
         displayName: Include minor version upgrades
         path: upgrades.minor
-        value:
-          - false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Environment deployed.

--- a/deploy/catalog_resources/community/1.3.0/kiecloud-operator.1.3.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/community/1.3.0/kiecloud-operator.1.3.0.clusterserviceversion.yaml
@@ -63,14 +63,16 @@ spec:
           it is disabled by default.
         displayName: Enable Upgrades
         path: upgrades.enabled
-        value: false
+        value:
+          - false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Set true to enable automatic minor product version upgrades,
           it is disabled by default. Requires spec.upgrades.enabled to be true.
         displayName: Include minor version upgrades
         path: upgrades.minor
-        value: false
+        value:
+          - false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Environment deployed.

--- a/deploy/catalog_resources/community/1.4.0/kiecloud-operator.1.4.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/community/1.4.0/kiecloud-operator.1.4.0.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Integration & Delivery
     certified: "false"
     containerImage: quay.io/kiegroup/kie-cloud-operator:1.4.0
-    createdAt: "2020-01-15 14:34:03"
+    createdAt: "2020-01-29 18:30:54"
     description: Kie Cloud Operator for deployment and management of RHPAM/RHDM environments.
     repository: https://github.com/kiegroup/kie-cloud-operator
     support: Red Hat, Inc.
@@ -63,14 +63,16 @@ spec:
           it is disabled by default.
         displayName: Enable Upgrades
         path: upgrades.enabled
-        value: false
+        value:
+        - false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Set true to enable automatic minor product version upgrades,
           it is disabled by default. Requires spec.upgrades.enabled to be true.
         displayName: Include minor version upgrades
         path: upgrades.minor
-        value: false
+        value:
+        - false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Environment deployed.

--- a/deploy/catalog_resources/community/1.4.0/kiecloud-operator.1.4.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/community/1.4.0/kiecloud-operator.1.4.0.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Integration & Delivery
     certified: "false"
     containerImage: quay.io/kiegroup/kie-cloud-operator:1.4.0
-    createdAt: "2020-01-29 18:30:54"
+    createdAt: "2020-01-29 22:31:34"
     description: Kie Cloud Operator for deployment and management of RHPAM/RHDM environments.
     repository: https://github.com/kiegroup/kie-cloud-operator
     support: Red Hat, Inc.

--- a/deploy/catalog_resources/community/1.4.0/kiecloud-operator.1.4.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/community/1.4.0/kiecloud-operator.1.4.0.clusterserviceversion.yaml
@@ -63,16 +63,12 @@ spec:
           it is disabled by default.
         displayName: Enable Upgrades
         path: upgrades.enabled
-        value:
-        - false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Set true to enable automatic minor product version upgrades,
           it is disabled by default. Requires spec.upgrades.enabled to be true.
         displayName: Include minor version upgrades
         path: upgrades.minor
-        value:
-        - false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Environment deployed.

--- a/deploy/catalog_resources/redhat/1.2.0/businessautomation-operator.1.2.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/redhat/1.2.0/businessautomation-operator.1.2.0.clusterserviceversion.yaml
@@ -8,7 +8,7 @@ metadata:
     capabilities: "Basic Install"
     certified: "true"
     description: Business Automation Operator for deployment and management of RHPAM/RHDM environments.
-    repository: https://github.com/kiegroup/kie-cloud-operator    
+    repository: https://github.com/kiegroup/kie-cloud-operator
     containerImage: registry.redhat.io/rhpam-7/rhpam-rhel8-operator:7.5.0
     createdAt: 2019-08-21
     support: Red Hat, Inc.
@@ -94,13 +94,15 @@ spec:
         specDescriptors:
           - description: Set true to enable automatic micro version product upgrades, it is disabled by default.
             displayName: Enable Upgrades
-            value: [false]
+            value:
+              - false
             path: upgrades.enabled
             x-descriptors:
               - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
           - description: Set true to enable automatic minor product version upgrades, it is disabled by default. Requires spec.upgrades.enabled to be true.
             displayName: Include minor version upgrades
-            value: [false]
+            value:
+              - false
             path: upgrades.minor
             x-descriptors:
               - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"

--- a/deploy/catalog_resources/redhat/1.2.0/businessautomation-operator.1.2.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/redhat/1.2.0/businessautomation-operator.1.2.0.clusterserviceversion.yaml
@@ -94,13 +94,13 @@ spec:
         specDescriptors:
           - description: Set true to enable automatic micro version product upgrades, it is disabled by default.
             displayName: Enable Upgrades
-            value: false
+            value: [false]
             path: upgrades.enabled
             x-descriptors:
               - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
           - description: Set true to enable automatic minor product version upgrades, it is disabled by default. Requires spec.upgrades.enabled to be true.
             displayName: Include minor version upgrades
-            value: false
+            value: [false]
             path: upgrades.minor
             x-descriptors:
               - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"

--- a/deploy/catalog_resources/redhat/1.2.0/businessautomation-operator.1.2.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/redhat/1.2.0/businessautomation-operator.1.2.0.clusterserviceversion.yaml
@@ -94,15 +94,11 @@ spec:
         specDescriptors:
           - description: Set true to enable automatic micro version product upgrades, it is disabled by default.
             displayName: Enable Upgrades
-            value:
-              - false
             path: upgrades.enabled
             x-descriptors:
               - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"
           - description: Set true to enable automatic minor product version upgrades, it is disabled by default. Requires spec.upgrades.enabled to be true.
             displayName: Include minor version upgrades
-            value:
-              - false
             path: upgrades.minor
             x-descriptors:
               - "urn:alm:descriptor:com.tectonic.ui:booleanSwitch"

--- a/deploy/catalog_resources/redhat/1.2.1/businessautomation-operator.1.2.1.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/redhat/1.2.1/businessautomation-operator.1.2.1.clusterserviceversion.yaml
@@ -64,14 +64,16 @@ spec:
           it is disabled by default.
         displayName: Enable Upgrades
         path: upgrades.enabled
-        value: [false]
+        value:
+          - false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Set true to enable automatic minor product version upgrades,
           it is disabled by default. Requires spec.upgrades.enabled to be true.
         displayName: Include minor version upgrades
         path: upgrades.minor
-        value: [false]
+        value:
+          - false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Environment deployed.

--- a/deploy/catalog_resources/redhat/1.2.1/businessautomation-operator.1.2.1.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/redhat/1.2.1/businessautomation-operator.1.2.1.clusterserviceversion.yaml
@@ -64,14 +64,14 @@ spec:
           it is disabled by default.
         displayName: Enable Upgrades
         path: upgrades.enabled
-        value: false
+        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Set true to enable automatic minor product version upgrades,
           it is disabled by default. Requires spec.upgrades.enabled to be true.
         displayName: Include minor version upgrades
         path: upgrades.minor
-        value: false
+        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Environment deployed.

--- a/deploy/catalog_resources/redhat/1.2.1/businessautomation-operator.1.2.1.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/redhat/1.2.1/businessautomation-operator.1.2.1.clusterserviceversion.yaml
@@ -64,16 +64,12 @@ spec:
           it is disabled by default.
         displayName: Enable Upgrades
         path: upgrades.enabled
-        value:
-          - false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Set true to enable automatic minor product version upgrades,
           it is disabled by default. Requires spec.upgrades.enabled to be true.
         displayName: Include minor version upgrades
         path: upgrades.minor
-        value:
-          - false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Environment deployed.

--- a/deploy/catalog_resources/redhat/1.3.0/businessautomation-operator.1.3.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/redhat/1.3.0/businessautomation-operator.1.3.0.clusterserviceversion.yaml
@@ -64,14 +64,16 @@ spec:
           it is disabled by default.
         displayName: Enable Upgrades
         path: upgrades.enabled
-        value: [false]
+        value:
+          - false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Set true to enable automatic minor product version upgrades,
           it is disabled by default. Requires spec.upgrades.enabled to be true.
         displayName: Include minor version upgrades
         path: upgrades.minor
-        value: [false]
+        value:
+          - false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Environment deployed.

--- a/deploy/catalog_resources/redhat/1.3.0/businessautomation-operator.1.3.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/redhat/1.3.0/businessautomation-operator.1.3.0.clusterserviceversion.yaml
@@ -64,14 +64,14 @@ spec:
           it is disabled by default.
         displayName: Enable Upgrades
         path: upgrades.enabled
-        value: false
+        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Set true to enable automatic minor product version upgrades,
           it is disabled by default. Requires spec.upgrades.enabled to be true.
         displayName: Include minor version upgrades
         path: upgrades.minor
-        value: false
+        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Environment deployed.

--- a/deploy/catalog_resources/redhat/1.3.0/businessautomation-operator.1.3.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/redhat/1.3.0/businessautomation-operator.1.3.0.clusterserviceversion.yaml
@@ -64,16 +64,12 @@ spec:
           it is disabled by default.
         displayName: Enable Upgrades
         path: upgrades.enabled
-        value:
-          - false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Set true to enable automatic minor product version upgrades,
           it is disabled by default. Requires spec.upgrades.enabled to be true.
         displayName: Include minor version upgrades
         path: upgrades.minor
-        value:
-          - false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Environment deployed.

--- a/deploy/catalog_resources/redhat/1.4.0/businessautomation-operator.1.4.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/redhat/1.4.0/businessautomation-operator.1.4.0.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Integration & Delivery
     certified: "true"
     containerImage: registry.redhat.io/rhpam-7/rhpam-rhel8-operator:7.7.0
-    createdAt: "2020-01-29 18:30:54"
+    createdAt: "2020-01-29 22:31:34"
     description: Business Automation Operator for deployment and management of RHPAM/RHDM
       environments.
     repository: https://github.com/kiegroup/kie-cloud-operator

--- a/deploy/catalog_resources/redhat/1.4.0/businessautomation-operator.1.4.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/redhat/1.4.0/businessautomation-operator.1.4.0.clusterserviceversion.yaml
@@ -64,14 +64,14 @@ spec:
           it is disabled by default.
         displayName: Enable Upgrades
         path: upgrades.enabled
-        value: false
+        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Set true to enable automatic minor product version upgrades,
           it is disabled by default. Requires spec.upgrades.enabled to be true.
         displayName: Include minor version upgrades
         path: upgrades.minor
-        value: false
+        value: [false]
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Environment deployed.

--- a/deploy/catalog_resources/redhat/1.4.0/businessautomation-operator.1.4.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/redhat/1.4.0/businessautomation-operator.1.4.0.clusterserviceversion.yaml
@@ -64,16 +64,12 @@ spec:
           it is disabled by default.
         displayName: Enable Upgrades
         path: upgrades.enabled
-        value:
-        - false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Set true to enable automatic minor product version upgrades,
           it is disabled by default. Requires spec.upgrades.enabled to be true.
         displayName: Include minor version upgrades
         path: upgrades.minor
-        value:
-        - false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Environment deployed.

--- a/deploy/catalog_resources/redhat/1.4.0/businessautomation-operator.1.4.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/redhat/1.4.0/businessautomation-operator.1.4.0.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Integration & Delivery
     certified: "true"
     containerImage: registry.redhat.io/rhpam-7/rhpam-rhel8-operator:7.7.0
-    createdAt: "2020-01-15 14:34:03"
+    createdAt: "2020-01-29 18:30:54"
     description: Business Automation Operator for deployment and management of RHPAM/RHDM
       environments.
     repository: https://github.com/kiegroup/kie-cloud-operator
@@ -64,14 +64,16 @@ spec:
           it is disabled by default.
         displayName: Enable Upgrades
         path: upgrades.enabled
-        value: [false]
+        value:
+        - false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Set true to enable automatic minor product version upgrades,
           it is disabled by default. Requires spec.upgrades.enabled to be true.
         displayName: Include minor version upgrades
         path: upgrades.minor
-        value: [false]
+        value:
+        - false
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - description: Environment deployed.

--- a/tools/csv-gen/csv-gen.go
+++ b/tools/csv-gen/csv-gen.go
@@ -221,14 +221,12 @@ func main() {
 					{
 						Description:  "Set true to enable automatic micro version product upgrades, it is disabled by default.",
 						DisplayName:  "Enable Upgrades",
-						Value:        util.RawMessagePointer("false"),
 						Path:         "upgrades.enabled",
 						XDescriptors: []string{"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"},
 					},
 					{
 						Description:  "Set true to enable automatic minor product version upgrades, it is disabled by default. Requires spec.upgrades.enabled to be true.",
 						DisplayName:  "Include minor version upgrades",
-						Value:        util.RawMessagePointer("false"),
 						Path:         "upgrades.minor",
 						XDescriptors: []string{"urn:alm:descriptor:com.tectonic.ui:booleanSwitch"},
 					},

--- a/tools/util/marshaller.go
+++ b/tools/util/marshaller.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"strings"
 
@@ -102,6 +103,6 @@ func MarshallObject(obj interface{}, writer io.Writer) error {
 
 func RawMessagePointer(str string) *json.RawMessage {
 	message := json.RawMessage{}
-	message = []byte(str)
+	message = []byte(fmt.Sprintf("[%s]", str))
 	return &message
 }


### PR DESCRIPTION
Signed-off-by: Ruben Romero Montes <rromerom@redhat.com>

Fix https://issues.redhat.com/browse/RHPAM-2658

I have reproduced the issue and validated the fix on the following environment

```
Server Version: 4.4.0-0.nightly-2020-01-23-054055
Kubernetes Version: v1.17.1
```

```
oc create -f deploy/catalog_resources/redhat/1.4.0/businessautomation-operator.1.4.0.clusterserviceversion.yaml                                                                                                  
The ClusterServiceVersion "businessautomation-operator.1.4.0" is invalid: spec.customresourcedefinitions.owned.specDescriptors.value: Invalid value: "": spec.customresourcedefinitions.owned.specDescriptors.value in body must be of type byte: ""
```