### PR TITLE
[RHPAM-2694] Create ServiceMonitor for operator metrics

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -136,11 +136,15 @@ func main() {
 		{Port: operatorMetricsPort, Name: metrics.CRPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: operatorMetricsPort}},
 	}
 	// Create Service object to expose the metrics port(s).
-	_, err = metrics.CreateMetricsService(ctx, cfg, servicePorts)
+	service, err := metrics.CreateMetricsService(ctx, cfg, servicePorts)
 	if err != nil {
 		log.Info("Could not create metrics Service", "error", err.Error())
 	}
-
+	// Create ServiceMonitor pointing to the metrics service.
+	serviceMonitor := metrics.GenerateServiceMonitor(service)
+	if err := mgr.GetClient().Create(context.TODO(), serviceMonitor); err != nil {
+		log.Info("Failed to create ServiceMonitor based on metrics Service", "error", err.Error())
+	}
 	log.Info("Starting the Operator.")
 
 	message := "ConfigMaps not available. Using embedded configs."

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -141,8 +141,8 @@ func main() {
 		log.Info("Could not create metrics Service", "error", err.Error())
 	}
 	// Create ServiceMonitor pointing to the metrics service.
-	serviceMonitor := metrics.GenerateServiceMonitor(service)
-	if err := mgr.GetClient().Create(context.TODO(), serviceMonitor); err != nil {
+	services := []*v1.Service{service}
+	if _, err := metrics.CreateServiceMonitors(cfg, namespace, services); err != nil {
 		log.Info("Failed to create ServiceMonitor based on metrics Service", "error", err.Error())
 	}
 	log.Info("Starting the Operator.")

--- a/pkg/apis/addtoscheme_app_apis.go
+++ b/pkg/apis/addtoscheme_app_apis.go
@@ -1,6 +1,7 @@
 package apis
 
 import (
+	monv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	v1 "github.com/kiegroup/kie-cloud-operator/pkg/apis/app/v1"
 	api "github.com/kiegroup/kie-cloud-operator/pkg/apis/app/v2"
 	oappsv1 "github.com/openshift/api/apps/v1"
@@ -22,5 +23,6 @@ func init() {
 		oimagev1.Install,
 		buildv1.Install,
 		operatorsv1alpha1.AddToScheme,
+		monv1.AddToScheme,
 	)
 }


### PR DESCRIPTION
Create ServiceMonitor pointing to the metrics service.

Signed-off-by: Babak Mozaffari <bmozaffa@redhat.com>