### PR TITLE
[RHPAM-2657] KieServer Scale-Up-From-Zero lifecycle hooks logic broken

### DIFF
--- a/config/7.7.0/common.yaml
+++ b/config/7.7.0/common.yaml
@@ -87,14 +87,14 @@ console:
                     value: "[[.Console.GitHooks.MountPath]]"
                   #[[end]]
                   ## OpenShift Enhancement BEGIN
+                  - name: KIE_SERVER_CONTROLLER_OPENSHIFT_ENABLED
+                    value: "true"
                   - name: KIE_SERVER_CONTROLLER_OPENSHIFT_GLOBAL_DISCOVERY_ENABLED
                     value: "true"
                   - name: KIE_SERVER_CONTROLLER_OPENSHIFT_PREFER_KIESERVER_SERVICE
                     value: "true"
                   - name: KIE_SERVER_CONTROLLER_TEMPLATE_CACHE_TTL
                     value: "5000"
-                  - name: KIE_WORKBENCH_CONTROLLER_OPENSHIFT_ENABLED
-                    value: "true"
                   ## OpenShift Enhancement END
                   - name: HTTPS_KEYSTORE_DIR
                     value: "/etc/businesscentral-secret-volume"


### PR DESCRIPTION
Signed-off-by: Evan Zhang <evan.zhang@redhat.com>

Minor refactoring
PLEASE DO NOT MERGE TILL PREREQUISITE PRs MERGED

Related JIRAs
https://issues.redhat.com/projects/RHPAM/issues/RHPAM-2657
https://issues.redhat.com/projects/RHPAM/issues/RHPAM-2008
https://issues.redhat.com/browse/JBPM-8585

Prerequisite PRs
kiegroup/kie-wb-common#3139
kiegroup/droolsjbpm-integration#1995

Related PRs
jboss-container-images/jboss-kie-modules#352
https://github.com/jboss-container-images/rhdm-7-openshift-image/pull/329
https://github.com/jboss-container-images/rhpam-7-openshift-image/pull/414
