### PR TITLE
[RHPAM-2533] - External DB driver not working - build config required…

### DIFF
--- a/config/7.7.0/dbs/external.yaml
+++ b/config/7.7.0/dbs/external.yaml
@@ -77,6 +77,7 @@ servers:
             template.alpha.openshift.io/wait-for-ready: "true"
         spec:
           source:
+            type: Image
             images:
               - from:
                   kind: ImageStreamTag


### PR DESCRIPTION
… in Operator for extensions image settings

The Kie Server is being rebuild and restarted every some random time.
Cause by a mismasth object on comparator:
"deployed":{...."source":{"type":"Image",...}
"requested":{...."source":{"type":"",...}

Signed-off-by: spolti <fspolti@redhat.com>