### PR TITLE
[KIECLOUD-348] make storageClassName configurable

### DIFF
--- a/config/7.8.0/common.yaml
+++ b/config/7.8.0/common.yaml
@@ -309,6 +309,9 @@ console:
     - metadata:
         name: "[[.ApplicationName]]-[[.Console.Name]]-claim"
       spec:
+        # [[ if ne .Console.StorageClassName "" ]]
+        storageClassName: "[[.Console.StorageClassName]]"
+        # [[ end ]]
         accessModes:
           - ReadWriteMany
         resources:
@@ -380,6 +383,9 @@ smartRouter:
           application: "[[.ApplicationName]]"
           service: "[[.ApplicationName]]-smartrouter"
       spec:
+        # [[ if ne .SmartRouter.StorageClassName "" ]]
+        storageClassName: "[[.SmartRouter.StorageClassName]]"
+        # [[ end ]]
         accessModes:
           - ReadWriteMany
         resources:

--- a/config/7.8.0/dbs/h2.yaml
+++ b/config/7.8.0/dbs/h2.yaml
@@ -61,6 +61,9 @@ servers:
             application: "[[$.ApplicationName]]"
             service: "[[.KieName]]"
         spec:
+          # [[ if ne .Database.StorageClassName "" ]]
+          storageClassName: "[[.Database.StorageClassName]]"
+          # [[ end ]]
           accessModes:
             - ReadWriteOnce
           resources:

--- a/config/7.8.0/dbs/mysql.yaml
+++ b/config/7.8.0/dbs/mysql.yaml
@@ -126,6 +126,9 @@ servers:
             application: "[[$.ApplicationName]]"
             service: "[[.KieName]]-mysql"
         spec:
+          # [[ if ne .Database.StorageClassName "" ]]
+          storageClassName: "[[.Database.StorageClassName]]"
+          # [[ end ]]
           accessModes:
             - ReadWriteOnce
           resources:

--- a/config/7.8.0/dbs/postgresql.yaml
+++ b/config/7.8.0/dbs/postgresql.yaml
@@ -126,6 +126,9 @@ servers:
             application: "[[$.ApplicationName]]"
             service: "[[.KieName]]-postgresql"
         spec:
+          # [[ if ne .Database.StorageClassName "" ]]
+          storageClassName: "[[.Database.StorageClassName]]"
+          # [[ end ]]
           accessModes:
             - ReadWriteOnce
           resources:

--- a/config/7.8.0/envs/rhdm-authoring-ha.yaml
+++ b/config/7.8.0/envs/rhdm-authoring-ha.yaml
@@ -6,6 +6,9 @@ console:
           app: "[[.ApplicationName]]"
           application: "[[.ApplicationName]]"
       spec:
+        # [[ if ne .Console.StorageClassName "" ]]
+        storageClassName: "[[.Console.StorageClassName]]"
+        # [[ end ]]
         accessModes:
           - ReadWriteMany
         resources:
@@ -142,6 +145,9 @@ others:
             - metadata:
                 name: srv-data
               spec:
+                # [[ if ne .Console.StorageClassName "" ]]
+                storageClassName: "[[.Console.StorageClassName]]"
+                # [[ end ]]
                 accessModes:
                   - ReadWriteOnce
                 resources:
@@ -256,6 +262,9 @@ others:
             - metadata:
                 name: "[[.ApplicationName]]-amq-pvol"
               spec:
+                # [[ if ne .Console.StorageClassName "" ]]
+                storageClassName: "[[.Console.StorageClassName]]"
+                # [[ end ]]
                 accessModes:
                   - ReadWriteOnce
                 resources:

--- a/config/7.8.0/envs/rhdm-authoring.yaml
+++ b/config/7.8.0/envs/rhdm-authoring.yaml
@@ -30,6 +30,9 @@ console:
     - metadata:
         name: "[[.ApplicationName]]-[[.Console.Name]]-claim"
       spec:
+        # [[ if ne .Console.StorageClassName "" ]]
+        storageClassName: "[[.Console.StorageClassName]]"
+        # [[ end ]]
         accessModes:
           - ReadWriteOnce
         resources:

--- a/config/7.8.0/envs/rhpam-authoring-ha.yaml
+++ b/config/7.8.0/envs/rhpam-authoring-ha.yaml
@@ -6,6 +6,9 @@ console:
           app: "[[.ApplicationName]]"
           application: "[[.ApplicationName]]"
       spec:
+        # [[ if ne .Console.StorageClassName "" ]]
+        storageClassName: "[[.Console.StorageClassName]]"
+        # [[ end ]]
         accessModes:
           - ReadWriteMany
         resources:
@@ -142,6 +145,9 @@ others:
             - metadata:
                 name: srv-data
               spec:
+                # [[ if ne .Console.StorageClassName "" ]]
+                storageClassName: "[[.Console.StorageClassName]]"
+                # [[ end ]]
                 accessModes:
                   - ReadWriteOnce
                 resources:
@@ -257,6 +263,9 @@ others:
                 creationTimestamp: null
                 name: "[[.ApplicationName]]-amq-pvol"
               spec:
+                # [[ if ne .Console.StorageClassName "" ]]
+                storageClassName: "[[.Console.StorageClassName]]"
+                # [[ end ]]
                 accessModes:
                   - ReadWriteOnce
                 resources:

--- a/config/7.8.0/envs/rhpam-authoring.yaml
+++ b/config/7.8.0/envs/rhpam-authoring.yaml
@@ -13,6 +13,9 @@ console:
     - metadata:
         name: "[[.ApplicationName]]-[[.Console.Name]]-claim"
       spec:
+        # [[ if ne .Console.StorageClassName "" ]]
+        storageClassName: "[[.Console.StorageClassName]]"
+        # [[ end ]]
         accessModes:
           - ReadWriteOnce
         resources:

--- a/deploy/crds/kieapp.crd.yaml
+++ b/deploy/crds/kieapp.crd.yaml
@@ -158,6 +158,9 @@ spec:
                               type: object
                             requests:
                               type: object
+                        storageClassName:
+                          type: string
+                          description: The storageClassName to use for console pvc's.
                         ssoClient:
                           type: object
                           description: Client definitions used for creating the RH-SSO clients in the specified Realm
@@ -410,6 +413,9 @@ spec:
                                 type: object
                               requests:
                                 type: object
+                          storageClassName:
+                            type: string
+                            description: The storageClassName to use for server pvc's.
                           ssoClient:
                             type: object
                             description: Client definitions used for creating the RH-SSO clients in the specified Realm
@@ -443,6 +449,9 @@ spec:
                               size:
                                 type: string
                                 description: Size of the PersistentVolumeClaim to create. For example, 100Gi
+                              storageClassName:
+                                type: string
+                                description: The storageClassName to use for database pvc's.
                               externalConfig:
                                 type: object
                                 description: External Database configuration
@@ -675,6 +684,9 @@ spec:
                               type: object
                             requests:
                               type: object
+                        storageClassName:
+                          type: string
+                          description: The storageClassName to use for smart router pvc's.
                 imageRegistry:
                   type: object
                   description: If required imagestreams are missing in both the 'openshift' and local namespaces, the operator will create said imagestreams locally using the registry specified here.

--- a/deploy/examples/v2/server_mysql.yaml
+++ b/deploy/examples/v2/server_mysql.yaml
@@ -10,4 +10,8 @@ spec:
         database:
           type: mysql
           size: 30Gi
-
+      - deployments: 1
+        database:
+          type: mysql
+          size: 30Gi
+          storageClassName: gold

--- a/deploy/examples/v2/server_postgresql.yaml
+++ b/deploy/examples/v2/server_postgresql.yaml
@@ -10,3 +10,8 @@ spec:
         database:
           type: postgresql
           size: 30Gi
+      - deployments: 1
+        database:
+          type: postgresql
+          size: 30Gi
+          storageClassName: gold

--- a/deploy/examples/v2/storage_class_name.yaml
+++ b/deploy/examples/v2/storage_class_name.yaml
@@ -1,17 +1,17 @@
 apiVersion: app.kiegroup.org/v2
 kind: KieApp
 metadata:
-  name: server-h2
+  name: storage-class-name
 spec:
-  environment: rhpam-trial
+  environment: rhpam-authoring
   objects:
+    console:
+      storageClassName: fast
     servers:
-      - deployments: 2
-        database:
-          type: h2
-          size: 30Gi
       - deployments: 1
         database:
-          type: h2
+          type: mysql
           size: 30Gi
           storageClassName: gold
+    smartRouter:
+      storageClassName: slow

--- a/pkg/apis/app/v2/kieapp_types.go
+++ b/pkg/apis/app/v2/kieapp_types.go
@@ -189,12 +189,13 @@ type JvmObject struct {
 
 // KieAppObject Generic object definition
 type KieAppObject struct {
-	Env            []corev1.EnvVar             `json:"env,omitempty"`
-	Replicas       *int32                      `json:"replicas,omitempty"`
-	Resources      corev1.ResourceRequirements `json:"resources"`
-	KeystoreSecret string                      `json:"keystoreSecret,omitempty"`
-	Image          string                      `json:"image,omitempty"`
-	ImageTag       string                      `json:"imageTag,omitempty"`
+	Env              []corev1.EnvVar             `json:"env,omitempty"`
+	Replicas         *int32                      `json:"replicas,omitempty"`
+	Resources        corev1.ResourceRequirements `json:"resources"`
+	KeystoreSecret   string                      `json:"keystoreSecret,omitempty"`
+	Image            string                      `json:"image,omitempty"`
+	ImageTag         string                      `json:"imageTag,omitempty"`
+	StorageClassName string                      `json:"storageClassName,omitempty"`
 }
 
 type Environment struct {
@@ -347,9 +348,10 @@ const (
 // DatabaseObject Defines how a KieServer will manage and create a new Database
 // or connect to an existing one
 type DatabaseObject struct {
-	Type           DatabaseType            `json:"type,omitempty"`
-	Size           string                  `json:"size,omitempty"`
-	ExternalConfig *ExternalDatabaseObject `json:"externalConfig,omitempty"`
+	Type             DatabaseType            `json:"type,omitempty"`
+	Size             string                  `json:"size,omitempty"`
+	StorageClassName string                  `json:"storageClassName,omitempty"`
+	ExternalConfig   *ExternalDatabaseObject `json:"externalConfig,omitempty"`
 }
 
 // ExternalDatabaseObject configuration definition of an external database
@@ -409,33 +411,35 @@ type TemplateConstants struct {
 
 // ConsoleTemplate contains all the variables used in the yaml templates
 type ConsoleTemplate struct {
-	OmitImageStream bool           `json:"omitImageStream"`
-	SSOAuthClient   SSOAuthClient  `json:"ssoAuthClient,omitempty"`
-	Name            string         `json:"name,omitempty"`
-	Replicas        int32          `json:"replicas,omitempty"`
-	Image           string         `json:"image,omitempty"`
-	ImageTag        string         `json:"imageTag,omitempty"`
-	ImageURL        string         `json:"imageURL,omitempty"`
-	KeystoreSecret  string         `json:"keystoreSecret,omitempty"`
-	GitHooks        GitHooksVolume `json:"gitHooks,omitempty"`
-	Jvm             JvmObject      `json:"jvm,omitempty"`
+	OmitImageStream  bool           `json:"omitImageStream"`
+	SSOAuthClient    SSOAuthClient  `json:"ssoAuthClient,omitempty"`
+	Name             string         `json:"name,omitempty"`
+	Replicas         int32          `json:"replicas,omitempty"`
+	Image            string         `json:"image,omitempty"`
+	ImageTag         string         `json:"imageTag,omitempty"`
+	ImageURL         string         `json:"imageURL,omitempty"`
+	KeystoreSecret   string         `json:"keystoreSecret,omitempty"`
+	GitHooks         GitHooksVolume `json:"gitHooks,omitempty"`
+	Jvm              JvmObject      `json:"jvm,omitempty"`
+	StorageClassName string         `json:"storageClassName,omitempty"`
 }
 
 // ServerTemplate contains all the variables used in the yaml templates
 type ServerTemplate struct {
-	OmitImageStream bool                   `json:"omitImageStream"`
-	KieName         string                 `json:"kieName,omitempty"`
-	KieServerID     string                 `json:"kieServerID,omitempty"`
-	Replicas        int32                  `json:"replicas,omitempty"`
-	SSOAuthClient   SSOAuthClient          `json:"ssoAuthClient,omitempty"`
-	From            corev1.ObjectReference `json:"from,omitempty"`
-	ImageURL        string                 `json:"imageURL,omitempty"`
-	Build           BuildTemplate          `json:"build,omitempty"`
-	KeystoreSecret  string                 `json:"keystoreSecret,omitempty"`
-	Database        DatabaseObject         `json:"database,omitempty"`
-	Jms             KieAppJmsObject        `json:"jms,omitempty"`
-	SmartRouter     SmartRouterObject      `json:"smartRouter,omitempty"`
-	Jvm             JvmObject              `json:"jvm,omitempty"`
+	OmitImageStream  bool                   `json:"omitImageStream"`
+	KieName          string                 `json:"kieName,omitempty"`
+	KieServerID      string                 `json:"kieServerID,omitempty"`
+	Replicas         int32                  `json:"replicas,omitempty"`
+	SSOAuthClient    SSOAuthClient          `json:"ssoAuthClient,omitempty"`
+	From             corev1.ObjectReference `json:"from,omitempty"`
+	ImageURL         string                 `json:"imageURL,omitempty"`
+	Build            BuildTemplate          `json:"build,omitempty"`
+	KeystoreSecret   string                 `json:"keystoreSecret,omitempty"`
+	Database         DatabaseObject         `json:"database,omitempty"`
+	Jms              KieAppJmsObject        `json:"jms,omitempty"`
+	SmartRouter      SmartRouterObject      `json:"smartRouter,omitempty"`
+	Jvm              JvmObject              `json:"jvm,omitempty"`
+	StorageClassName string                 `json:"storageClassName,omitempty"`
 }
 
 // SmartRouterTemplate contains all the variables used in the yaml templates
@@ -448,6 +452,7 @@ type SmartRouterTemplate struct {
 	Image            string `json:"image,omitempty"`
 	ImageTag         string `json:"imageTag,omitempty"`
 	ImageURL         string `json:"imageURL,omitempty"`
+	StorageClassName string `json:"storageClassName,omitempty"`
 }
 
 // ReplicaConstants contains the default replica amounts for a component in a given environment type

--- a/pkg/controller/kieapp/defaults/defaults.go
+++ b/pkg/controller/kieapp/defaults/defaults.go
@@ -6,11 +6,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/RHsyseng/operator-utils/pkg/logs"
-	"github.com/RHsyseng/operator-utils/pkg/utils/kubernetes"
 	"os"
 	"strings"
 	"text/template"
+
+	"github.com/RHsyseng/operator-utils/pkg/logs"
+	"github.com/RHsyseng/operator-utils/pkg/utils/kubernetes"
 
 	"github.com/ghodss/yaml"
 	"github.com/gobuffalo/packr/v2"
@@ -253,6 +254,7 @@ func getConsoleTemplate(cr *api.KieApp) api.ConsoleTemplate {
 	template.Replicas = replicas
 	template.Name = envConstants.App.Prefix
 	template.ImageURL = envConstants.App.Product + "-" + envConstants.App.ImageName + constants.RhelVersion + ":" + cr.Spec.Version
+	template.StorageClassName = cr.Spec.Objects.Console.StorageClassName
 
 	if val, exists := os.LookupEnv(envConstants.App.ImageVar + cr.Spec.Version); exists && !cr.Spec.UseImageTags {
 		template.ImageURL = val
@@ -305,6 +307,7 @@ func getSmartRouterTemplate(cr *api.KieApp) api.SmartRouterTemplate {
 		}
 
 		template.UseExternalRoute = cr.Spec.Objects.SmartRouter.UseExternalRoute
+		template.StorageClassName = cr.Spec.Objects.SmartRouter.StorageClassName
 
 		// Set replicas
 		envReplicas := api.Replicas{}
@@ -422,10 +425,11 @@ func getServersConfig(cr *api.KieApp) ([]api.ServerTemplate, error) {
 			}
 			usedNames[name] = true
 			template := api.ServerTemplate{
-				KieName:        name,
-				KieServerID:    name,
-				Build:          getBuildConfig(product, cr, serverSet),
-				KeystoreSecret: serverSet.KeystoreSecret,
+				KieName:          name,
+				KieServerID:      name,
+				Build:            getBuildConfig(product, cr, serverSet),
+				KeystoreSecret:   serverSet.KeystoreSecret,
+				StorageClassName: serverSet.StorageClassName,
 			}
 			if serverSet.ID != "" {
 				template.KieServerID = serverSet.ID

--- a/pkg/controller/kieapp/defaults/upgrade_test.go
+++ b/pkg/controller/kieapp/defaults/upgrade_test.go
@@ -95,8 +95,8 @@ func TestCheckProductUpgrade(t *testing.T) {
 	assert.True(t, micro)
 
 	diffs = configDiffs(getConfigVersionLists(cr.Spec.Version, constants.CurrentVersion))
-	// assert.NotEmpty(t, diffs)
-	assert.Empty(t, diffs)
+	assert.NotEmpty(t, diffs)
+	// assert.Empty(t, diffs)
 
 	// Past version, all upgrades true
 	cr = &api.KieApp{
@@ -115,8 +115,8 @@ func TestCheckProductUpgrade(t *testing.T) {
 	assert.True(t, micro)
 
 	diffs = configDiffs(getConfigVersionLists(cr.Spec.Version, constants.CurrentVersion))
-	// assert.NotEmpty(t, diffs)
-	assert.Empty(t, diffs)
+	assert.NotEmpty(t, diffs)
+	// assert.Empty(t, diffs)
 
 	// Current version, no upgrades
 	cr = &api.KieApp{
@@ -153,6 +153,6 @@ func TestCheckProductUpgrade(t *testing.T) {
 	assert.False(t, micro)
 
 	diffs = configDiffs(getConfigVersionLists(cr.Spec.Version, constants.CurrentVersion))
-	// assert.NotEmpty(t, diffs)
-	assert.Empty(t, diffs)
+	assert.NotEmpty(t, diffs)
+	// assert.Empty(t, diffs)
 }


### PR DESCRIPTION
in its current state... for HA envs, the `cr.spec.objects.console.storageClassName` setting is also used to configure the datagrid PVCs. 

Signed-off-by: tchughesiv <tchughesiv@gmail.com>