### PR TITLE
fix crd schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,8 @@ clean:
 	rm -rf build/_output \
 		pkg/controller/kieapp/defaults/defaults-packr.go \
 		pkg/controller/kieapp/defaults/packrd \
+		pkg/controller/kieapp/kieapp-packr.go \
+		pkg/controller/kieapp/packrd \
 		pkg/ui/ui-packr.go \
 		pkg/ui/packrd \
 		target/

--- a/deploy/crds/kieapp.crd.yaml
+++ b/deploy/crds/kieapp.crd.yaml
@@ -11,12 +11,29 @@ spec:
     singular: kieapp
   scope: Namespaced
   version: v2
+  additionalPrinterColumns:
+  - name: Version
+    type: string
+    description: The version of the application deployment
+    JSONPath: .spec.version
+  - name: Environment
+    type: string
+    description: The name of the environment used as a baseline
+    JSONPath: .spec.environment
+  - name: Status
+    type: string
+    description: The status of the KieApp deployment
+    JSONPath: .status.phase
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp  
   versions:
     - name: v2
       served: true
       storage: true
       schema:
         openAPIV3Schema:
+          type: object
           required:
             - spec
           properties:
@@ -817,6 +834,7 @@ spec:
       storage: false
       schema:
         openAPIV3Schema:
+          type: object
           required:
             - spec
           properties:

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -104,16 +104,16 @@ github.com/gobuffalo/packd/internal/takeon/github.com/markbates/errx
 # github.com/gobuffalo/packr/v2 v2.7.1 => github.com/gobuffalo/packr/v2 v2.7.1
 github.com/gobuffalo/packr/v2/jam
 github.com/gobuffalo/packr/v2
-github.com/gobuffalo/packr/v2/file/resolver
 github.com/gobuffalo/packr/v2/jam/parser
 github.com/gobuffalo/packr/v2/jam/store
 github.com/gobuffalo/packr/v2/plog
 github.com/gobuffalo/packr/v2/file
+github.com/gobuffalo/packr/v2/file/resolver
 github.com/gobuffalo/packr/v2/internal/takeon/github.com/markbates/oncer
 github.com/gobuffalo/packr/v2/internal/takeon/github.com/markbates/safe
-github.com/gobuffalo/packr/v2/file/resolver/encoding/hex
 github.com/gobuffalo/packr/v2/internal/takeon/github.com/karrick/godirwalk
 github.com/gobuffalo/packr/v2/internal/takeon/github.com/markbates/errx
+github.com/gobuffalo/packr/v2/file/resolver/encoding/hex
 # github.com/gogo/protobuf v1.3.1
 github.com/gogo/protobuf/proto
 github.com/gogo/protobuf/sortkeys


### PR DESCRIPTION
fixes this error seen in ocp4.3.5 when crd is installed -
```
[spec.version[v2].schema.openAPIV3Schema.type: Required value: must not be empty at the root, spec.version[v1].schema.openAPIV3Schema.type: Required value: must not be empty at the root]
```

adds printer columns -
```
$ oc get kieapp
NAME          VERSION   ENVIRONMENT   STATUS     AGE
rhpam-trial   7.8.0     rhpam-trial   Deployed   5m5s
test          7.8.0     rhpam-trial   Deployed   3m55s
```

[WIP] allow `oc explain` to work as expected as well??
https://github.com/kubernetes/kube-openapi/issues/97
https://itnext.io/understanding-kubectl-explain-9d703396cc8

Signed-off-by: tchughesiv <tchughesiv@gmail.com>