### PR TITLE
[RHPAM-2750] additional tests and service annotation fix

### DIFF
--- a/pkg/controller/initializer.go
+++ b/pkg/controller/initializer.go
@@ -22,17 +22,21 @@ func init() {
 			log.Error(err)
 		}
 		if info.IsOpenShift() {
-			version := openshift.MapKnownVersion(info)
-			if version.Version != "" {
-				log.Info(fmt.Sprintf("OpenShift Version: %s", version.Version))
-				reconciler.OcpVersion = version.Version
-				reconciler.OcpVersionMajor = version.MajorVersion()
-				reconciler.OcpVersionMinor = version.MinorVersion()
+			mappedVersion := openshift.MapKnownVersion(info)
+			if mappedVersion.Version != "" {
+				log.Info(fmt.Sprintf("OpenShift Version: %s", mappedVersion.Version))
+				reconciler.OcpVersion = mappedVersion.Version
+				reconciler.OcpVersionMajor = mappedVersion.MajorVersion()
+				reconciler.OcpVersionMinor = mappedVersion.MinorVersion()
+				/* ?? warning if ocp version isn't in SupportedOcpVersions slice ??
+				if _, ok := shared.Find(constants.SupportedOcpVersions, reconciler.OcpVersion); !ok {
+					log.Warn("OpenShift version not supported.")
+				}
+				*/
+			} else {
+				log.Warn("OpenShift version could not be determined.")
 			}
 		}
-
-		// ??? check against supported ocp versions here and log something if version doesn't match???
-
 		kieapp.CreateConsoleYAMLSamples(&reconciler)
 		return kieapp.Add(mgr, &reconciler)
 	}

--- a/pkg/controller/kieapp/shared/utils.go
+++ b/pkg/controller/kieapp/shared/utils.go
@@ -7,14 +7,15 @@ import (
 	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"math/big"
+	"math/rand"
+	"time"
+
 	"github.com/pavel-v-chernykh/keystore-go"
 	"github.com/prometheus/common/log"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"math/big"
-	"math/rand"
-	"time"
 )
 
 // GenerateKeystore returns a Java Keystore with a self-signed certificate
@@ -173,4 +174,13 @@ func GetNamespacedName(object metav1.Object) types.NamespacedName {
 		Name:      object.GetName(),
 		Namespace: object.GetNamespace(),
 	}
+}
+
+func Find(slice []string, val string) (int, bool) {
+	for i, item := range slice {
+		if item == val {
+			return i, true
+		}
+	}
+	return -1, false
 }

--- a/tools/csv-gen/csv-gen.go
+++ b/tools/csv-gen/csv-gen.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kiegroup/kie-cloud-operator/pkg/components"
 	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/constants"
 	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/defaults"
+	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/shared"
 	"github.com/kiegroup/kie-cloud-operator/tools/util"
 	"github.com/kiegroup/kie-cloud-operator/version"
 	oappsv1 "github.com/openshift/api/apps/v1"
@@ -363,7 +364,7 @@ func main() {
 						hub.Client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 							return http.ErrUseLastResponse
 						}
-						if _, exists := find(tags, imageTag); exists {
+						if _, exists := shared.Find(tags, imageTag); exists {
 							req, err := http.NewRequest("GET", url+"/v2/"+repo+"/manifests/"+imageTag, nil)
 							if err != nil {
 								log.Error(err)
@@ -489,13 +490,4 @@ func createFile(filepath string, obj interface{}) {
 	writer := bufio.NewWriter(f)
 	util.MarshallObject(obj, writer)
 	writer.Flush()
-}
-
-func find(slice []string, val string) (int, bool) {
-	for i, item := range slice {
-		if item == val {
-			return i, true
-		}
-	}
-	return -1, false
 }


### PR DESCRIPTION
only ocp v4+ should use `service.beta.openshift.io/serving-cert-secret-name`... while earlier 3.x version should use the `alpha` annotation instead.

Signed-off-by: tchughesiv <tchughesiv@gmail.com>