### PR TITLE
Switch to semver for product & ocp version checks

### DIFF
--- a/deploy/catalog_resources/community/7.8/image-references
+++ b/deploy/catalog_resources/community/7.8/image-references
@@ -112,15 +112,19 @@ spec:
     name: golang-github-openshift-oauth-proxy-container
   - from:
       kind: DockerImage
-      name: registry.redhat.io/openshift4/ose-oauth-proxy:4.3
+      name: registry.redhat.io/openshift4/ose-oauth-proxy:v4.4
     name: golang-github-openshift-oauth-proxy-container
   - from:
       kind: DockerImage
-      name: registry.redhat.io/openshift4/ose-oauth-proxy:4.2
+      name: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3
     name: golang-github-openshift-oauth-proxy-container
   - from:
       kind: DockerImage
-      name: registry.redhat.io/openshift4/ose-oauth-proxy:4.1
+      name: registry.redhat.io/openshift4/ose-oauth-proxy:v4.2
+    name: golang-github-openshift-oauth-proxy-container
+  - from:
+      kind: DockerImage
+      name: registry.redhat.io/openshift4/ose-oauth-proxy:v4.1
     name: golang-github-openshift-oauth-proxy-container
   - from:
       kind: DockerImage

--- a/deploy/catalog_resources/community/7.8/kiecloud-operator.7.8.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/community/7.8/kiecloud-operator.7.8.0.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Integration & Delivery
     certified: "false"
     containerImage: quay.io/kiegroup/kie-cloud-operator:7.8.0
-    createdAt: "2020-04-30 11:12:47"
+    createdAt: "2020-05-01 11:17:24"
     description: Deploys and manages Red Hat Process Automation Manager and Red Hat
       Decision Manager environments.
     repository: https://github.com/kiegroup/kie-cloud-operator

--- a/deploy/catalog_resources/community/7.8/kiecloud-operator.7.8.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/community/7.8/kiecloud-operator.7.8.0.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Integration & Delivery
     certified: "false"
     containerImage: quay.io/kiegroup/kie-cloud-operator:7.8.0
-    createdAt: "2020-04-28 15:29:59"
+    createdAt: "2020-04-30 11:12:47"
     description: Deploys and manages Red Hat Process Automation Manager and Red Hat
       Decision Manager environments.
     repository: https://github.com/kiegroup/kie-cloud-operator
@@ -251,12 +251,14 @@ spec:
                   value: registry.redhat.io/amq7/amq-broker:7.5
                 - name: OAUTH_PROXY_IMAGE_LATEST
                   value: registry.redhat.io/openshift4/ose-oauth-proxy:latest
+                - name: OAUTH_PROXY_IMAGE_4.4
+                  value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.4
                 - name: OAUTH_PROXY_IMAGE_4.3
-                  value: registry.redhat.io/openshift4/ose-oauth-proxy:4.3
+                  value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3
                 - name: OAUTH_PROXY_IMAGE_4.2
-                  value: registry.redhat.io/openshift4/ose-oauth-proxy:4.2
+                  value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.2
                 - name: OAUTH_PROXY_IMAGE_4.1
-                  value: registry.redhat.io/openshift4/ose-oauth-proxy:4.1
+                  value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.1
                 - name: OAUTH_PROXY_IMAGE_3
                   value: registry.redhat.io/openshift3/oauth-proxy:latest
                 image: quay.io/kiegroup/kie-cloud-operator:7.8.0
@@ -488,11 +490,13 @@ spec:
     name: rhpam-smartrouter-rhel8
   - image: registry.redhat.io/openshift4/ose-oauth-proxy:latest
     name: ose-oauth-proxy
-  - image: registry.redhat.io/openshift4/ose-oauth-proxy:4.3
+  - image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.4
     name: ose-oauth-proxy
-  - image: registry.redhat.io/openshift4/ose-oauth-proxy:4.2
+  - image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3
     name: ose-oauth-proxy
-  - image: registry.redhat.io/openshift4/ose-oauth-proxy:4.1
+  - image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.2
+    name: ose-oauth-proxy
+  - image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.1
     name: ose-oauth-proxy
   - image: registry.redhat.io/openshift3/oauth-proxy:latest
     name: oauth-proxy

--- a/deploy/catalog_resources/redhat/7.8/businessautomation-operator.7.8.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/redhat/7.8/businessautomation-operator.7.8.0.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Integration & Delivery
     certified: "true"
     containerImage: registry.redhat.io/rhpam-7/rhpam-rhel8-operator:7.8.0
-    createdAt: "2020-04-28 15:29:59"
+    createdAt: "2020-04-30 11:12:47"
     description: Deploys and manages Red Hat Process Automation Manager and Red Hat
       Decision Manager environments.
     repository: https://github.com/kiegroup/kie-cloud-operator
@@ -251,12 +251,14 @@ spec:
                   value: registry.redhat.io/amq7/amq-broker:7.5
                 - name: OAUTH_PROXY_IMAGE_LATEST
                   value: registry.redhat.io/openshift4/ose-oauth-proxy:latest
+                - name: OAUTH_PROXY_IMAGE_4.4
+                  value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.4
                 - name: OAUTH_PROXY_IMAGE_4.3
-                  value: registry.redhat.io/openshift4/ose-oauth-proxy:4.3
+                  value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3
                 - name: OAUTH_PROXY_IMAGE_4.2
-                  value: registry.redhat.io/openshift4/ose-oauth-proxy:4.2
+                  value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.2
                 - name: OAUTH_PROXY_IMAGE_4.1
-                  value: registry.redhat.io/openshift4/ose-oauth-proxy:4.1
+                  value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.1
                 - name: OAUTH_PROXY_IMAGE_3
                   value: registry.redhat.io/openshift3/oauth-proxy:latest
                 image: registry.redhat.io/rhpam-7/rhpam-rhel8-operator:7.8.0
@@ -488,11 +490,13 @@ spec:
     name: rhpam-smartrouter-rhel8
   - image: registry.redhat.io/openshift4/ose-oauth-proxy:latest
     name: ose-oauth-proxy
-  - image: registry.redhat.io/openshift4/ose-oauth-proxy:4.3
+  - image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.4
     name: ose-oauth-proxy
-  - image: registry.redhat.io/openshift4/ose-oauth-proxy:4.2
+  - image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3
     name: ose-oauth-proxy
-  - image: registry.redhat.io/openshift4/ose-oauth-proxy:4.1
+  - image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.2
+    name: ose-oauth-proxy
+  - image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.1
     name: ose-oauth-proxy
   - image: registry.redhat.io/openshift3/oauth-proxy:latest
     name: oauth-proxy

--- a/deploy/catalog_resources/redhat/7.8/businessautomation-operator.7.8.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/redhat/7.8/businessautomation-operator.7.8.0.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Integration & Delivery
     certified: "true"
     containerImage: registry.redhat.io/rhpam-7/rhpam-rhel8-operator:7.8.0
-    createdAt: "2020-04-30 11:12:47"
+    createdAt: "2020-05-01 11:17:24"
     description: Deploys and manages Red Hat Process Automation Manager and Red Hat
       Decision Manager environments.
     repository: https://github.com/kiegroup/kie-cloud-operator

--- a/deploy/catalog_resources/redhat/7.8/image-references
+++ b/deploy/catalog_resources/redhat/7.8/image-references
@@ -112,15 +112,19 @@ spec:
     name: golang-github-openshift-oauth-proxy-container
   - from:
       kind: DockerImage
-      name: registry.redhat.io/openshift4/ose-oauth-proxy:4.3
+      name: registry.redhat.io/openshift4/ose-oauth-proxy:v4.4
     name: golang-github-openshift-oauth-proxy-container
   - from:
       kind: DockerImage
-      name: registry.redhat.io/openshift4/ose-oauth-proxy:4.2
+      name: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3
     name: golang-github-openshift-oauth-proxy-container
   - from:
       kind: DockerImage
-      name: registry.redhat.io/openshift4/ose-oauth-proxy:4.1
+      name: registry.redhat.io/openshift4/ose-oauth-proxy:v4.2
+    name: golang-github-openshift-oauth-proxy-container
+  - from:
+      kind: DockerImage
+      name: registry.redhat.io/openshift4/ose-oauth-proxy:v4.1
     name: golang-github-openshift-oauth-proxy-container
   - from:
       kind: DockerImage

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -119,12 +119,14 @@ spec:
           value: registry.redhat.io/amq7/amq-broker:7.5
         - name: OAUTH_PROXY_IMAGE_LATEST
           value: registry.redhat.io/openshift4/ose-oauth-proxy:latest
+        - name: OAUTH_PROXY_IMAGE_4.4
+          value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.4
         - name: OAUTH_PROXY_IMAGE_4.3
-          value: registry.redhat.io/openshift4/ose-oauth-proxy:4.3
+          value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3
         - name: OAUTH_PROXY_IMAGE_4.2
-          value: registry.redhat.io/openshift4/ose-oauth-proxy:4.2
+          value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.2
         - name: OAUTH_PROXY_IMAGE_4.1
-          value: registry.redhat.io/openshift4/ose-oauth-proxy:4.1
+          value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.1
         - name: OAUTH_PROXY_IMAGE_3
           value: registry.redhat.io/openshift3/oauth-proxy:latest
         image: quay.io/kiegroup/kie-cloud-operator:7.8.0

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/tidwall/gjson v1.4.0 // indirect
 	github.com/tidwall/sjson v1.0.4
+	golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee
 	k8s.io/api v0.17.2
 	k8s.io/apiextensions-apiserver v0.17.2-0.20200115000228-b5a272542936
 	k8s.io/apimachinery v0.17.3-beta.0

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -4,7 +4,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/blang/semver"
 	monv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	v1 "github.com/kiegroup/kie-cloud-operator/pkg/apis/app/v1"
 	api "github.com/kiegroup/kie-cloud-operator/pkg/apis/app/v2"
@@ -15,7 +14,7 @@ import (
 	oimagev1 "github.com/openshift/api/image/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	csvv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
-	"github.com/prometheus/common/log"
+	"golang.org/x/mod/semver"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -116,12 +115,8 @@ func GetDeployment(operatorName, repository, context, imageName, tag, imagePullP
 	}
 	sort.Sort(sort.Reverse(sort.StringSlice(constants.SupportedVersions)))
 	for _, imageVersion := range constants.SupportedVersions {
-		v, err := semver.New(imageVersion)
-		if err != nil {
-			log.Error(err)
-		}
 		for _, i := range constants.Images {
-			if i.Var == constants.PamProcessMigrationVar && v.LT(semver.MustParse("7.8.0")) {
+			if i.Var == constants.PamProcessMigrationVar && semver.Compare(semver.MajorMinor("v"+imageVersion), "v7.8") < 0 {
 				continue
 			}
 			deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{

--- a/pkg/controller/kieapp/constants/constants.go
+++ b/pkg/controller/kieapp/constants/constants.go
@@ -19,7 +19,8 @@ const (
 var SupportedVersions = []string{CurrentVersion, PriorVersion1, PriorVersion2}
 
 // SupportedOcpVersions - Supported OpenShift minor versions
-var SupportedOcpVersions = []string{"4.3", "4.2", "4.1", "3.11"}
+// var SupportedOcpVersions = []string{"4.4", "4.3", "4.2", "4.1", "3.11"}
+var SupportedOcpVersions = []string{"4.4", "4.3", "4.2", "4.1"}
 
 const (
 	// RhpamPrefix RHPAM prefix

--- a/pkg/controller/kieapp/defaults/defaults.go
+++ b/pkg/controller/kieapp/defaults/defaults.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/RHsyseng/operator-utils/pkg/logs"
 	"github.com/RHsyseng/operator-utils/pkg/utils/kubernetes"
-	"github.com/blang/semver"
 	"github.com/ghodss/yaml"
 	"github.com/gobuffalo/packr/v2"
 	"github.com/imdario/mergo"
@@ -20,6 +19,7 @@ import (
 	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/constants"
 	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/shared"
 	"github.com/kiegroup/kie-cloud-operator/version"
+	"golang.org/x/mod/semver"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1030,11 +1030,7 @@ func deployProcessMigration(cr *api.KieApp) bool {
 }
 
 func isGE78(cr *api.KieApp) bool {
-	v, err := semver.New(cr.Status.Applied.Version)
-	if err != nil {
-		log.Error(err)
-	}
-	return err == nil && v != nil && v.GE(semver.MustParse("7.8.0"))
+	return semver.Compare(semver.MajorMinor("v"+cr.Status.Applied.Version), "v7.8") >= 0
 }
 
 func getDatabaseDeploymentTemplate(cr *api.KieApp, serversConfig []api.ServerTemplate,

--- a/pkg/controller/kieapp/deploy_ui_test.go
+++ b/pkg/controller/kieapp/deploy_ui_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/blang/semver"
 	"github.com/ghodss/yaml"
 	"github.com/gobuffalo/packr/v2"
 	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/constants"
@@ -26,8 +27,6 @@ import (
 )
 
 func TestUpdateLink(t *testing.T) {
-	service := test.MockServiceWithExtraScheme(&operators.ClusterServiceVersion{}, &appsv1.Deployment{}, &corev1.Pod{}, &corev1.ConfigMap{})
-
 	opMajor, opMinor, _ := defaults.MajorMinorMicro(version.Version)
 	box := packr.New("CSV", "../../../deploy/catalog_resources/redhat/"+opMajor+"."+opMinor)
 	bytes, err := box.Find("businessautomation-operator." + version.Version + ".clusterserviceversion.yaml")
@@ -36,47 +35,10 @@ func TestUpdateLink(t *testing.T) {
 	err = yaml.Unmarshal(bytes, csv)
 	assert.Nil(t, err, "Error parsing CSV file")
 	assert.False(t, strings.Contains(csv.Spec.Description, constants.ConsoleDescription), "Should be no information about link in description")
-
-	err = service.Create(context.TODO(), csv)
-	assert.Nil(t, err, "Error creating the CSV")
-
-	box = packr.New("Operator", "../../../deploy")
-	bytes, err = box.Find("operator.yaml")
-	assert.Nil(t, err, "Error reading Operator file")
-	operator := &appsv1.Deployment{}
-	err = yaml.Unmarshal(bytes, operator)
-	assert.Nil(t, err, "Error parsing Operator file")
-
-	operator.Namespace = "placeholder"
-	err = controllerutil.SetControllerReference(csv, operator, service.GetScheme())
-	assert.Nil(t, err, "Error setting operator owner as CSV")
-
-	err = service.Create(context.TODO(), operator)
-	assert.Nil(t, err, "Error creating the Operator")
-
-	var url string
-	service.CreateFunc = func(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
-		if route, matched := obj.(*routev1.Route); matched {
-			url = fmt.Sprintf("%s.apps.example.com", route.Name)
-			route.Spec.Host = url
-		}
-		return service.Client.Create(ctx, obj, opts...)
-	}
-	deployConsole(&Reconciler{Service: service}, operator)
-
-	updatedCSV := &operators.ClusterServiceVersion{}
-	err = service.Get(context.TODO(), types.NamespacedName{Name: csv.Name, Namespace: csv.Namespace}, updatedCSV)
-	assert.Nil(t, err, "Error fetching CSV from client")
-
-	link := getConsoleLink(updatedCSV)
-	assert.NotNil(t, link, "Found no console link in CSV")
-	assert.True(t, strings.Contains(updatedCSV.Spec.Description, constants.ConsoleDescription), "Found no information about link in description")
-	assert.Equal(t, fmt.Sprintf("https://%s", url), link.URL, "The console link did not have the expected value")
+	checkCSV(t, csv)
 }
 
 func TestUpdateExistingLink(t *testing.T) {
-	service := test.MockServiceWithExtraScheme(&operators.ClusterServiceVersion{}, &appsv1.Deployment{}, &corev1.Pod{})
-
 	opMajor, opMinor, _ := defaults.MajorMinorMicro(version.Version)
 	box := packr.New("CSV", "../../../deploy/catalog_resources/redhat/"+opMajor+"."+opMinor)
 	bytes, err := box.Find("businessautomation-operator." + version.Version + ".clusterserviceversion.yaml")
@@ -85,58 +47,28 @@ func TestUpdateExistingLink(t *testing.T) {
 	err = yaml.Unmarshal(bytes, csv)
 	assert.Nil(t, err, "Error parsing CSV file")
 	assert.False(t, strings.Contains(csv.Spec.Description, constants.ConsoleDescription), "Should be no information about link in description")
-
 	csv.Spec.Links = append([]operators.AppLink{{Name: constants.ConsoleLinkName, URL: "some-bad-link"}}, csv.Spec.Links...)
-
-	err = service.Create(context.TODO(), csv)
-	assert.Nil(t, err, "Error creating the CSV")
-
-	box = packr.New("Operator", "../../../deploy")
-	bytes, err = box.Find("operator.yaml")
-	assert.Nil(t, err, "Error reading Operator file")
-	operator := &appsv1.Deployment{}
-	err = yaml.Unmarshal(bytes, operator)
-	assert.Nil(t, err, "Error parsing Operator file")
-
-	operator.Namespace = "placeholder"
-	err = controllerutil.SetControllerReference(csv, operator, service.GetScheme())
-	assert.Nil(t, err, "Error setting operator owner as CSV")
-
-	err = service.Create(context.TODO(), operator)
-	assert.Nil(t, err, "Error creating the Operator")
-
-	var url string
-	service.CreateFunc = func(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
-		if route, matched := obj.(*routev1.Route); matched {
-			url = fmt.Sprintf("%s.apps.example.com", route.Name)
-			route.Spec.Host = url
-		}
-		return service.Client.Create(ctx, obj, opts...)
-	}
-	deployConsole(&Reconciler{Service: service}, operator)
-
-	updatedCSV := &operators.ClusterServiceVersion{}
-	err = service.Get(context.TODO(), types.NamespacedName{Name: csv.Name, Namespace: csv.Namespace}, updatedCSV)
-	assert.Nil(t, err, "Error fetching CSV from client")
-
-	link := getConsoleLink(updatedCSV)
-	assert.NotNil(t, link, "Found no console link in CSV")
-	assert.True(t, strings.Contains(updatedCSV.Spec.Description, constants.ConsoleDescription), "Found no information about link in description")
-	assert.Equal(t, fmt.Sprintf("https://%s", url), link.URL, "The console link did not have the expected value")
+	checkCSV(t, csv)
 }
 
 func TestProxyVersion(t *testing.T) {
-	checkConsoleProxySettings(t, "4.3")
-	checkConsoleProxySettings(t, "4.2")
-	checkConsoleProxySettings(t, "4.1")
+	checkConsoleProxySettings(t, "4.3.2")
+	checkConsoleProxySettings(t, "4.3.0")
+	checkConsoleProxySettings(t, "4.2.0")
+	checkConsoleProxySettings(t, "4.1.0")
+
 	// ocp 3.x versions should default to latest oauth3 image
-	checkConsoleProxySettings(t, "3.11")
-	checkConsoleProxySettings(t, "3.5")
+	checkConsoleProxySettings(t, "3.11.0")
+	checkConsoleProxySettings(t, "3.5.0")
+
 	// unknown ocp version should default to 'latest' proxy image
-	checkConsoleProxySettings(t, "7.3")
+	checkConsoleProxySettings(t, "7.3.5")
+	checkConsoleProxySettings(t, "4.11.0")
+	checkConsoleProxySettings(t, "")
 }
 
-func checkConsoleProxySettings(t *testing.T, ocpVersion string) {
+func checkConsoleProxySettings(t *testing.T, version string) {
+	var v *semver.Version
 	box := packr.New("Operator", "../../../deploy")
 	bytes, err := box.Find("operator.yaml")
 	assert.Nil(t, err, "Error reading Operator file")
@@ -144,44 +76,103 @@ func checkConsoleProxySettings(t *testing.T, ocpVersion string) {
 	err = yaml.Unmarshal(bytes, operator)
 	assert.Nil(t, err, "Error parsing Operator file")
 	operatorName = operator.Name
-	ocpVersionMajor := strings.Split(ocpVersion, ".")[0]
-	ocpVersionMinor := strings.Split(ocpVersion, ".")[1]
+	if version != "" {
+		v, err = semver.New(version)
+		assert.Nil(t, err)
+	}
+	var ocpMajor, ocpMinor uint64
+	if v != nil {
+		ocpMajor = v.Major
+		ocpMinor = v.Minor
+	}
 	for _, envVar := range operator.Spec.Template.Spec.Containers[0].Env {
-		if envVar.Name == constants.OauthVar+ocpVersion {
+		if envVar.Name == fmt.Sprintf(constants.OauthVar+"%d.%d", ocpMajor, ocpMinor) {
 			os.Setenv(envVar.Name, envVar.Value)
 		}
 	}
 	for _, envVar := range operator.Spec.Template.Spec.Containers[0].Env {
-		if envVar.Name == constants.OauthVar+"3" {
+		if envVar.Name == fmt.Sprintf(constants.OauthVar+"%d", ocpMinor) {
 			os.Setenv(envVar.Name, envVar.Value)
 		}
 	}
-	pod := getPod(operator.Namespace, getImage(operator), "saName", ocpVersionMajor, ocpVersionMinor, operator)
+	pod := getPod(operator.Namespace, getImage(operator), "saName", v, operator)
 	caBundlePath := "--openshift-ca=/etc/pki/ca-trust/extracted/crt/ca-bundle.crt"
-	if ocpVersionMajor < "4" {
-		assert.Equal(t, getService(pod.Namespace, ocpVersionMajor).Annotations,
+	if ocpMajor == 3 {
+		assert.NotContains(t, pod.Spec.Containers[0].Args, caBundlePath)
+		assert.Equal(t,
 			map[string]string{
 				"service.alpha.openshift.io/serving-cert-secret-name": operator.Name + "-proxy-tls",
 			},
+			getService(pod.Namespace, ocpMajor).Annotations,
 			"should use service.alpha.openshift.io version of serving-cert-secret-name",
 		)
 		assert.Equal(t, constants.Oauth3ImageLatestURL, pod.Spec.Containers[0].Image)
 	} else {
-		assert.Equal(t, getService(pod.Namespace, ocpVersionMajor).Annotations,
+		if v == nil || v.GE(semver.MustParse("4.2.0")) {
+			assert.Contains(t, pod.Spec.Containers[0].Args, caBundlePath)
+		} else {
+			log.Warn(err)
+		}
+		assert.Equal(t,
 			map[string]string{
 				"service.beta.openshift.io/serving-cert-secret-name": operator.Name + "-proxy-tls",
 			},
+			getService(pod.Namespace, ocpMajor).Annotations,
 			"should use service.beta.openshift.io version of serving-cert-secret-name",
 		)
-		if _, ok := shared.Find(constants.SupportedOcpVersions, ocpVersion); ok {
-			assert.Equal(t, constants.Oauth4ImageURL+":"+ocpVersion, pod.Spec.Containers[0].Image)
+		if _, ok := shared.Find(constants.SupportedOcpVersions, fmt.Sprintf("%d.%d", ocpMajor, ocpMinor)); ok {
+			assert.Equal(t, constants.Oauth4ImageURL+":v"+fmt.Sprintf("%d.%d", ocpMajor, ocpMinor), pod.Spec.Containers[0].Image)
 		} else {
 			assert.Equal(t, constants.Oauth4ImageLatestURL, pod.Spec.Containers[0].Image)
 		}
 	}
-	if ocpVersion >= "4.2" {
+	if v == nil || v.GE(semver.MustParse("4.2.0")) {
 		assert.Contains(t, pod.Spec.Containers[0].Args, caBundlePath)
 	} else {
 		assert.NotContains(t, pod.Spec.Containers[0].Args, caBundlePath)
 	}
+	os.Clearenv()
+}
+
+func checkCSV(t *testing.T, csv *operators.ClusterServiceVersion) {
+	service := test.MockServiceWithExtraScheme(&operators.ClusterServiceVersion{}, &appsv1.Deployment{}, &corev1.Pod{})
+	err := service.Create(context.TODO(), csv)
+	assert.Nil(t, err, "Error creating the CSV")
+
+	box := packr.New("Operator", "../../../deploy")
+	bytes, err := box.Find("operator.yaml")
+	assert.Nil(t, err, "Error reading Operator file")
+	operator := &appsv1.Deployment{}
+	err = yaml.Unmarshal(bytes, operator)
+	assert.Nil(t, err, "Error parsing Operator file")
+
+	operator.Namespace = "placeholder"
+	err = controllerutil.SetControllerReference(csv, operator, service.GetScheme())
+	assert.Nil(t, err, "Error setting operator owner as CSV")
+
+	err = service.Create(context.TODO(), operator)
+	assert.Nil(t, err, "Error creating the Operator")
+
+	var url string
+	service.CreateFunc = func(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
+		if route, matched := obj.(*routev1.Route); matched {
+			url = fmt.Sprintf("%s.apps.example.com", route.Name)
+			route.Spec.Host = url
+		}
+		return service.Client.Create(ctx, obj, opts...)
+	}
+	v, err := semver.New("4.1.0")
+	if err != nil {
+		log.Warn("OpenShift version could not be parsed.")
+	}
+	deployConsole(&Reconciler{Service: service, OcpVersion: v}, operator)
+
+	updatedCSV := &operators.ClusterServiceVersion{}
+	err = service.Get(context.TODO(), types.NamespacedName{Name: csv.Name, Namespace: csv.Namespace}, updatedCSV)
+	assert.Nil(t, err, "Error fetching CSV from client")
+
+	link := getConsoleLink(updatedCSV)
+	assert.NotNil(t, link, "Found no console link in CSV")
+	assert.True(t, strings.Contains(updatedCSV.Spec.Description, constants.ConsoleDescription), "Found no information about link in description")
+	assert.Equal(t, fmt.Sprintf("https://%s", url), link.URL, "The console link did not have the expected value")
 }

--- a/pkg/controller/kieapp/webconsole.go
+++ b/pkg/controller/kieapp/webconsole.go
@@ -4,6 +4,7 @@ package kieapp
 
 import (
 	"context"
+
 	"github.com/RHsyseng/operator-utils/pkg/utils/openshift"
 	"github.com/ghodss/yaml"
 	"github.com/gobuffalo/packr/v2"

--- a/tools/csv-gen/csv-gen.go
+++ b/tools/csv-gen/csv-gen.go
@@ -312,8 +312,12 @@ func main() {
 
 		sort.Sort(sort.Reverse(sort.StringSlice(constants.SupportedVersions)))
 		for _, imageVersion := range constants.SupportedVersions {
+			v, err := semver.New(imageVersion)
+			if err != nil {
+				log.Error(err)
+			}
 			for _, i := range constants.Images {
-				if i.Var == constants.PamProcessMigrationVar && imageVersion < "7.8.0" {
+				if i.Var == constants.PamProcessMigrationVar && v.LT(semver.MustParse("7.8.0")) {
 					continue
 				}
 				relatedImages = addRefRelatedImages(i.Registry+":"+imageVersion, i.Component, imageRef, relatedImages)
@@ -324,8 +328,8 @@ func main() {
 		relatedImages = addRefRelatedImages(constants.Oauth4ImageLatestURL, constants.OauthComponent, imageRef, relatedImages)
 		sort.Sort(sort.Reverse(sort.StringSlice(constants.SupportedOcpVersions)))
 		for _, ocpVersion := range constants.SupportedOcpVersions {
-			if ocpVersion > "4" {
-				relatedImages = addRefRelatedImages(constants.Oauth4ImageURL+":"+ocpVersion, constants.OauthComponent, imageRef, relatedImages)
+			if strings.Split(ocpVersion, ".")[0] == "4" {
+				relatedImages = addRefRelatedImages(constants.Oauth4ImageURL+":v"+ocpVersion, constants.OauthComponent, imageRef, relatedImages)
 			}
 		}
 		relatedImages = addRefRelatedImages(constants.Oauth3ImageLatestURL, constants.OauthComponent, imageRef, relatedImages)

--- a/vendor/golang.org/x/mod/LICENSE
+++ b/vendor/golang.org/x/mod/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/mod/PATENTS
+++ b/vendor/golang.org/x/mod/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/mod/semver/semver.go
+++ b/vendor/golang.org/x/mod/semver/semver.go
@@ -1,0 +1,388 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package semver implements comparison of semantic version strings.
+// In this package, semantic version strings must begin with a leading "v",
+// as in "v1.0.0".
+//
+// The general form of a semantic version string accepted by this package is
+//
+//	vMAJOR[.MINOR[.PATCH[-PRERELEASE][+BUILD]]]
+//
+// where square brackets indicate optional parts of the syntax;
+// MAJOR, MINOR, and PATCH are decimal integers without extra leading zeros;
+// PRERELEASE and BUILD are each a series of non-empty dot-separated identifiers
+// using only alphanumeric characters and hyphens; and
+// all-numeric PRERELEASE identifiers must not have leading zeros.
+//
+// This package follows Semantic Versioning 2.0.0 (see semver.org)
+// with two exceptions. First, it requires the "v" prefix. Second, it recognizes
+// vMAJOR and vMAJOR.MINOR (with no prerelease or build suffixes)
+// as shorthands for vMAJOR.0.0 and vMAJOR.MINOR.0.
+package semver
+
+// parsed returns the parsed form of a semantic version string.
+type parsed struct {
+	major      string
+	minor      string
+	patch      string
+	short      string
+	prerelease string
+	build      string
+	err        string
+}
+
+// IsValid reports whether v is a valid semantic version string.
+func IsValid(v string) bool {
+	_, ok := parse(v)
+	return ok
+}
+
+// Canonical returns the canonical formatting of the semantic version v.
+// It fills in any missing .MINOR or .PATCH and discards build metadata.
+// Two semantic versions compare equal only if their canonical formattings
+// are identical strings.
+// The canonical invalid semantic version is the empty string.
+func Canonical(v string) string {
+	p, ok := parse(v)
+	if !ok {
+		return ""
+	}
+	if p.build != "" {
+		return v[:len(v)-len(p.build)]
+	}
+	if p.short != "" {
+		return v + p.short
+	}
+	return v
+}
+
+// Major returns the major version prefix of the semantic version v.
+// For example, Major("v2.1.0") == "v2".
+// If v is an invalid semantic version string, Major returns the empty string.
+func Major(v string) string {
+	pv, ok := parse(v)
+	if !ok {
+		return ""
+	}
+	return v[:1+len(pv.major)]
+}
+
+// MajorMinor returns the major.minor version prefix of the semantic version v.
+// For example, MajorMinor("v2.1.0") == "v2.1".
+// If v is an invalid semantic version string, MajorMinor returns the empty string.
+func MajorMinor(v string) string {
+	pv, ok := parse(v)
+	if !ok {
+		return ""
+	}
+	i := 1 + len(pv.major)
+	if j := i + 1 + len(pv.minor); j <= len(v) && v[i] == '.' && v[i+1:j] == pv.minor {
+		return v[:j]
+	}
+	return v[:i] + "." + pv.minor
+}
+
+// Prerelease returns the prerelease suffix of the semantic version v.
+// For example, Prerelease("v2.1.0-pre+meta") == "-pre".
+// If v is an invalid semantic version string, Prerelease returns the empty string.
+func Prerelease(v string) string {
+	pv, ok := parse(v)
+	if !ok {
+		return ""
+	}
+	return pv.prerelease
+}
+
+// Build returns the build suffix of the semantic version v.
+// For example, Build("v2.1.0+meta") == "+meta".
+// If v is an invalid semantic version string, Build returns the empty string.
+func Build(v string) string {
+	pv, ok := parse(v)
+	if !ok {
+		return ""
+	}
+	return pv.build
+}
+
+// Compare returns an integer comparing two versions according to
+// semantic version precedence.
+// The result will be 0 if v == w, -1 if v < w, or +1 if v > w.
+//
+// An invalid semantic version string is considered less than a valid one.
+// All invalid semantic version strings compare equal to each other.
+func Compare(v, w string) int {
+	pv, ok1 := parse(v)
+	pw, ok2 := parse(w)
+	if !ok1 && !ok2 {
+		return 0
+	}
+	if !ok1 {
+		return -1
+	}
+	if !ok2 {
+		return +1
+	}
+	if c := compareInt(pv.major, pw.major); c != 0 {
+		return c
+	}
+	if c := compareInt(pv.minor, pw.minor); c != 0 {
+		return c
+	}
+	if c := compareInt(pv.patch, pw.patch); c != 0 {
+		return c
+	}
+	return comparePrerelease(pv.prerelease, pw.prerelease)
+}
+
+// Max canonicalizes its arguments and then returns the version string
+// that compares greater.
+func Max(v, w string) string {
+	v = Canonical(v)
+	w = Canonical(w)
+	if Compare(v, w) > 0 {
+		return v
+	}
+	return w
+}
+
+func parse(v string) (p parsed, ok bool) {
+	if v == "" || v[0] != 'v' {
+		p.err = "missing v prefix"
+		return
+	}
+	p.major, v, ok = parseInt(v[1:])
+	if !ok {
+		p.err = "bad major version"
+		return
+	}
+	if v == "" {
+		p.minor = "0"
+		p.patch = "0"
+		p.short = ".0.0"
+		return
+	}
+	if v[0] != '.' {
+		p.err = "bad minor prefix"
+		ok = false
+		return
+	}
+	p.minor, v, ok = parseInt(v[1:])
+	if !ok {
+		p.err = "bad minor version"
+		return
+	}
+	if v == "" {
+		p.patch = "0"
+		p.short = ".0"
+		return
+	}
+	if v[0] != '.' {
+		p.err = "bad patch prefix"
+		ok = false
+		return
+	}
+	p.patch, v, ok = parseInt(v[1:])
+	if !ok {
+		p.err = "bad patch version"
+		return
+	}
+	if len(v) > 0 && v[0] == '-' {
+		p.prerelease, v, ok = parsePrerelease(v)
+		if !ok {
+			p.err = "bad prerelease"
+			return
+		}
+	}
+	if len(v) > 0 && v[0] == '+' {
+		p.build, v, ok = parseBuild(v)
+		if !ok {
+			p.err = "bad build"
+			return
+		}
+	}
+	if v != "" {
+		p.err = "junk on end"
+		ok = false
+		return
+	}
+	ok = true
+	return
+}
+
+func parseInt(v string) (t, rest string, ok bool) {
+	if v == "" {
+		return
+	}
+	if v[0] < '0' || '9' < v[0] {
+		return
+	}
+	i := 1
+	for i < len(v) && '0' <= v[i] && v[i] <= '9' {
+		i++
+	}
+	if v[0] == '0' && i != 1 {
+		return
+	}
+	return v[:i], v[i:], true
+}
+
+func parsePrerelease(v string) (t, rest string, ok bool) {
+	// "A pre-release version MAY be denoted by appending a hyphen and
+	// a series of dot separated identifiers immediately following the patch version.
+	// Identifiers MUST comprise only ASCII alphanumerics and hyphen [0-9A-Za-z-].
+	// Identifiers MUST NOT be empty. Numeric identifiers MUST NOT include leading zeroes."
+	if v == "" || v[0] != '-' {
+		return
+	}
+	i := 1
+	start := 1
+	for i < len(v) && v[i] != '+' {
+		if !isIdentChar(v[i]) && v[i] != '.' {
+			return
+		}
+		if v[i] == '.' {
+			if start == i || isBadNum(v[start:i]) {
+				return
+			}
+			start = i + 1
+		}
+		i++
+	}
+	if start == i || isBadNum(v[start:i]) {
+		return
+	}
+	return v[:i], v[i:], true
+}
+
+func parseBuild(v string) (t, rest string, ok bool) {
+	if v == "" || v[0] != '+' {
+		return
+	}
+	i := 1
+	start := 1
+	for i < len(v) {
+		if !isIdentChar(v[i]) && v[i] != '.' {
+			return
+		}
+		if v[i] == '.' {
+			if start == i {
+				return
+			}
+			start = i + 1
+		}
+		i++
+	}
+	if start == i {
+		return
+	}
+	return v[:i], v[i:], true
+}
+
+func isIdentChar(c byte) bool {
+	return 'A' <= c && c <= 'Z' || 'a' <= c && c <= 'z' || '0' <= c && c <= '9' || c == '-'
+}
+
+func isBadNum(v string) bool {
+	i := 0
+	for i < len(v) && '0' <= v[i] && v[i] <= '9' {
+		i++
+	}
+	return i == len(v) && i > 1 && v[0] == '0'
+}
+
+func isNum(v string) bool {
+	i := 0
+	for i < len(v) && '0' <= v[i] && v[i] <= '9' {
+		i++
+	}
+	return i == len(v)
+}
+
+func compareInt(x, y string) int {
+	if x == y {
+		return 0
+	}
+	if len(x) < len(y) {
+		return -1
+	}
+	if len(x) > len(y) {
+		return +1
+	}
+	if x < y {
+		return -1
+	} else {
+		return +1
+	}
+}
+
+func comparePrerelease(x, y string) int {
+	// "When major, minor, and patch are equal, a pre-release version has
+	// lower precedence than a normal version.
+	// Example: 1.0.0-alpha < 1.0.0.
+	// Precedence for two pre-release versions with the same major, minor,
+	// and patch version MUST be determined by comparing each dot separated
+	// identifier from left to right until a difference is found as follows:
+	// identifiers consisting of only digits are compared numerically and
+	// identifiers with letters or hyphens are compared lexically in ASCII
+	// sort order. Numeric identifiers always have lower precedence than
+	// non-numeric identifiers. A larger set of pre-release fields has a
+	// higher precedence than a smaller set, if all of the preceding
+	// identifiers are equal.
+	// Example: 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta <
+	// 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0."
+	if x == y {
+		return 0
+	}
+	if x == "" {
+		return +1
+	}
+	if y == "" {
+		return -1
+	}
+	for x != "" && y != "" {
+		x = x[1:] // skip - or .
+		y = y[1:] // skip - or .
+		var dx, dy string
+		dx, x = nextIdent(x)
+		dy, y = nextIdent(y)
+		if dx != dy {
+			ix := isNum(dx)
+			iy := isNum(dy)
+			if ix != iy {
+				if ix {
+					return -1
+				} else {
+					return +1
+				}
+			}
+			if ix {
+				if len(dx) < len(dy) {
+					return -1
+				}
+				if len(dx) > len(dy) {
+					return +1
+				}
+			}
+			if dx < dy {
+				return -1
+			} else {
+				return +1
+			}
+		}
+	}
+	if x == "" {
+		return -1
+	} else {
+		return +1
+	}
+}
+
+func nextIdent(x string) (dx, rest string) {
+	i := 0
+	for i < len(x) && x[i] != '.' {
+		i++
+	}
+	return x[:i], x[i:]
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -264,6 +264,8 @@ golang.org/x/crypto/ssh/terminal
 # golang.org/x/lint v0.0.0-20200130185559-910be7a94367
 golang.org/x/lint/golint
 golang.org/x/lint
+# golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee
+golang.org/x/mod/semver
 # golang.org/x/net v0.0.0-20200202094626-16171245cfb2
 golang.org/x/net/http2
 golang.org/x/net/http/httpguts


### PR DESCRIPTION
 - `golang.org/x/mod/semver` for ocp and product version checks
 - pim enabled only for product version 7.8+
 - ocp 4.4 added
 - oauth image tags changed to use `v4.x` format
 - ConsoleLink and `inject-trusted-cabundle` ConfigMap only supported in OCP 4.2+
 - ConsoleYAMLSamples only supported in OCP 4.3+

Signed-off-by: tchughesiv <tchughesiv@gmail.com>