### PR TITLE
[KIECLOUD-376] add generated section to KieApp status

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 ## Requirements
 
-- go v1.12+
-- operator-sdk v0.14.1
+- go v1.12.x
+- operator-sdk v0.12.0
 
 ## Build
 

--- a/config/7.8.0/common.yaml
+++ b/config/7.8.0/common.yaml
@@ -446,6 +446,7 @@ smartRouter:
                   - name: KIE_SERVER_ROUTER_HOST
                     valueFrom:
                       fieldRef:
+                        apiVersion: v1
                         fieldPath: status.podIP
                   - name: KIE_SERVER_ROUTER_PORT
                     value: "9000"
@@ -618,10 +619,12 @@ servers:
                     - name: KIE_SERVER_HOST
                       valueFrom:
                         fieldRef:
+                          apiVersion: v1
                           fieldPath: status.podIP
                     - name: KIE_SERVER_ID
                       valueFrom:
                         fieldRef:
+                          apiVersion: v1
                           fieldPath: metadata.labels['services.server.kie.org/kie-server-id']
                     - name: KIE_SERVER_ROUTE_NAME
                       value: "[[.KieName]]"

--- a/deploy/catalog_resources/community/7.8/kiecloud-operator.7.8.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/community/7.8/kiecloud-operator.7.8.0.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Integration & Delivery
     certified: "false"
     containerImage: quay.io/kiegroup/kie-cloud-operator:7.8.0
-    createdAt: "2020-04-28 14:51:44"
+    createdAt: "2020-04-28 15:29:59"
     description: Deploys and manages Red Hat Process Automation Manager and Red Hat
       Decision Manager environments.
     repository: https://github.com/kiegroup/kie-cloud-operator
@@ -84,11 +84,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:label
       statusDescriptors:
-      - description: Deployments for the KieApp environment.
-        displayName: Deployments
-        path: deployments
+      - description: Product version installed.
+        displayName: Version
+        path: version
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:podStatuses
+        - urn:alm:descriptor:com.tectonic.ui:label
       - description: Current phase.
         displayName: Status
         path: phase
@@ -99,11 +99,11 @@ spec:
         path: consoleHost
         x-descriptors:
         - urn:alm:descriptor:org.w3:link
-      - description: Product version installed.
-        displayName: Version
-        path: version
+      - description: Deployments for the KieApp environment.
+        displayName: Deployments
+        path: deployments
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:label
+        - urn:alm:descriptor:com.tectonic.ui:podStatuses
       version: v2
   description: |-
     Deploys and manages Red Hat Process Automation Manager and Red Hat Decision Manager environments.

--- a/deploy/catalog_resources/community/7.8/kiecloud-operator.7.8.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/community/7.8/kiecloud-operator.7.8.0.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Integration & Delivery
     certified: "false"
     containerImage: quay.io/kiegroup/kie-cloud-operator:7.8.0
-    createdAt: "2020-04-14 16:48:47"
+    createdAt: "2020-04-28 14:51:44"
     description: Deploys and manages Red Hat Process Automation Manager and Red Hat
       Decision Manager environments.
     repository: https://github.com/kiegroup/kie-cloud-operator
@@ -83,11 +83,6 @@ spec:
         path: environment
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:label
-      - description: Product version installed.
-        displayName: Version
-        path: version
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:label
       statusDescriptors:
       - description: Deployments for the KieApp environment.
         displayName: Deployments
@@ -104,6 +99,11 @@ spec:
         path: consoleHost
         x-descriptors:
         - urn:alm:descriptor:org.w3:link
+      - description: Product version installed.
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:label
       version: v2
   description: |-
     Deploys and manages Red Hat Process Automation Manager and Red Hat Decision Manager environments.
@@ -188,15 +188,15 @@ spec:
                 - name: PAM_PROCESS_MIGRATION_IMAGE_7.8.0
                   value: registry.redhat.io/rhpam-7/rhpam-process-migration-rhel8:7.8.0
                 - name: OSE_CLI_IMAGE_7.8.0
-                  value: registry.redhat.io/openshift3/ose-cli@sha256:8643bfd9cda3afeb02da4c6e79245d4805b07a7a8d83068fa796df44178fbe5d
+                  value: registry.redhat.io/openshift3/ose-cli:v3.11
                 - name: MYSQL_PROXY_IMAGE_7.8.0
-                  value: registry.redhat.io/rhscl/mysql-57-rhel7@sha256:9a781abe7581cc141e14a7e404ec34125b3e89c008b14f4e7b41e094fd3049fe
+                  value: registry.redhat.io/rhscl/mysql-57-rhel7:latest
                 - name: POSTGRESQL_PROXY_IMAGE_7.8.0
-                  value: registry.redhat.io/rhscl/postgresql-10-rhel7@sha256:8c459a1c790cb81503b16a1bfb296dc2306cbb9e51f24194e8a730416296b006
+                  value: registry.redhat.io/rhscl/postgresql-10-rhel7:latest
                 - name: DATAGRID_IMAGE_7.8.0
-                  value: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift@sha256:3375ec169d274278da56d1401c5c1285f7d2812ea0bde2ac9ad9652b69f80893
+                  value: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.5
                 - name: BROKER_IMAGE_7.8.0
-                  value: registry.redhat.io/amq7/amq-broker@sha256:690b802891b015fa2ca0b5e6d7eee9831772d774754364b9ac73e215f520d6e5
+                  value: registry.redhat.io/amq7/amq-broker:7.6
                 - name: DM_KIESERVER_IMAGE_7.7.1
                   value: registry.redhat.io/rhdm-7/rhdm-kieserver-rhel8:7.7.1
                 - name: DM_CONTROLLER_IMAGE_7.7.1
@@ -214,51 +214,51 @@ spec:
                 - name: PAM_SMARTROUTER_IMAGE_7.7.1
                   value: registry.redhat.io/rhpam-7/rhpam-smartrouter-rhel8:7.7.1
                 - name: OSE_CLI_IMAGE_7.7.1
-                  value: registry.redhat.io/openshift3/ose-cli@sha256:8643bfd9cda3afeb02da4c6e79245d4805b07a7a8d83068fa796df44178fbe5d
+                  value: registry.redhat.io/openshift3/ose-cli:v3.11
                 - name: MYSQL_PROXY_IMAGE_7.7.1
-                  value: registry.redhat.io/rhscl/mysql-57-rhel7@sha256:9a781abe7581cc141e14a7e404ec34125b3e89c008b14f4e7b41e094fd3049fe
+                  value: registry.redhat.io/rhscl/mysql-57-rhel7:latest
                 - name: POSTGRESQL_PROXY_IMAGE_7.7.1
-                  value: registry.redhat.io/rhscl/postgresql-10-rhel7@sha256:8c459a1c790cb81503b16a1bfb296dc2306cbb9e51f24194e8a730416296b006
+                  value: registry.redhat.io/rhscl/postgresql-10-rhel7:latest
                 - name: DATAGRID_IMAGE_7.7.1
-                  value: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift@sha256:3375ec169d274278da56d1401c5c1285f7d2812ea0bde2ac9ad9652b69f80893
+                  value: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.5
                 - name: BROKER_IMAGE_7.7.1
-                  value: registry.redhat.io/amq7/amq-broker@sha256:ba5273b390a4762c21f005fdc92a837680417250dcd5e6d9d3c8f776e9cc372e
+                  value: registry.redhat.io/amq7/amq-broker:7.5
                 - name: DM_KIESERVER_IMAGE_7.7.0
-                  value: registry.redhat.io/rhdm-7/rhdm-kieserver-rhel8@sha256:372d0de47fe02ecacca9f2b48f7ae0f7bfa81f0130eba4f3c6bd8d280c5a9fc1
+                  value: registry.redhat.io/rhdm-7/rhdm-kieserver-rhel8:7.7.0
                 - name: DM_CONTROLLER_IMAGE_7.7.0
-                  value: registry.redhat.io/rhdm-7/rhdm-controller-rhel8@sha256:47779af90707a6b8239ed848cd472eca55949c60927ded8b9ed295716dbb94c9
+                  value: registry.redhat.io/rhdm-7/rhdm-controller-rhel8:7.7.0
                 - name: DM_DC_IMAGE_7.7.0
-                  value: registry.redhat.io/rhdm-7/rhdm-decisioncentral-rhel8@sha256:fe5a2b692031862b8a2c8c869a64d2965e2a6c00490dbf807d8b8f2271b506fc
+                  value: registry.redhat.io/rhdm-7/rhdm-decisioncentral-rhel8:7.7.0
                 - name: PAM_KIESERVER_IMAGE_7.7.0
-                  value: registry.redhat.io/rhpam-7/rhpam-kieserver-rhel8@sha256:d905132e2856709b053442fc586e8c63f5828eea37636bdd76ca57150828f47d
+                  value: registry.redhat.io/rhpam-7/rhpam-kieserver-rhel8:7.7.0
                 - name: PAM_CONTROLLER_IMAGE_7.7.0
-                  value: registry.redhat.io/rhpam-7/rhpam-controller-rhel8@sha256:511bd9427fa369a50df782a6cf7370b4bf42eb5b995a7494ff88d6df6b621a55
+                  value: registry.redhat.io/rhpam-7/rhpam-controller-rhel8:7.7.0
                 - name: PAM_BC_IMAGE_7.7.0
-                  value: registry.redhat.io/rhpam-7/rhpam-businesscentral-rhel8@sha256:4b634fbd2e44cca9bd04d69ff80d36c9d52590c2c02c49e11fb5818c17b9da61
+                  value: registry.redhat.io/rhpam-7/rhpam-businesscentral-rhel8:7.7.0
                 - name: PAM_BC_MONITORING_IMAGE_7.7.0
-                  value: registry.redhat.io/rhpam-7/rhpam-businesscentral-monitoring-rhel8@sha256:18571b10e500d7579f64e1b1d8aecdd7beba45d2c886054342922149f00194b4
+                  value: registry.redhat.io/rhpam-7/rhpam-businesscentral-monitoring-rhel8:7.7.0
                 - name: PAM_SMARTROUTER_IMAGE_7.7.0
-                  value: registry.redhat.io/rhpam-7/rhpam-smartrouter-rhel8@sha256:34ccf7889abce588bf0db5956b1747d785934dc5630135094949318bef49a70e
+                  value: registry.redhat.io/rhpam-7/rhpam-smartrouter-rhel8:7.7.0
                 - name: OSE_CLI_IMAGE_7.7.0
-                  value: registry.redhat.io/openshift3/ose-cli@sha256:8643bfd9cda3afeb02da4c6e79245d4805b07a7a8d83068fa796df44178fbe5d
+                  value: registry.redhat.io/openshift3/ose-cli:v3.11
                 - name: MYSQL_PROXY_IMAGE_7.7.0
-                  value: registry.redhat.io/rhscl/mysql-57-rhel7@sha256:9a781abe7581cc141e14a7e404ec34125b3e89c008b14f4e7b41e094fd3049fe
+                  value: registry.redhat.io/rhscl/mysql-57-rhel7:latest
                 - name: POSTGRESQL_PROXY_IMAGE_7.7.0
-                  value: registry.redhat.io/rhscl/postgresql-10-rhel7@sha256:8c459a1c790cb81503b16a1bfb296dc2306cbb9e51f24194e8a730416296b006
+                  value: registry.redhat.io/rhscl/postgresql-10-rhel7:latest
                 - name: DATAGRID_IMAGE_7.7.0
-                  value: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift@sha256:cfd8c4ac1c495b766dd3ff1a85c35afe092858f8f65b52a5b044811719482236
+                  value: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.3
                 - name: BROKER_IMAGE_7.7.0
-                  value: registry.redhat.io/amq7/amq-broker@sha256:ba5273b390a4762c21f005fdc92a837680417250dcd5e6d9d3c8f776e9cc372e
+                  value: registry.redhat.io/amq7/amq-broker:7.5
                 - name: OAUTH_PROXY_IMAGE_LATEST
-                  value: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:7a4d8734d3a066248569de73c581ce18d12869312a2de70fcd3008dd9e88b897
+                  value: registry.redhat.io/openshift4/ose-oauth-proxy:latest
                 - name: OAUTH_PROXY_IMAGE_4.3
-                  value: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:f32f957063bee5a12787f8ce7990499a62874a2984c883205c6617b9ebe50ea5
+                  value: registry.redhat.io/openshift4/ose-oauth-proxy:4.3
                 - name: OAUTH_PROXY_IMAGE_4.2
-                  value: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4be6afd636c51f83fdd9118eb12768a23acd2c5cd0786b986bf80a9450a5c697
+                  value: registry.redhat.io/openshift4/ose-oauth-proxy:4.2
                 - name: OAUTH_PROXY_IMAGE_4.1
-                  value: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:512a3096734987157936894a0062caf87752150d1902a60f51c67b3cbd6559ab
+                  value: registry.redhat.io/openshift4/ose-oauth-proxy:4.1
                 - name: OAUTH_PROXY_IMAGE_3
-                  value: registry.redhat.io/openshift3/oauth-proxy@sha256:fbf396fa968b2155343d594ea0e4279364195dbb35cf40bfa430b18542e55197
+                  value: registry.redhat.io/openshift3/oauth-proxy:latest
                 image: quay.io/kiegroup/kie-cloud-operator:7.8.0
                 imagePullPolicy: Always
                 name: kie-cloud-operator
@@ -470,45 +470,45 @@ spec:
     name: rhpam-businesscentral-monitoring-rhel8
   - image: registry.redhat.io/rhpam-7/rhpam-smartrouter-rhel8:7.7.1
     name: rhpam-smartrouter-rhel8
-  - image: registry.redhat.io/rhdm-7/rhdm-kieserver-rhel8@sha256:372d0de47fe02ecacca9f2b48f7ae0f7bfa81f0130eba4f3c6bd8d280c5a9fc1
+  - image: registry.redhat.io/rhdm-7/rhdm-kieserver-rhel8:7.7.0
     name: rhdm-kieserver-rhel8
-  - image: registry.redhat.io/rhdm-7/rhdm-controller-rhel8@sha256:47779af90707a6b8239ed848cd472eca55949c60927ded8b9ed295716dbb94c9
+  - image: registry.redhat.io/rhdm-7/rhdm-controller-rhel8:7.7.0
     name: rhdm-controller-rhel8
-  - image: registry.redhat.io/rhdm-7/rhdm-decisioncentral-rhel8@sha256:fe5a2b692031862b8a2c8c869a64d2965e2a6c00490dbf807d8b8f2271b506fc
+  - image: registry.redhat.io/rhdm-7/rhdm-decisioncentral-rhel8:7.7.0
     name: rhdm-decisioncentral-rhel8
-  - image: registry.redhat.io/rhpam-7/rhpam-kieserver-rhel8@sha256:d905132e2856709b053442fc586e8c63f5828eea37636bdd76ca57150828f47d
+  - image: registry.redhat.io/rhpam-7/rhpam-kieserver-rhel8:7.7.0
     name: rhpam-kieserver-rhel8
-  - image: registry.redhat.io/rhpam-7/rhpam-controller-rhel8@sha256:511bd9427fa369a50df782a6cf7370b4bf42eb5b995a7494ff88d6df6b621a55
+  - image: registry.redhat.io/rhpam-7/rhpam-controller-rhel8:7.7.0
     name: rhpam-controller-rhel8
-  - image: registry.redhat.io/rhpam-7/rhpam-businesscentral-rhel8@sha256:4b634fbd2e44cca9bd04d69ff80d36c9d52590c2c02c49e11fb5818c17b9da61
+  - image: registry.redhat.io/rhpam-7/rhpam-businesscentral-rhel8:7.7.0
     name: rhpam-businesscentral-rhel8
-  - image: registry.redhat.io/rhpam-7/rhpam-businesscentral-monitoring-rhel8@sha256:18571b10e500d7579f64e1b1d8aecdd7beba45d2c886054342922149f00194b4
+  - image: registry.redhat.io/rhpam-7/rhpam-businesscentral-monitoring-rhel8:7.7.0
     name: rhpam-businesscentral-monitoring-rhel8
-  - image: registry.redhat.io/rhpam-7/rhpam-smartrouter-rhel8@sha256:34ccf7889abce588bf0db5956b1747d785934dc5630135094949318bef49a70e
+  - image: registry.redhat.io/rhpam-7/rhpam-smartrouter-rhel8:7.7.0
     name: rhpam-smartrouter-rhel8
-  - image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:7a4d8734d3a066248569de73c581ce18d12869312a2de70fcd3008dd9e88b897
+  - image: registry.redhat.io/openshift4/ose-oauth-proxy:latest
     name: ose-oauth-proxy
-  - image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:f32f957063bee5a12787f8ce7990499a62874a2984c883205c6617b9ebe50ea5
+  - image: registry.redhat.io/openshift4/ose-oauth-proxy:4.3
     name: ose-oauth-proxy
-  - image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4be6afd636c51f83fdd9118eb12768a23acd2c5cd0786b986bf80a9450a5c697
+  - image: registry.redhat.io/openshift4/ose-oauth-proxy:4.2
     name: ose-oauth-proxy
-  - image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:512a3096734987157936894a0062caf87752150d1902a60f51c67b3cbd6559ab
+  - image: registry.redhat.io/openshift4/ose-oauth-proxy:4.1
     name: ose-oauth-proxy
-  - image: registry.redhat.io/openshift3/oauth-proxy@sha256:fbf396fa968b2155343d594ea0e4279364195dbb35cf40bfa430b18542e55197
+  - image: registry.redhat.io/openshift3/oauth-proxy:latest
     name: oauth-proxy
-  - image: registry.redhat.io/openshift3/ose-cli@sha256:8643bfd9cda3afeb02da4c6e79245d4805b07a7a8d83068fa796df44178fbe5d
+  - image: registry.redhat.io/openshift3/ose-cli:v3.11
     name: ose-cli
-  - image: registry.redhat.io/rhscl/mysql-57-rhel7@sha256:9a781abe7581cc141e14a7e404ec34125b3e89c008b14f4e7b41e094fd3049fe
+  - image: registry.redhat.io/rhscl/mysql-57-rhel7:latest
     name: mysql-57-rhel7
-  - image: registry.redhat.io/rhscl/postgresql-10-rhel7@sha256:8c459a1c790cb81503b16a1bfb296dc2306cbb9e51f24194e8a730416296b006
+  - image: registry.redhat.io/rhscl/postgresql-10-rhel7:latest
     name: postgresql-10-rhel7
-  - image: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift@sha256:cfd8c4ac1c495b766dd3ff1a85c35afe092858f8f65b52a5b044811719482236
+  - image: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.3
     name: datagrid73-openshift
-  - image: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift@sha256:3375ec169d274278da56d1401c5c1285f7d2812ea0bde2ac9ad9652b69f80893
+  - image: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.5
     name: datagrid73-openshift
-  - image: registry.redhat.io/amq7/amq-broker@sha256:ba5273b390a4762c21f005fdc92a837680417250dcd5e6d9d3c8f776e9cc372e
+  - image: registry.redhat.io/amq7/amq-broker:7.5
     name: amq-broker
-  - image: registry.redhat.io/amq7/amq-broker@sha256:690b802891b015fa2ca0b5e6d7eee9831772d774754364b9ac73e215f520d6e5
+  - image: registry.redhat.io/amq7/amq-broker:7.6
     name: amq-broker
   replaces: kiecloud-operator.1.4.1
   selector:

--- a/deploy/catalog_resources/redhat/7.8/businessautomation-operator.7.8.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/redhat/7.8/businessautomation-operator.7.8.0.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Integration & Delivery
     certified: "true"
     containerImage: registry.redhat.io/rhpam-7/rhpam-rhel8-operator:7.8.0
-    createdAt: "2020-04-14 16:48:47"
+    createdAt: "2020-04-28 14:51:44"
     description: Deploys and manages Red Hat Process Automation Manager and Red Hat
       Decision Manager environments.
     repository: https://github.com/kiegroup/kie-cloud-operator
@@ -83,11 +83,6 @@ spec:
         path: environment
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:label
-      - description: Product version installed.
-        displayName: Version
-        path: version
-        x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:label
       statusDescriptors:
       - description: Deployments for the KieApp environment.
         displayName: Deployments
@@ -104,6 +99,11 @@ spec:
         path: consoleHost
         x-descriptors:
         - urn:alm:descriptor:org.w3:link
+      - description: Product version installed.
+        displayName: Version
+        path: version
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:label
       version: v2
   description: |-
     Deploys and manages Red Hat Process Automation Manager and Red Hat Decision Manager environments.
@@ -188,15 +188,15 @@ spec:
                 - name: PAM_PROCESS_MIGRATION_IMAGE_7.8.0
                   value: registry.redhat.io/rhpam-7/rhpam-process-migration-rhel8:7.8.0
                 - name: OSE_CLI_IMAGE_7.8.0
-                  value: registry.redhat.io/openshift3/ose-cli@sha256:8643bfd9cda3afeb02da4c6e79245d4805b07a7a8d83068fa796df44178fbe5d
+                  value: registry.redhat.io/openshift3/ose-cli:v3.11
                 - name: MYSQL_PROXY_IMAGE_7.8.0
-                  value: registry.redhat.io/rhscl/mysql-57-rhel7@sha256:9a781abe7581cc141e14a7e404ec34125b3e89c008b14f4e7b41e094fd3049fe
+                  value: registry.redhat.io/rhscl/mysql-57-rhel7:latest
                 - name: POSTGRESQL_PROXY_IMAGE_7.8.0
-                  value: registry.redhat.io/rhscl/postgresql-10-rhel7@sha256:8c459a1c790cb81503b16a1bfb296dc2306cbb9e51f24194e8a730416296b006
+                  value: registry.redhat.io/rhscl/postgresql-10-rhel7:latest
                 - name: DATAGRID_IMAGE_7.8.0
-                  value: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift@sha256:3375ec169d274278da56d1401c5c1285f7d2812ea0bde2ac9ad9652b69f80893
+                  value: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.5
                 - name: BROKER_IMAGE_7.8.0
-                  value: registry.redhat.io/amq7/amq-broker@sha256:690b802891b015fa2ca0b5e6d7eee9831772d774754364b9ac73e215f520d6e5
+                  value: registry.redhat.io/amq7/amq-broker:7.6
                 - name: DM_KIESERVER_IMAGE_7.7.1
                   value: registry.redhat.io/rhdm-7/rhdm-kieserver-rhel8:7.7.1
                 - name: DM_CONTROLLER_IMAGE_7.7.1
@@ -214,51 +214,51 @@ spec:
                 - name: PAM_SMARTROUTER_IMAGE_7.7.1
                   value: registry.redhat.io/rhpam-7/rhpam-smartrouter-rhel8:7.7.1
                 - name: OSE_CLI_IMAGE_7.7.1
-                  value: registry.redhat.io/openshift3/ose-cli@sha256:8643bfd9cda3afeb02da4c6e79245d4805b07a7a8d83068fa796df44178fbe5d
+                  value: registry.redhat.io/openshift3/ose-cli:v3.11
                 - name: MYSQL_PROXY_IMAGE_7.7.1
-                  value: registry.redhat.io/rhscl/mysql-57-rhel7@sha256:9a781abe7581cc141e14a7e404ec34125b3e89c008b14f4e7b41e094fd3049fe
+                  value: registry.redhat.io/rhscl/mysql-57-rhel7:latest
                 - name: POSTGRESQL_PROXY_IMAGE_7.7.1
-                  value: registry.redhat.io/rhscl/postgresql-10-rhel7@sha256:8c459a1c790cb81503b16a1bfb296dc2306cbb9e51f24194e8a730416296b006
+                  value: registry.redhat.io/rhscl/postgresql-10-rhel7:latest
                 - name: DATAGRID_IMAGE_7.7.1
-                  value: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift@sha256:3375ec169d274278da56d1401c5c1285f7d2812ea0bde2ac9ad9652b69f80893
+                  value: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.5
                 - name: BROKER_IMAGE_7.7.1
-                  value: registry.redhat.io/amq7/amq-broker@sha256:ba5273b390a4762c21f005fdc92a837680417250dcd5e6d9d3c8f776e9cc372e
+                  value: registry.redhat.io/amq7/amq-broker:7.5
                 - name: DM_KIESERVER_IMAGE_7.7.0
-                  value: registry.redhat.io/rhdm-7/rhdm-kieserver-rhel8@sha256:372d0de47fe02ecacca9f2b48f7ae0f7bfa81f0130eba4f3c6bd8d280c5a9fc1
+                  value: registry.redhat.io/rhdm-7/rhdm-kieserver-rhel8:7.7.0
                 - name: DM_CONTROLLER_IMAGE_7.7.0
-                  value: registry.redhat.io/rhdm-7/rhdm-controller-rhel8@sha256:47779af90707a6b8239ed848cd472eca55949c60927ded8b9ed295716dbb94c9
+                  value: registry.redhat.io/rhdm-7/rhdm-controller-rhel8:7.7.0
                 - name: DM_DC_IMAGE_7.7.0
-                  value: registry.redhat.io/rhdm-7/rhdm-decisioncentral-rhel8@sha256:fe5a2b692031862b8a2c8c869a64d2965e2a6c00490dbf807d8b8f2271b506fc
+                  value: registry.redhat.io/rhdm-7/rhdm-decisioncentral-rhel8:7.7.0
                 - name: PAM_KIESERVER_IMAGE_7.7.0
-                  value: registry.redhat.io/rhpam-7/rhpam-kieserver-rhel8@sha256:d905132e2856709b053442fc586e8c63f5828eea37636bdd76ca57150828f47d
+                  value: registry.redhat.io/rhpam-7/rhpam-kieserver-rhel8:7.7.0
                 - name: PAM_CONTROLLER_IMAGE_7.7.0
-                  value: registry.redhat.io/rhpam-7/rhpam-controller-rhel8@sha256:511bd9427fa369a50df782a6cf7370b4bf42eb5b995a7494ff88d6df6b621a55
+                  value: registry.redhat.io/rhpam-7/rhpam-controller-rhel8:7.7.0
                 - name: PAM_BC_IMAGE_7.7.0
-                  value: registry.redhat.io/rhpam-7/rhpam-businesscentral-rhel8@sha256:4b634fbd2e44cca9bd04d69ff80d36c9d52590c2c02c49e11fb5818c17b9da61
+                  value: registry.redhat.io/rhpam-7/rhpam-businesscentral-rhel8:7.7.0
                 - name: PAM_BC_MONITORING_IMAGE_7.7.0
-                  value: registry.redhat.io/rhpam-7/rhpam-businesscentral-monitoring-rhel8@sha256:18571b10e500d7579f64e1b1d8aecdd7beba45d2c886054342922149f00194b4
+                  value: registry.redhat.io/rhpam-7/rhpam-businesscentral-monitoring-rhel8:7.7.0
                 - name: PAM_SMARTROUTER_IMAGE_7.7.0
-                  value: registry.redhat.io/rhpam-7/rhpam-smartrouter-rhel8@sha256:34ccf7889abce588bf0db5956b1747d785934dc5630135094949318bef49a70e
+                  value: registry.redhat.io/rhpam-7/rhpam-smartrouter-rhel8:7.7.0
                 - name: OSE_CLI_IMAGE_7.7.0
-                  value: registry.redhat.io/openshift3/ose-cli@sha256:8643bfd9cda3afeb02da4c6e79245d4805b07a7a8d83068fa796df44178fbe5d
+                  value: registry.redhat.io/openshift3/ose-cli:v3.11
                 - name: MYSQL_PROXY_IMAGE_7.7.0
-                  value: registry.redhat.io/rhscl/mysql-57-rhel7@sha256:9a781abe7581cc141e14a7e404ec34125b3e89c008b14f4e7b41e094fd3049fe
+                  value: registry.redhat.io/rhscl/mysql-57-rhel7:latest
                 - name: POSTGRESQL_PROXY_IMAGE_7.7.0
-                  value: registry.redhat.io/rhscl/postgresql-10-rhel7@sha256:8c459a1c790cb81503b16a1bfb296dc2306cbb9e51f24194e8a730416296b006
+                  value: registry.redhat.io/rhscl/postgresql-10-rhel7:latest
                 - name: DATAGRID_IMAGE_7.7.0
-                  value: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift@sha256:cfd8c4ac1c495b766dd3ff1a85c35afe092858f8f65b52a5b044811719482236
+                  value: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.3
                 - name: BROKER_IMAGE_7.7.0
-                  value: registry.redhat.io/amq7/amq-broker@sha256:ba5273b390a4762c21f005fdc92a837680417250dcd5e6d9d3c8f776e9cc372e
+                  value: registry.redhat.io/amq7/amq-broker:7.5
                 - name: OAUTH_PROXY_IMAGE_LATEST
-                  value: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:7a4d8734d3a066248569de73c581ce18d12869312a2de70fcd3008dd9e88b897
+                  value: registry.redhat.io/openshift4/ose-oauth-proxy:latest
                 - name: OAUTH_PROXY_IMAGE_4.3
-                  value: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:f32f957063bee5a12787f8ce7990499a62874a2984c883205c6617b9ebe50ea5
+                  value: registry.redhat.io/openshift4/ose-oauth-proxy:4.3
                 - name: OAUTH_PROXY_IMAGE_4.2
-                  value: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4be6afd636c51f83fdd9118eb12768a23acd2c5cd0786b986bf80a9450a5c697
+                  value: registry.redhat.io/openshift4/ose-oauth-proxy:4.2
                 - name: OAUTH_PROXY_IMAGE_4.1
-                  value: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:512a3096734987157936894a0062caf87752150d1902a60f51c67b3cbd6559ab
+                  value: registry.redhat.io/openshift4/ose-oauth-proxy:4.1
                 - name: OAUTH_PROXY_IMAGE_3
-                  value: registry.redhat.io/openshift3/oauth-proxy@sha256:fbf396fa968b2155343d594ea0e4279364195dbb35cf40bfa430b18542e55197
+                  value: registry.redhat.io/openshift3/oauth-proxy:latest
                 image: registry.redhat.io/rhpam-7/rhpam-rhel8-operator:7.8.0
                 imagePullPolicy: Always
                 name: business-automation-operator
@@ -470,45 +470,45 @@ spec:
     name: rhpam-businesscentral-monitoring-rhel8
   - image: registry.redhat.io/rhpam-7/rhpam-smartrouter-rhel8:7.7.1
     name: rhpam-smartrouter-rhel8
-  - image: registry.redhat.io/rhdm-7/rhdm-kieserver-rhel8@sha256:372d0de47fe02ecacca9f2b48f7ae0f7bfa81f0130eba4f3c6bd8d280c5a9fc1
+  - image: registry.redhat.io/rhdm-7/rhdm-kieserver-rhel8:7.7.0
     name: rhdm-kieserver-rhel8
-  - image: registry.redhat.io/rhdm-7/rhdm-controller-rhel8@sha256:47779af90707a6b8239ed848cd472eca55949c60927ded8b9ed295716dbb94c9
+  - image: registry.redhat.io/rhdm-7/rhdm-controller-rhel8:7.7.0
     name: rhdm-controller-rhel8
-  - image: registry.redhat.io/rhdm-7/rhdm-decisioncentral-rhel8@sha256:fe5a2b692031862b8a2c8c869a64d2965e2a6c00490dbf807d8b8f2271b506fc
+  - image: registry.redhat.io/rhdm-7/rhdm-decisioncentral-rhel8:7.7.0
     name: rhdm-decisioncentral-rhel8
-  - image: registry.redhat.io/rhpam-7/rhpam-kieserver-rhel8@sha256:d905132e2856709b053442fc586e8c63f5828eea37636bdd76ca57150828f47d
+  - image: registry.redhat.io/rhpam-7/rhpam-kieserver-rhel8:7.7.0
     name: rhpam-kieserver-rhel8
-  - image: registry.redhat.io/rhpam-7/rhpam-controller-rhel8@sha256:511bd9427fa369a50df782a6cf7370b4bf42eb5b995a7494ff88d6df6b621a55
+  - image: registry.redhat.io/rhpam-7/rhpam-controller-rhel8:7.7.0
     name: rhpam-controller-rhel8
-  - image: registry.redhat.io/rhpam-7/rhpam-businesscentral-rhel8@sha256:4b634fbd2e44cca9bd04d69ff80d36c9d52590c2c02c49e11fb5818c17b9da61
+  - image: registry.redhat.io/rhpam-7/rhpam-businesscentral-rhel8:7.7.0
     name: rhpam-businesscentral-rhel8
-  - image: registry.redhat.io/rhpam-7/rhpam-businesscentral-monitoring-rhel8@sha256:18571b10e500d7579f64e1b1d8aecdd7beba45d2c886054342922149f00194b4
+  - image: registry.redhat.io/rhpam-7/rhpam-businesscentral-monitoring-rhel8:7.7.0
     name: rhpam-businesscentral-monitoring-rhel8
-  - image: registry.redhat.io/rhpam-7/rhpam-smartrouter-rhel8@sha256:34ccf7889abce588bf0db5956b1747d785934dc5630135094949318bef49a70e
+  - image: registry.redhat.io/rhpam-7/rhpam-smartrouter-rhel8:7.7.0
     name: rhpam-smartrouter-rhel8
-  - image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:7a4d8734d3a066248569de73c581ce18d12869312a2de70fcd3008dd9e88b897
+  - image: registry.redhat.io/openshift4/ose-oauth-proxy:latest
     name: ose-oauth-proxy
-  - image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:f32f957063bee5a12787f8ce7990499a62874a2984c883205c6617b9ebe50ea5
+  - image: registry.redhat.io/openshift4/ose-oauth-proxy:4.3
     name: ose-oauth-proxy
-  - image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4be6afd636c51f83fdd9118eb12768a23acd2c5cd0786b986bf80a9450a5c697
+  - image: registry.redhat.io/openshift4/ose-oauth-proxy:4.2
     name: ose-oauth-proxy
-  - image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:512a3096734987157936894a0062caf87752150d1902a60f51c67b3cbd6559ab
+  - image: registry.redhat.io/openshift4/ose-oauth-proxy:4.1
     name: ose-oauth-proxy
-  - image: registry.redhat.io/openshift3/oauth-proxy@sha256:fbf396fa968b2155343d594ea0e4279364195dbb35cf40bfa430b18542e55197
+  - image: registry.redhat.io/openshift3/oauth-proxy:latest
     name: oauth-proxy
-  - image: registry.redhat.io/openshift3/ose-cli@sha256:8643bfd9cda3afeb02da4c6e79245d4805b07a7a8d83068fa796df44178fbe5d
+  - image: registry.redhat.io/openshift3/ose-cli:v3.11
     name: ose-cli
-  - image: registry.redhat.io/rhscl/mysql-57-rhel7@sha256:9a781abe7581cc141e14a7e404ec34125b3e89c008b14f4e7b41e094fd3049fe
+  - image: registry.redhat.io/rhscl/mysql-57-rhel7:latest
     name: mysql-57-rhel7
-  - image: registry.redhat.io/rhscl/postgresql-10-rhel7@sha256:8c459a1c790cb81503b16a1bfb296dc2306cbb9e51f24194e8a730416296b006
+  - image: registry.redhat.io/rhscl/postgresql-10-rhel7:latest
     name: postgresql-10-rhel7
-  - image: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift@sha256:cfd8c4ac1c495b766dd3ff1a85c35afe092858f8f65b52a5b044811719482236
+  - image: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.3
     name: datagrid73-openshift
-  - image: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift@sha256:3375ec169d274278da56d1401c5c1285f7d2812ea0bde2ac9ad9652b69f80893
+  - image: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.5
     name: datagrid73-openshift
-  - image: registry.redhat.io/amq7/amq-broker@sha256:ba5273b390a4762c21f005fdc92a837680417250dcd5e6d9d3c8f776e9cc372e
+  - image: registry.redhat.io/amq7/amq-broker:7.5
     name: amq-broker
-  - image: registry.redhat.io/amq7/amq-broker@sha256:690b802891b015fa2ca0b5e6d7eee9831772d774754364b9ac73e215f520d6e5
+  - image: registry.redhat.io/amq7/amq-broker:7.6
     name: amq-broker
   replaces: businessautomation-operator.1.4.1
   selector:

--- a/deploy/catalog_resources/redhat/7.8/businessautomation-operator.7.8.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/redhat/7.8/businessautomation-operator.7.8.0.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Integration & Delivery
     certified: "true"
     containerImage: registry.redhat.io/rhpam-7/rhpam-rhel8-operator:7.8.0
-    createdAt: "2020-04-28 14:51:44"
+    createdAt: "2020-04-28 15:29:59"
     description: Deploys and manages Red Hat Process Automation Manager and Red Hat
       Decision Manager environments.
     repository: https://github.com/kiegroup/kie-cloud-operator
@@ -84,11 +84,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:label
       statusDescriptors:
-      - description: Deployments for the KieApp environment.
-        displayName: Deployments
-        path: deployments
+      - description: Product version installed.
+        displayName: Version
+        path: version
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:podStatuses
+        - urn:alm:descriptor:com.tectonic.ui:label
       - description: Current phase.
         displayName: Status
         path: phase
@@ -99,11 +99,11 @@ spec:
         path: consoleHost
         x-descriptors:
         - urn:alm:descriptor:org.w3:link
-      - description: Product version installed.
-        displayName: Version
-        path: version
+      - description: Deployments for the KieApp environment.
+        displayName: Deployments
+        path: deployments
         x-descriptors:
-        - urn:alm:descriptor:com.tectonic.ui:label
+        - urn:alm:descriptor:com.tectonic.ui:podStatuses
       version: v2
   description: |-
     Deploys and manages Red Hat Process Automation Manager and Red Hat Decision Manager environments.

--- a/deploy/crds/kieapp.crd.yaml
+++ b/deploy/crds/kieapp.crd.yaml
@@ -15,7 +15,7 @@ spec:
     - name: Version
       type: string
       description: The version of the application deployment
-      JSONPath: .spec.version
+      JSONPath: .status.version
     - name: Environment
       type: string
       description: The name of the environment used as a baseline

--- a/go.sum
+++ b/go.sum
@@ -199,6 +199,7 @@ github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkg
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.6+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
+github.com/emicklei/go-restful v2.11.1+incompatible h1:CjKsv3uWcCMvySPQYKxO8XX3f9zD4FeZRsW4G0B4ffE=
 github.com/emicklei/go-restful v2.11.1+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/euank/go-kmsg-parser v2.0.0+incompatible/go.mod h1:MhmAMZ8V4CYH4ybgdRwPr2TU5ThnS43puaKEMpja1uw=
 github.com/evanphx/json-patch v4.1.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=

--- a/hack/go-fmt.sh
+++ b/hack/go-fmt.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-gofmt -s -l -w cmd/ pkg/ version/
+gofmt -s -l -w cmd/ pkg/ version/ tools/
 
 if [[ -n ${CI} ]]; then
     git diff --exit-code

--- a/pkg/apis/app/v2/conversion.go
+++ b/pkg/apis/app/v2/conversion.go
@@ -29,7 +29,7 @@ func convertKieAppV1toV2(kieAppV1 *v1.KieApp) (*KieApp, error) {
 		},
 		Spec: KieAppSpec{
 			Version: kieAppV1.Spec.CommonConfig.Version,
-			Upgrades: KieAppUpgrades{
+			Upgrades: &KieAppUpgrades{
 				Enabled: *kieAppV1.Spec.Upgrades.Patch,
 				Minor:   kieAppV1.Spec.Upgrades.Minor,
 			},

--- a/pkg/apis/app/v2/conversion.go
+++ b/pkg/apis/app/v2/conversion.go
@@ -29,7 +29,7 @@ func convertKieAppV1toV2(kieAppV1 *v1.KieApp) (*KieApp, error) {
 		},
 		Spec: KieAppSpec{
 			Version: kieAppV1.Spec.CommonConfig.Version,
-			Upgrades: &KieAppUpgrades{
+			Upgrades: KieAppUpgrades{
 				Enabled: *kieAppV1.Spec.Upgrades.Patch,
 				Minor:   kieAppV1.Spec.Upgrades.Minor,
 			},

--- a/pkg/apis/app/v2/kieapp_types.go
+++ b/pkg/apis/app/v2/kieapp_types.go
@@ -20,7 +20,7 @@ type KieAppSpec struct {
 	Objects       KieAppObjects     `json:"objects,omitempty"`
 	CommonConfig  CommonConfig      `json:"commonConfig,omitempty"`
 	Auth          *KieAppAuthObject `json:"auth,omitempty"`
-	Upgrades      *KieAppUpgrades   `json:"upgrades,omitempty"`
+	Upgrades      KieAppUpgrades    `json:"upgrades,omitempty"`
 	UseImageTags  bool              `json:"useImageTags,omitempty"`
 	Version       string            `json:"version,omitempty"`
 }

--- a/pkg/apis/app/v2/kieapp_types.go
+++ b/pkg/apis/app/v2/kieapp_types.go
@@ -1,7 +1,6 @@
 package v2
 
 import (
-	"github.com/RHsyseng/operator-utils/pkg/olm"
 	oappsv1 "github.com/openshift/api/apps/v1"
 	buildv1 "github.com/openshift/api/build/v1"
 	oimagev1 "github.com/openshift/api/image/v1"
@@ -13,22 +12,17 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
-// NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
-
 // KieAppSpec defines the desired state of KieApp
 type KieAppSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
-	// KIE environment type to deploy (prod, authoring, trial, etc)
-	Environment   EnvironmentType  `json:"environment,omitempty"`
-	ImageRegistry *KieAppRegistry  `json:"imageRegistry,omitempty"`
-	Objects       KieAppObjects    `json:"objects,omitempty"`
-	CommonConfig  CommonConfig     `json:"commonConfig,omitempty"`
-	Auth          KieAppAuthObject `json:"auth,omitempty"`
-	Upgrades      KieAppUpgrades   `json:"upgrades,omitempty"`
-	Version       string           `json:"version,omitempty"`
-	UseImageTags  bool             `json:"useImageTags"`
+	Environment   EnvironmentType   `json:"environment,omitempty"`
+	ImageRegistry *KieAppRegistry   `json:"imageRegistry,omitempty"`
+	Objects       KieAppObjects     `json:"objects,omitempty"`
+	CommonConfig  CommonConfig      `json:"commonConfig,omitempty"`
+	Auth          *KieAppAuthObject `json:"auth,omitempty"`
+	Upgrades      *KieAppUpgrades   `json:"upgrades,omitempty"`
+	UseImageTags  bool              `json:"useImageTags,omitempty"`
+	Version       string            `json:"version,omitempty"`
 }
 
 // EnvironmentType describes a possible application environment
@@ -76,7 +70,7 @@ type AppConstants struct {
 // KieAppRegistry defines the registry that should be used for rhpam images
 type KieAppRegistry struct {
 	Registry string `json:"registry,omitempty"` // Registry to use, can also be set w/ "REGISTRY" env variable
-	Insecure bool   `json:"insecure"`           // Specify whether registry is insecure, can also be set w/ "INSECURE" env variable
+	Insecure bool   `json:"insecure,omitempty"` // Specify whether registry is insecure, can also be set w/ "INSECURE" env variable
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -115,8 +109,8 @@ type KieAppObjects struct {
 
 // KieAppUpgrades KIE App product upgrade flags
 type KieAppUpgrades struct {
-	Enabled bool `json:"enabled"`
-	Minor   bool `json:"minor"`
+	Enabled bool `json:"enabled,omitempty"`
+	Minor   bool `json:"minor,omitempty"`
 }
 
 // KieServerSet KIE Server configuration for a single set, or for multiple sets if deployments is set to >1
@@ -191,13 +185,13 @@ type JvmObject struct {
 
 // KieAppObject Generic object definition
 type KieAppObject struct {
-	Env              []corev1.EnvVar             `json:"env,omitempty"`
-	Replicas         *int32                      `json:"replicas,omitempty"`
-	Resources        corev1.ResourceRequirements `json:"resources"`
-	KeystoreSecret   string                      `json:"keystoreSecret,omitempty"`
-	Image            string                      `json:"image,omitempty"`
-	ImageTag         string                      `json:"imageTag,omitempty"`
-	StorageClassName string                      `json:"storageClassName,omitempty"`
+	Env              []corev1.EnvVar              `json:"env,omitempty"`
+	Replicas         *int32                       `json:"replicas,omitempty"`
+	Resources        *corev1.ResourceRequirements `json:"resources,omitempty"`
+	KeystoreSecret   string                       `json:"keystoreSecret,omitempty"`
+	Image            string                       `json:"image,omitempty"`
+	ImageTag         string                       `json:"imageTag,omitempty"`
+	StorageClassName string                       `json:"storageClassName,omitempty"`
 }
 
 type Environment struct {
@@ -581,49 +575,6 @@ type KieServerClient struct {
 	Host     string `json:"host,omitempty"`
 	Username string `json:"username,omitempty"`
 	Password string `json:"password,omitempty"`
-}
-
-// ConditionType - type of condition
-type ConditionType string
-
-const (
-	// DeployedConditionType - the kieapp is deployed
-	DeployedConditionType ConditionType = "Deployed"
-	// ProvisioningConditionType - the kieapp is being provisioned
-	ProvisioningConditionType ConditionType = "Provisioning"
-	// FailedConditionType - the kieapp is in a failed state
-	FailedConditionType ConditionType = "Failed"
-)
-
-// ReasonType - type of reason
-type ReasonType string
-
-const (
-	// DeploymentFailedReason - Unable to deploy the application
-	DeploymentFailedReason ReasonType = "DeploymentFailed"
-	// ConfigurationErrorReason - An invalid configuration caused an error
-	ConfigurationErrorReason ReasonType = "ConfigurationError"
-	// MissingDependenciesReason - Dependencies does not exist or cannot be found
-	MissingDependenciesReason ReasonType = "MissingDependencies"
-	// UnknownReason - Unable to determine the error
-	UnknownReason ReasonType = "Unknown"
-)
-
-// Condition - The condition for the kie-cloud-operator
-type Condition struct {
-	Type               ConditionType          `json:"type"`
-	Status             corev1.ConditionStatus `json:"status"`
-	LastTransitionTime metav1.Time            `json:"lastTransitionTime,omitempty"`
-	Reason             ReasonType             `json:"reason,omitempty"`
-	Message            string                 `json:"message,omitempty"`
-}
-
-// KieAppStatus - The status for custom resources managed by the operator-sdk.
-type KieAppStatus struct {
-	Conditions  []Condition          `json:"conditions"`
-	ConsoleHost string               `json:"consoleHost,omitempty"`
-	Deployments olm.DeploymentStatus `json:"deployments"`
-	Phase       ConditionType        `json:"phase,omitempty"`
 }
 
 func init() {

--- a/pkg/apis/app/v2/status.go
+++ b/pkg/apis/app/v2/status.go
@@ -1,0 +1,53 @@
+package v2
+
+import (
+	"github.com/RHsyseng/operator-utils/pkg/olm"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ConditionType - type of condition
+type ConditionType string
+
+const (
+	// DeployedConditionType - the kieapp is deployed
+	DeployedConditionType ConditionType = "Deployed"
+	// ProvisioningConditionType - the kieapp is being provisioned
+	ProvisioningConditionType ConditionType = "Provisioning"
+	// FailedConditionType - the kieapp is in a failed state
+	FailedConditionType ConditionType = "Failed"
+)
+
+// ReasonType - type of reason
+type ReasonType string
+
+const (
+	// DeploymentFailedReason - Unable to deploy the application
+	DeploymentFailedReason ReasonType = "DeploymentFailed"
+	// ConfigurationErrorReason - An invalid configuration caused an error
+	ConfigurationErrorReason ReasonType = "ConfigurationError"
+	// MissingDependenciesReason - Dependencies does not exist or cannot be found
+	MissingDependenciesReason ReasonType = "MissingDependencies"
+	// UnknownReason - Unable to determine the error
+	UnknownReason ReasonType = "Unknown"
+)
+
+// Condition - The condition for the kie-cloud-operator
+type Condition struct {
+	Type               ConditionType          `json:"type"`
+	Status             corev1.ConditionStatus `json:"status"`
+	LastTransitionTime metav1.Time            `json:"lastTransitionTime,omitempty"`
+	Reason             ReasonType             `json:"reason,omitempty"`
+	Message            string                 `json:"message,omitempty"`
+	Version            string                 `json:"version,omitempty"`
+}
+
+// KieAppStatus - The status for custom resources managed by the operator-sdk.
+type KieAppStatus struct {
+	Conditions  []Condition          `json:"conditions"`
+	ConsoleHost string               `json:"consoleHost,omitempty"`
+	Deployments olm.DeploymentStatus `json:"deployments"`
+	Phase       ConditionType        `json:"phase,omitempty"`
+	Generated   KieAppSpec           `json:"generated,omitempty"`
+	Version     string               `json:"version,omitempty"`
+}

--- a/pkg/apis/app/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/app/v2/zz_generated.deepcopy.go
@@ -714,7 +714,11 @@ func (in *KieAppObject) DeepCopyInto(out *KieAppObject) {
 		*out = new(int32)
 		**out = **in
 	}
-	in.Resources.DeepCopyInto(&out.Resources)
+	if in.Resources != nil {
+		in, out := &in.Resources, &out.Resources
+		*out = new(v1.ResourceRequirements)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 
@@ -788,8 +792,16 @@ func (in *KieAppSpec) DeepCopyInto(out *KieAppSpec) {
 	}
 	in.Objects.DeepCopyInto(&out.Objects)
 	out.CommonConfig = in.CommonConfig
-	in.Auth.DeepCopyInto(&out.Auth)
-	out.Upgrades = in.Upgrades
+	if in.Auth != nil {
+		in, out := &in.Auth, &out.Auth
+		*out = new(KieAppAuthObject)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.Upgrades != nil {
+		in, out := &in.Upgrades, &out.Upgrades
+		*out = new(KieAppUpgrades)
+		**out = **in
+	}
 	return
 }
 
@@ -814,6 +826,7 @@ func (in *KieAppStatus) DeepCopyInto(out *KieAppStatus) {
 		}
 	}
 	in.Deployments.DeepCopyInto(&out.Deployments)
+	in.Generated.DeepCopyInto(&out.Generated)
 	return
 }
 

--- a/pkg/apis/app/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/app/v2/zz_generated.deepcopy.go
@@ -797,11 +797,7 @@ func (in *KieAppSpec) DeepCopyInto(out *KieAppSpec) {
 		*out = new(KieAppAuthObject)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.Upgrades != nil {
-		in, out := &in.Upgrades, &out.Upgrades
-		*out = new(KieAppUpgrades)
-		**out = **in
-	}
+	out.Upgrades = in.Upgrades
 	return
 }
 

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -115,6 +115,9 @@ func GetDeployment(operatorName, repository, context, imageName, tag, imagePullP
 	sort.Sort(sort.Reverse(sort.StringSlice(constants.SupportedVersions)))
 	for _, imageVersion := range constants.SupportedVersions {
 		for _, i := range constants.Images {
+			if i.Var == constants.PamProcessMigrationVar && imageVersion < "7.8.0" {
+				continue
+			}
 			deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
 				Name:  i.Var + imageVersion,
 				Value: i.Registry + ":" + imageVersion,

--- a/pkg/controller/kieapp/defaults/auth_test.go
+++ b/pkg/controller/kieapp/defaults/auth_test.go
@@ -86,7 +86,7 @@ func TestConfigureHostname(t *testing.T) {
 	}
 	cr := &api.KieApp{
 		Spec: api.KieAppSpec{
-			Auth: api.KieAppAuthObject{
+			Auth: &api.KieAppAuthObject{
 				SSO: &api.SSOAuthConfig{
 					URL:   "https://sso.example.com",
 					Realm: "therealm",
@@ -119,7 +119,7 @@ func TestAuthMultipleType(t *testing.T) {
 		},
 		Spec: api.KieAppSpec{
 			Environment: "rhpam-trial",
-			Auth: api.KieAppAuthObject{
+			Auth: &api.KieAppAuthObject{
 				SSO:  &api.SSOAuthConfig{},
 				LDAP: &api.LDAPAuthConfig{},
 			},
@@ -136,7 +136,7 @@ func TestAuthOnlyRoleMapper(t *testing.T) {
 		},
 		Spec: api.KieAppSpec{
 			Environment: "rhpam-trial",
-			Auth: api.KieAppAuthObject{
+			Auth: &api.KieAppAuthObject{
 				RoleMapper: &api.RoleMapperAuthConfig{},
 			},
 		},
@@ -165,7 +165,7 @@ func TestAuthSSOEmptyConfig(t *testing.T) {
 		},
 		Spec: api.KieAppSpec{
 			Environment: "rhpam-trial",
-			Auth: api.KieAppAuthObject{
+			Auth: &api.KieAppAuthObject{
 				SSO: &api.SSOAuthConfig{},
 			},
 		},
@@ -181,7 +181,7 @@ func TestAuthSSOConfig(t *testing.T) {
 		},
 		Spec: api.KieAppSpec{
 			Environment: "rhpam-trial",
-			Auth: api.KieAppAuthObject{
+			Auth: &api.KieAppAuthObject{
 				SSO: &api.SSOAuthConfig{
 					URL:   "https://sso.example.com:8080",
 					Realm: "rhpam-test",
@@ -230,7 +230,7 @@ func TestAuthSSOConfigWithClients(t *testing.T) {
 		},
 		Spec: api.KieAppSpec{
 			Environment: "rhpam-trial",
-			Auth: api.KieAppAuthObject{
+			Auth: &api.KieAppAuthObject{
 				SSO: &api.SSOAuthConfig{
 					URL:   "https://sso.example.com:8080",
 					Realm: "rhpam-test",
@@ -322,7 +322,7 @@ func TestAuthLDAPEmptyConfig(t *testing.T) {
 		},
 		Spec: api.KieAppSpec{
 			Environment: "rhpam-trial",
-			Auth: api.KieAppAuthObject{
+			Auth: &api.KieAppAuthObject{
 				LDAP: &api.LDAPAuthConfig{},
 			},
 		},
@@ -343,7 +343,7 @@ func TestAuthLDAPConfig(t *testing.T) {
 					{Deployments: Pint(2)},
 				},
 			},
-			Auth: api.KieAppAuthObject{
+			Auth: &api.KieAppAuthObject{
 				LDAP: &api.LDAPAuthConfig{
 					URL:    "ldaps://ldap.example.com",
 					BindDN: "cn=admin,dc=example,dc=com",
@@ -503,7 +503,7 @@ func TestAuthRoleMapperConfig(t *testing.T) {
 					{Deployments: Pint(2)},
 				},
 			},
-			Auth: api.KieAppAuthObject{
+			Auth: &api.KieAppAuthObject{
 				LDAP: &api.LDAPAuthConfig{
 					URL:    "ldaps://ldap.example.com",
 					BindDN: "cn=admin,dc=example,dc=com",

--- a/pkg/controller/kieapp/defaults/defaults_test.go
+++ b/pkg/controller/kieapp/defaults/defaults_test.go
@@ -1384,7 +1384,7 @@ func TestKieAppDefaults(t *testing.T) {
 	_, err := GetEnvironment(cr, test.MockService())
 	assert.Nil(t, err)
 
-	assert.Nil(t, cr.Spec.Upgrades)
+	assert.False(t, cr.Spec.Upgrades.Enabled)
 	assert.Empty(t, cr.Spec.CommonConfig.ApplicationName)
 	assert.Nil(t, cr.Spec.Objects.Console.Replicas)
 	assert.Nil(t, cr.Spec.Objects.Servers)

--- a/pkg/controller/kieapp/defaults/merge_test.go
+++ b/pkg/controller/kieapp/defaults/merge_test.go
@@ -1,18 +1,17 @@
 package defaults
 
 import (
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"testing"
-
-	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/test"
 
 	"github.com/ghodss/yaml"
 	api "github.com/kiegroup/kie-cloud-operator/pkg/apis/app/v2"
+	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/test"
 	appsv1 "github.com/openshift/api/apps/v1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func TestMergeServices(t *testing.T) {
@@ -594,7 +593,7 @@ func getParsedTemplateFromCR(cr *api.KieApp, filename string, object interface{}
 		log.Error("Error getting environment template", err)
 	}
 
-	yamlBytes, err := loadYaml(test.MockService(), filename, cr.Spec.Version, cr.Namespace, envTemplate)
+	yamlBytes, err := loadYaml(test.MockService(), filename, GetVersion(cr), cr.Namespace, envTemplate)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/kieapp/defaults/upgrade.go
+++ b/pkg/controller/kieapp/defaults/upgrade.go
@@ -3,14 +3,13 @@ package defaults
 import (
 	"context"
 	"fmt"
-	"github.com/RHsyseng/operator-utils/pkg/utils/kubernetes"
 	"strings"
 
+	"github.com/RHsyseng/operator-utils/pkg/utils/kubernetes"
 	"github.com/gobuffalo/packr/v2"
 	"github.com/google/go-cmp/cmp"
 	api "github.com/kiegroup/kie-cloud-operator/pkg/apis/app/v2"
 	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/constants"
-	"github.com/kiegroup/kie-cloud-operator/version"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -18,13 +17,13 @@ import (
 // checkProductUpgrade ...
 func checkProductUpgrade(cr *api.KieApp) (minor, micro bool, err error) {
 	setDefaults(cr)
-	if checkVersion(cr.Spec.Version) {
-		if cr.Spec.Version != constants.CurrentVersion && cr.Spec.Upgrades.Enabled {
+	if checkVersion(GetVersion(cr)) {
+		if cr.Spec.Upgrades != nil && GetVersion(cr) != constants.CurrentVersion && cr.Spec.Upgrades.Enabled {
 			micro = cr.Spec.Upgrades.Enabled
 			minor = cr.Spec.Upgrades.Minor
 		}
 	} else {
-		err = fmt.Errorf("Product version %s is not allowed in operator version %s. The following versions are allowed - %s", cr.Spec.Version, version.Version, constants.SupportedVersions)
+		err = fmt.Errorf("Product version %s is not allowed. The following versions are allowed - %s", GetVersion(cr), constants.SupportedVersions)
 	}
 	return minor, micro, err
 }

--- a/pkg/controller/kieapp/defaults/upgrade.go
+++ b/pkg/controller/kieapp/defaults/upgrade.go
@@ -18,7 +18,7 @@ import (
 func checkProductUpgrade(cr *api.KieApp) (minor, micro bool, err error) {
 	setDefaults(cr)
 	if checkVersion(GetVersion(cr)) {
-		if cr.Spec.Upgrades != nil && GetVersion(cr) != constants.CurrentVersion && cr.Spec.Upgrades.Enabled {
+		if GetVersion(cr) != constants.CurrentVersion && cr.Spec.Upgrades.Enabled {
 			micro = cr.Spec.Upgrades.Enabled
 			minor = cr.Spec.Upgrades.Minor
 		}

--- a/pkg/controller/kieapp/defaults/upgrade_test.go
+++ b/pkg/controller/kieapp/defaults/upgrade_test.go
@@ -18,7 +18,7 @@ func TestUpgradesTrue(t *testing.T) {
 		},
 		Spec: api.KieAppSpec{
 			Environment: api.RhpamTrial,
-			Upgrades:    &api.KieAppUpgrades{Enabled: true},
+			Upgrades:    api.KieAppUpgrades{Enabled: true},
 		},
 	}
 	_, err := GetEnvironment(cr, test.MockService())
@@ -34,7 +34,7 @@ func TestGetConfigVersionDiffs(t *testing.T) {
 		Spec: api.KieAppSpec{
 			Environment: api.RhpamTrial,
 			Version:     constants.PriorVersion2,
-			Upgrades:    &api.KieAppUpgrades{Enabled: true},
+			Upgrades:    api.KieAppUpgrades{Enabled: true},
 		},
 	}
 	err := getConfigVersionDiffs(GetVersion(cr), constants.CurrentVersion, test.MockService())
@@ -50,7 +50,7 @@ func TestCheckProductUpgrade(t *testing.T) {
 		Spec: api.KieAppSpec{
 			Environment: api.RhpamProduction,
 			Version:     "6.3.1",
-			Upgrades:    &api.KieAppUpgrades{Minor: true, Enabled: true},
+			Upgrades:    api.KieAppUpgrades{Minor: true, Enabled: true},
 		},
 	}
 	minor, micro, err := checkProductUpgrade(cr)
@@ -85,7 +85,7 @@ func TestCheckProductUpgrade(t *testing.T) {
 		Spec: api.KieAppSpec{
 			Environment: api.RhpamProduction,
 			Version:     constants.PriorVersion2,
-			Upgrades:    &api.KieAppUpgrades{Enabled: true},
+			Upgrades:    api.KieAppUpgrades{Enabled: true},
 		},
 	}
 	minor, micro, err = checkProductUpgrade(cr)
@@ -105,7 +105,7 @@ func TestCheckProductUpgrade(t *testing.T) {
 		Spec: api.KieAppSpec{
 			Environment: api.RhpamProduction,
 			Version:     constants.PriorVersion2,
-			Upgrades:    &api.KieAppUpgrades{Minor: true, Enabled: true},
+			Upgrades:    api.KieAppUpgrades{Minor: true, Enabled: true},
 		},
 	}
 	minor, micro, err = checkProductUpgrade(cr)
@@ -124,7 +124,7 @@ func TestCheckProductUpgrade(t *testing.T) {
 		},
 		Spec: api.KieAppSpec{
 			Environment: api.RhpamProduction,
-			Upgrades:    &api.KieAppUpgrades{Minor: true, Enabled: true},
+			Upgrades:    api.KieAppUpgrades{Minor: true, Enabled: true},
 		},
 	}
 	minor, micro, err = checkProductUpgrade(cr)
@@ -143,7 +143,7 @@ func TestCheckProductUpgrade(t *testing.T) {
 		Spec: api.KieAppSpec{
 			Environment: api.RhpamProduction,
 			Version:     constants.PriorVersion2,
-			Upgrades:    &api.KieAppUpgrades{Minor: true, Enabled: false},
+			Upgrades:    api.KieAppUpgrades{Minor: true, Enabled: false},
 		},
 	}
 	minor, micro, err = checkProductUpgrade(cr)

--- a/pkg/controller/kieapp/defaults/upgrade_test.go
+++ b/pkg/controller/kieapp/defaults/upgrade_test.go
@@ -7,7 +7,6 @@ import (
 	api "github.com/kiegroup/kie-cloud-operator/pkg/apis/app/v2"
 	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/constants"
 	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/test"
-	"github.com/kiegroup/kie-cloud-operator/version"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -19,7 +18,7 @@ func TestUpgradesTrue(t *testing.T) {
 		},
 		Spec: api.KieAppSpec{
 			Environment: api.RhpamTrial,
-			Upgrades:    api.KieAppUpgrades{Enabled: true},
+			Upgrades:    &api.KieAppUpgrades{Enabled: true},
 		},
 	}
 	_, err := GetEnvironment(cr, test.MockService())
@@ -35,10 +34,10 @@ func TestGetConfigVersionDiffs(t *testing.T) {
 		Spec: api.KieAppSpec{
 			Environment: api.RhpamTrial,
 			Version:     constants.PriorVersion2,
-			Upgrades:    api.KieAppUpgrades{Enabled: true},
+			Upgrades:    &api.KieAppUpgrades{Enabled: true},
 		},
 	}
-	err := getConfigVersionDiffs(cr.Spec.Version, constants.CurrentVersion, test.MockService())
+	err := getConfigVersionDiffs(GetVersion(cr), constants.CurrentVersion, test.MockService())
 	assert.Error(t, err)
 }
 
@@ -51,16 +50,16 @@ func TestCheckProductUpgrade(t *testing.T) {
 		Spec: api.KieAppSpec{
 			Environment: api.RhpamProduction,
 			Version:     "6.3.1",
-			Upgrades:    api.KieAppUpgrades{Minor: true, Enabled: true},
+			Upgrades:    &api.KieAppUpgrades{Minor: true, Enabled: true},
 		},
 	}
 	minor, micro, err := checkProductUpgrade(cr)
 	assert.Error(t, err, "Incompatible product versions should throw an error")
-	assert.Equal(t, fmt.Sprintf("Product version %s is not allowed in operator version %s. The following versions are allowed - %s", cr.Spec.Version, version.Version, constants.SupportedVersions), err.Error())
+	assert.Equal(t, fmt.Sprintf("Product version %s is not allowed. The following versions are allowed - %s", GetVersion(cr), constants.SupportedVersions), err.Error())
 	assert.False(t, minor)
 	assert.False(t, micro)
 
-	diffs := configDiffs(getConfigVersionLists(cr.Spec.Version, constants.CurrentVersion))
+	diffs := configDiffs(getConfigVersionLists(GetVersion(cr), constants.CurrentVersion))
 	assert.Empty(t, diffs)
 
 	// Upgrades default to false
@@ -86,7 +85,7 @@ func TestCheckProductUpgrade(t *testing.T) {
 		Spec: api.KieAppSpec{
 			Environment: api.RhpamProduction,
 			Version:     constants.PriorVersion2,
-			Upgrades:    api.KieAppUpgrades{Enabled: true},
+			Upgrades:    &api.KieAppUpgrades{Enabled: true},
 		},
 	}
 	minor, micro, err = checkProductUpgrade(cr)
@@ -94,7 +93,7 @@ func TestCheckProductUpgrade(t *testing.T) {
 	assert.False(t, minor)
 	assert.True(t, micro)
 
-	diffs = configDiffs(getConfigVersionLists(cr.Spec.Version, constants.CurrentVersion))
+	diffs = configDiffs(getConfigVersionLists(GetVersion(cr), constants.CurrentVersion))
 	assert.NotEmpty(t, diffs)
 	// assert.Empty(t, diffs)
 
@@ -106,7 +105,7 @@ func TestCheckProductUpgrade(t *testing.T) {
 		Spec: api.KieAppSpec{
 			Environment: api.RhpamProduction,
 			Version:     constants.PriorVersion2,
-			Upgrades:    api.KieAppUpgrades{Minor: true, Enabled: true},
+			Upgrades:    &api.KieAppUpgrades{Minor: true, Enabled: true},
 		},
 	}
 	minor, micro, err = checkProductUpgrade(cr)
@@ -114,7 +113,7 @@ func TestCheckProductUpgrade(t *testing.T) {
 	assert.True(t, minor)
 	assert.True(t, micro)
 
-	diffs = configDiffs(getConfigVersionLists(cr.Spec.Version, constants.CurrentVersion))
+	diffs = configDiffs(getConfigVersionLists(GetVersion(cr), constants.CurrentVersion))
 	assert.NotEmpty(t, diffs)
 	// assert.Empty(t, diffs)
 
@@ -125,7 +124,7 @@ func TestCheckProductUpgrade(t *testing.T) {
 		},
 		Spec: api.KieAppSpec{
 			Environment: api.RhpamProduction,
-			Upgrades:    api.KieAppUpgrades{Minor: true, Enabled: true},
+			Upgrades:    &api.KieAppUpgrades{Minor: true, Enabled: true},
 		},
 	}
 	minor, micro, err = checkProductUpgrade(cr)
@@ -133,7 +132,7 @@ func TestCheckProductUpgrade(t *testing.T) {
 	assert.False(t, minor)
 	assert.False(t, micro)
 
-	diffs = configDiffs(getConfigVersionLists(cr.Spec.Version, constants.CurrentVersion))
+	diffs = configDiffs(getConfigVersionLists(GetVersion(cr), constants.CurrentVersion))
 	assert.Empty(t, diffs)
 
 	// Upgrades disabled with minor true
@@ -144,7 +143,7 @@ func TestCheckProductUpgrade(t *testing.T) {
 		Spec: api.KieAppSpec{
 			Environment: api.RhpamProduction,
 			Version:     constants.PriorVersion2,
-			Upgrades:    api.KieAppUpgrades{Minor: true, Enabled: false},
+			Upgrades:    &api.KieAppUpgrades{Minor: true, Enabled: false},
 		},
 	}
 	minor, micro, err = checkProductUpgrade(cr)
@@ -152,7 +151,7 @@ func TestCheckProductUpgrade(t *testing.T) {
 	assert.False(t, minor)
 	assert.False(t, micro)
 
-	diffs = configDiffs(getConfigVersionLists(cr.Spec.Version, constants.CurrentVersion))
+	diffs = configDiffs(getConfigVersionLists(GetVersion(cr), constants.CurrentVersion))
 	assert.NotEmpty(t, diffs)
 	// assert.Empty(t, diffs)
 }

--- a/pkg/controller/kieapp/deploy_ui_test.go
+++ b/pkg/controller/kieapp/deploy_ui_test.go
@@ -159,7 +159,6 @@ func checkConsoleProxySettings(t *testing.T, ocpVersion string) {
 	pod := getPod(operator.Namespace, getImage(operator), "saName", ocpVersionMajor, ocpVersionMinor, operator)
 	caBundlePath := "--openshift-ca=/etc/pki/ca-trust/extracted/crt/ca-bundle.crt"
 	if ocpVersionMajor < "4" {
-		assert.NotContains(t, pod.Spec.Containers[0].Args, caBundlePath)
 		assert.Equal(t, getService(pod.Namespace, ocpVersionMajor).Annotations,
 			map[string]string{
 				"service.alpha.openshift.io/serving-cert-secret-name": operator.Name + "-proxy-tls",
@@ -168,9 +167,6 @@ func checkConsoleProxySettings(t *testing.T, ocpVersion string) {
 		)
 		assert.Equal(t, constants.Oauth3ImageLatestURL, pod.Spec.Containers[0].Image)
 	} else {
-		if ocpVersion >= "4.2" {
-			assert.Contains(t, pod.Spec.Containers[0].Args, caBundlePath)
-		}
 		assert.Equal(t, getService(pod.Namespace, ocpVersionMajor).Annotations,
 			map[string]string{
 				"service.beta.openshift.io/serving-cert-secret-name": operator.Name + "-proxy-tls",
@@ -182,5 +178,10 @@ func checkConsoleProxySettings(t *testing.T, ocpVersion string) {
 		} else {
 			assert.Equal(t, constants.Oauth4ImageLatestURL, pod.Spec.Containers[0].Image)
 		}
+	}
+	if ocpVersion >= "4.2" {
+		assert.Contains(t, pod.Spec.Containers[0].Args, caBundlePath)
+	} else {
+		assert.NotContains(t, pod.Spec.Containers[0].Args, caBundlePath)
 	}
 }

--- a/pkg/controller/kieapp/status/status_test.go
+++ b/pkg/controller/kieapp/status/status_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	api "github.com/kiegroup/kie-cloud-operator/pkg/apis/app/v2"
+	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/constants"
+	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/defaults"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -12,7 +14,7 @@ import (
 
 func TestSetDeployed(t *testing.T) {
 	now := metav1.Now()
-	cr := &api.KieApp{}
+	cr := &api.KieApp{Spec: api.KieAppSpec{Version: constants.CurrentVersion}}
 
 	assert.True(t, SetDeployed(cr))
 
@@ -20,6 +22,8 @@ func TestSetDeployed(t *testing.T) {
 	assert.Equal(t, api.DeployedConditionType, cr.Status.Conditions[0].Type)
 	assert.Equal(t, api.DeployedConditionType, cr.Status.Phase)
 	assert.Equal(t, corev1.ConditionTrue, cr.Status.Conditions[0].Status)
+	assert.Equal(t, constants.CurrentVersion, cr.Status.Conditions[0].Version)
+	assert.Equal(t, constants.CurrentVersion, cr.Status.Version)
 	assert.True(t, now.Before(&cr.Status.Conditions[0].LastTransitionTime))
 }
 
@@ -38,13 +42,15 @@ func TestSetDeployedSkipUpdate(t *testing.T) {
 
 func TestSetProvisioning(t *testing.T) {
 	now := metav1.Now()
-	cr := &api.KieApp{}
+	cr := &api.KieApp{Spec: api.KieAppSpec{Version: constants.CurrentVersion}}
 	assert.True(t, SetProvisioning(cr))
 
 	assert.NotEmpty(t, cr.Status.Conditions)
 	assert.Equal(t, api.ProvisioningConditionType, cr.Status.Conditions[0].Type)
 	assert.Equal(t, api.ProvisioningConditionType, cr.Status.Phase)
 	assert.Equal(t, corev1.ConditionTrue, cr.Status.Conditions[0].Status)
+	assert.Equal(t, constants.CurrentVersion, cr.Status.Conditions[0].Version)
+	assert.NotEqual(t, constants.CurrentVersion, cr.Status.Version)
 	assert.True(t, now.Before(&cr.Status.Conditions[0].LastTransitionTime))
 }
 
@@ -63,26 +69,43 @@ func TestSetProvisioningSkipUpdate(t *testing.T) {
 
 func TestSetProvisioningAndThenDeployed(t *testing.T) {
 	now := metav1.Now()
-	cr := &api.KieApp{}
+	cr := &api.KieApp{Spec: api.KieAppSpec{Version: constants.PriorVersion1}}
 
+	assert.True(t, SetProvisioning(cr))
+	assert.True(t, SetDeployed(cr))
+	defaults.SetVersion(cr, constants.CurrentVersion)
 	assert.True(t, SetProvisioning(cr))
 	assert.True(t, SetDeployed(cr))
 
 	assert.NotEmpty(t, cr.Status.Conditions)
 	condition := cr.Status.Conditions[0]
-	assert.Equal(t, 2, len(cr.Status.Conditions))
-	assert.Equal(t, api.ProvisioningConditionType, condition.Type)
-	assert.Equal(t, corev1.ConditionTrue, condition.Status)
+	assert.Equal(t, 4, len(cr.Status.Conditions))
+
+	assert.Equal(t, api.ProvisioningConditionType, cr.Status.Conditions[0].Type)
+	assert.Equal(t, corev1.ConditionTrue, cr.Status.Conditions[0].Status)
+	assert.Equal(t, constants.PriorVersion1, cr.Status.Conditions[0].Version)
 	assert.True(t, now.Before(&condition.LastTransitionTime))
 
 	assert.Equal(t, api.DeployedConditionType, cr.Status.Conditions[1].Type)
 	assert.Equal(t, corev1.ConditionTrue, cr.Status.Conditions[1].Status)
 	assert.True(t, condition.LastTransitionTime.Before(&cr.Status.Conditions[1].LastTransitionTime))
+	assert.Equal(t, constants.PriorVersion1, cr.Status.Conditions[1].Version)
+
+	assert.Equal(t, api.ProvisioningConditionType, cr.Status.Conditions[2].Type)
+	assert.Equal(t, corev1.ConditionTrue, cr.Status.Conditions[2].Status)
+	assert.Equal(t, constants.CurrentVersion, cr.Status.Conditions[2].Version)
+	assert.True(t, condition.LastTransitionTime.Before(&cr.Status.Conditions[2].LastTransitionTime))
+
+	assert.Equal(t, api.DeployedConditionType, cr.Status.Conditions[3].Type)
+	assert.Equal(t, corev1.ConditionTrue, cr.Status.Conditions[3].Status)
+	assert.True(t, condition.LastTransitionTime.Before(&cr.Status.Conditions[3].LastTransitionTime))
+	assert.Equal(t, constants.CurrentVersion, cr.Status.Conditions[3].Version)
+	assert.Equal(t, constants.CurrentVersion, cr.Status.Version)
 	assert.Equal(t, api.DeployedConditionType, cr.Status.Phase)
 }
 
 func TestBuffer(t *testing.T) {
-	cr := &api.KieApp{}
+	cr := &api.KieApp{Spec: api.KieAppSpec{Version: constants.CurrentVersion}}
 	for i := 0; i < maxBuffer+2; i++ {
 		SetFailed(cr, api.UnknownReason, fmt.Errorf("Error %d", i))
 	}

--- a/tools/csv-gen/csv-gen.go
+++ b/tools/csv-gen/csv-gen.go
@@ -262,10 +262,10 @@ func main() {
 				},
 				StatusDescriptors: []csvv1.StatusDescriptor{
 					{
-						Description:  "Deployments for the KieApp environment.",
-						DisplayName:  "Deployments",
-						Path:         "deployments",
-						XDescriptors: []string{"urn:alm:descriptor:com.tectonic.ui:podStatuses"},
+						Description:  "Product version installed.",
+						DisplayName:  "Version",
+						Path:         "version",
+						XDescriptors: []string{"urn:alm:descriptor:com.tectonic.ui:label"},
 					},
 					{
 						Description:  "Current phase.",
@@ -280,10 +280,10 @@ func main() {
 						XDescriptors: []string{"urn:alm:descriptor:org.w3:link"},
 					},
 					{
-						Description:  "Product version installed.",
-						DisplayName:  "Version",
-						Path:         "version",
-						XDescriptors: []string{"urn:alm:descriptor:com.tectonic.ui:label"},
+						Description:  "Deployments for the KieApp environment.",
+						DisplayName:  "Deployments",
+						Path:         "deployments",
+						XDescriptors: []string{"urn:alm:descriptor:com.tectonic.ui:podStatuses"},
 					},
 				},
 			},

--- a/tools/csv-gen/csv-gen.go
+++ b/tools/csv-gen/csv-gen.go
@@ -259,12 +259,6 @@ func main() {
 						Path:         "environment",
 						XDescriptors: []string{"urn:alm:descriptor:com.tectonic.ui:label"},
 					},
-					{
-						Description:  "Product version installed.",
-						DisplayName:  "Version",
-						Path:         "version",
-						XDescriptors: []string{"urn:alm:descriptor:com.tectonic.ui:label"},
-					},
 				},
 				StatusDescriptors: []csvv1.StatusDescriptor{
 					{
@@ -284,6 +278,12 @@ func main() {
 						DisplayName:  "Business/Decision Central URL",
 						Path:         "consoleHost",
 						XDescriptors: []string{"urn:alm:descriptor:org.w3:link"},
+					},
+					{
+						Description:  "Product version installed.",
+						DisplayName:  "Version",
+						Path:         "version",
+						XDescriptors: []string{"urn:alm:descriptor:com.tectonic.ui:label"},
 					},
 				},
 			},
@@ -313,6 +313,9 @@ func main() {
 		sort.Sort(sort.Reverse(sort.StringSlice(constants.SupportedVersions)))
 		for _, imageVersion := range constants.SupportedVersions {
 			for _, i := range constants.Images {
+				if i.Var == constants.PamProcessMigrationVar && imageVersion < "7.8.0" {
+					continue
+				}
 				relatedImages = addRefRelatedImages(i.Registry+":"+imageVersion, i.Component, imageRef, relatedImages)
 			}
 		}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -104,16 +104,16 @@ github.com/gobuffalo/packd/internal/takeon/github.com/markbates/errx
 # github.com/gobuffalo/packr/v2 v2.7.1 => github.com/gobuffalo/packr/v2 v2.7.1
 github.com/gobuffalo/packr/v2/jam
 github.com/gobuffalo/packr/v2
-github.com/gobuffalo/packr/v2/file/resolver
 github.com/gobuffalo/packr/v2/jam/parser
 github.com/gobuffalo/packr/v2/jam/store
 github.com/gobuffalo/packr/v2/plog
 github.com/gobuffalo/packr/v2/file
+github.com/gobuffalo/packr/v2/file/resolver
 github.com/gobuffalo/packr/v2/internal/takeon/github.com/markbates/oncer
 github.com/gobuffalo/packr/v2/internal/takeon/github.com/markbates/safe
-github.com/gobuffalo/packr/v2/file/resolver/encoding/hex
 github.com/gobuffalo/packr/v2/internal/takeon/github.com/karrick/godirwalk
 github.com/gobuffalo/packr/v2/internal/takeon/github.com/markbates/errx
+github.com/gobuffalo/packr/v2/file/resolver/encoding/hex
 # github.com/gogo/protobuf v1.3.1
 github.com/gogo/protobuf/proto
 github.com/gogo/protobuf/sortkeys


### PR DESCRIPTION
results in a CR that looks like this:
```yaml
apiVersion: app.kiegroup.org/v2
kind: KieApp
metadata:
  annotations:
    app.kiegroup.org: 7.8.0
  creationTimestamp: '2020-04-28T20:23:51Z'
  generation: 6
  name: rhpam-trial
  namespace: testtom
  resourceVersion: '786037'
  selfLink: /apis/app.kiegroup.org/v2/namespaces/testtom/kieapps/rhpam-trial
  uid: fb5e4f4e-2d47-4e63-951c-857c100e22c5
spec:
  commonConfig: {}
  environment: rhpam-trial
  objects:
    console: {}
  upgrades: {}
status:
  conditions:
    - lastTransitionTime: '2020-04-28T20:23:53Z'
      status: 'True'
      type: Provisioning
      version: 7.8.0
    - lastTransitionTime: '2020-04-28T20:23:55Z'
      status: 'True'
      type: Deployed
      version: 7.8.0
  consoleHost: 'https://rhpam-trial-rhpamcentr-testtom.apps-crc.testing'
  deployments:
    starting:
      - rhpam-trial-rhpamcentr
    stopped:
      - rhpam-trial-kieserver
  generated:
    commonConfig:
      adminPassword: RedHat
      adminUser: adminUser
      amqClusterPassword: RedHat
      amqPassword: RedHat
      applicationName: rhpam-trial
      dbPassword: RedHat
      keyStorePassword: RedHat
    objects:
      console:
        replicas: 1
      servers:
        - deployments: 1
          name: rhpam-trial-kieserver
          replicas: 1
    upgrades: {}
    version: 7.8.0
  phase: Deployed
  version: 7.8.0
```

Signed-off-by: tchughesiv <tchughesiv@gmail.com>