### PR TITLE
[KIECLOUD-376] move to status.applied

### DIFF
--- a/pkg/apis/app/v2/status.go
+++ b/pkg/apis/app/v2/status.go
@@ -48,6 +48,6 @@ type KieAppStatus struct {
 	ConsoleHost string               `json:"consoleHost,omitempty"`
 	Deployments olm.DeploymentStatus `json:"deployments"`
 	Phase       ConditionType        `json:"phase,omitempty"`
-	Generated   KieAppSpec           `json:"generated,omitempty"`
+	Applied     KieAppSpec           `json:"applied,omitempty"`
 	Version     string               `json:"version,omitempty"`
 }

--- a/pkg/apis/app/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/app/v2/zz_generated.deepcopy.go
@@ -822,7 +822,7 @@ func (in *KieAppStatus) DeepCopyInto(out *KieAppStatus) {
 		}
 	}
 	in.Deployments.DeepCopyInto(&out.Deployments)
-	in.Generated.DeepCopyInto(&out.Generated)
+	in.Applied.DeepCopyInto(&out.Applied)
 	return
 }
 

--- a/pkg/controller/kieapp/defaults/auth.go
+++ b/pkg/controller/kieapp/defaults/auth.go
@@ -61,20 +61,16 @@ func configureSSO(cr *api.KieApp, envTemplate *api.EnvTemplate) error {
 	}
 	// Set defaults
 	if len(cr.Spec.Auth.SSO.PrincipalAttribute) == 0 {
-		if cr.Status.Generated.Auth == nil {
-			cr.Status.Generated.Auth = &api.KieAppAuthObject{SSO: &api.SSOAuthConfig{}}
+		if cr.Status.Applied.Auth == nil {
+			cr.Status.Applied.Auth = &api.KieAppAuthObject{SSO: &api.SSOAuthConfig{}}
 		}
-		cr.Status.Generated.Auth.SSO.PrincipalAttribute = constants.SSODefaultPrincipalAttribute
+		cr.Status.Applied.Auth.SSO.PrincipalAttribute = constants.SSODefaultPrincipalAttribute
 	}
-	resolvedSpec, err := ResolveSpec(cr)
-	if err != nil {
-		return err
+	if cr.Status.Applied.Objects.Console.SSOClient != nil {
+		envTemplate.Console.SSOAuthClient = *cr.Status.Applied.Objects.Console.SSOClient.DeepCopy()
 	}
-	if resolvedSpec.Objects.Console.SSOClient != nil {
-		envTemplate.Console.SSOAuthClient = *resolvedSpec.Objects.Console.SSOClient.DeepCopy()
-	}
-	if resolvedSpec.Auth.SSO != nil {
-		envTemplate.Auth.SSO = *resolvedSpec.Auth.SSO.DeepCopy()
+	if cr.Status.Applied.Auth.SSO != nil {
+		envTemplate.Auth.SSO = *cr.Status.Applied.Auth.SSO.DeepCopy()
 		for index := range envTemplate.Servers {
 			serverSet, _ := GetServerSet(cr, index)
 			if serverSet.SSOClient != nil {

--- a/pkg/controller/kieapp/defaults/merge_test.go
+++ b/pkg/controller/kieapp/defaults/merge_test.go
@@ -593,7 +593,7 @@ func getParsedTemplateFromCR(cr *api.KieApp, filename string, object interface{}
 		log.Error("Error getting environment template", err)
 	}
 
-	yamlBytes, err := loadYaml(test.MockService(), filename, GetVersion(cr), cr.Namespace, envTemplate)
+	yamlBytes, err := loadYaml(test.MockService(), filename, cr.Status.Applied.Version, cr.Namespace, envTemplate)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/kieapp/defaults/upgrade.go
+++ b/pkg/controller/kieapp/defaults/upgrade.go
@@ -16,14 +16,14 @@ import (
 
 // checkProductUpgrade ...
 func checkProductUpgrade(cr *api.KieApp) (minor, micro bool, err error) {
-	setDefaults(cr)
-	if checkVersion(GetVersion(cr)) {
-		if GetVersion(cr) != constants.CurrentVersion && cr.Spec.Upgrades.Enabled {
-			micro = cr.Spec.Upgrades.Enabled
-			minor = cr.Spec.Upgrades.Minor
+	SetDefaults(cr)
+	if checkVersion(cr.Status.Applied.Version) {
+		if cr.Status.Applied.Version != constants.CurrentVersion && cr.Status.Applied.Upgrades.Enabled {
+			micro = cr.Status.Applied.Upgrades.Enabled
+			minor = cr.Status.Applied.Upgrades.Minor
 		}
 	} else {
-		err = fmt.Errorf("Product version %s is not allowed. The following versions are allowed - %s", GetVersion(cr), constants.SupportedVersions)
+		err = fmt.Errorf("Product version %s is not allowed. The following versions are allowed - %s", cr.Status.Applied.Version, constants.SupportedVersions)
 	}
 	return minor, micro, err
 }

--- a/pkg/controller/kieapp/defaults/upgrade_test.go
+++ b/pkg/controller/kieapp/defaults/upgrade_test.go
@@ -37,7 +37,7 @@ func TestGetConfigVersionDiffs(t *testing.T) {
 			Upgrades:    api.KieAppUpgrades{Enabled: true},
 		},
 	}
-	err := getConfigVersionDiffs(GetVersion(cr), constants.CurrentVersion, test.MockService())
+	err := getConfigVersionDiffs(cr.Spec.Version, constants.CurrentVersion, test.MockService())
 	assert.Error(t, err)
 }
 
@@ -55,11 +55,11 @@ func TestCheckProductUpgrade(t *testing.T) {
 	}
 	minor, micro, err := checkProductUpgrade(cr)
 	assert.Error(t, err, "Incompatible product versions should throw an error")
-	assert.Equal(t, fmt.Sprintf("Product version %s is not allowed. The following versions are allowed - %s", GetVersion(cr), constants.SupportedVersions), err.Error())
+	assert.Equal(t, fmt.Sprintf("Product version %s is not allowed. The following versions are allowed - %s", cr.Status.Applied.Version, constants.SupportedVersions), err.Error())
 	assert.False(t, minor)
 	assert.False(t, micro)
 
-	diffs := configDiffs(getConfigVersionLists(GetVersion(cr), constants.CurrentVersion))
+	diffs := configDiffs(getConfigVersionLists(cr.Status.Applied.Version, constants.CurrentVersion))
 	assert.Empty(t, diffs)
 
 	// Upgrades default to false
@@ -93,7 +93,7 @@ func TestCheckProductUpgrade(t *testing.T) {
 	assert.False(t, minor)
 	assert.True(t, micro)
 
-	diffs = configDiffs(getConfigVersionLists(GetVersion(cr), constants.CurrentVersion))
+	diffs = configDiffs(getConfigVersionLists(cr.Status.Applied.Version, constants.CurrentVersion))
 	assert.NotEmpty(t, diffs)
 	// assert.Empty(t, diffs)
 
@@ -113,7 +113,7 @@ func TestCheckProductUpgrade(t *testing.T) {
 	assert.True(t, minor)
 	assert.True(t, micro)
 
-	diffs = configDiffs(getConfigVersionLists(GetVersion(cr), constants.CurrentVersion))
+	diffs = configDiffs(getConfigVersionLists(cr.Status.Applied.Version, constants.CurrentVersion))
 	assert.NotEmpty(t, diffs)
 	// assert.Empty(t, diffs)
 
@@ -132,7 +132,7 @@ func TestCheckProductUpgrade(t *testing.T) {
 	assert.False(t, minor)
 	assert.False(t, micro)
 
-	diffs = configDiffs(getConfigVersionLists(GetVersion(cr), constants.CurrentVersion))
+	diffs = configDiffs(getConfigVersionLists(cr.Status.Applied.Version, constants.CurrentVersion))
 	assert.Empty(t, diffs)
 
 	// Upgrades disabled with minor true
@@ -151,7 +151,7 @@ func TestCheckProductUpgrade(t *testing.T) {
 	assert.False(t, minor)
 	assert.False(t, micro)
 
-	diffs = configDiffs(getConfigVersionLists(GetVersion(cr), constants.CurrentVersion))
+	diffs = configDiffs(getConfigVersionLists(cr.Status.Applied.Version, constants.CurrentVersion))
 	assert.NotEmpty(t, diffs)
 	// assert.Empty(t, diffs)
 }

--- a/pkg/controller/kieapp/status/status.go
+++ b/pkg/controller/kieapp/status/status.go
@@ -3,7 +3,6 @@ package status
 import (
 	"github.com/RHsyseng/operator-utils/pkg/logs"
 	api "github.com/kiegroup/kie-cloud-operator/pkg/apis/app/v2"
-	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/defaults"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -28,7 +27,7 @@ func SetProvisioning(cr *api.KieApp) bool {
 // SetDeployed - Updates the condition with the DeployedCondition and True status
 func SetDeployed(cr *api.KieApp) bool {
 	log := log.With("kind", cr.Kind, "name", cr.Name, "namespace", cr.Namespace)
-	cr.Status.Version = defaults.GetVersion(cr)
+	cr.Status.Version = cr.Status.Applied.Version
 	size := len(cr.Status.Conditions)
 	if size > 0 && cr.Status.Conditions[size-1].Type == api.DeployedConditionType {
 		log.Debug("Status: unchanged status [deployed].")
@@ -54,7 +53,7 @@ func SetFailed(cr *api.KieApp, reason api.ReasonType, err error) {
 func addCondition(cr *api.KieApp, condition api.Condition) []api.Condition {
 	condition.Status = corev1.ConditionTrue
 	condition.LastTransitionTime = metav1.Now()
-	condition.Version = defaults.GetVersion(cr)
+	condition.Version = cr.Status.Applied.Version
 	conditions := cr.Status.Conditions
 	size := len(conditions) + 1
 	first := 0

--- a/pkg/controller/kieapp/status/status_test.go
+++ b/pkg/controller/kieapp/status/status_test.go
@@ -6,7 +6,6 @@ import (
 
 	api "github.com/kiegroup/kie-cloud-operator/pkg/apis/app/v2"
 	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/constants"
-	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/defaults"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,8 +13,7 @@ import (
 
 func TestSetDeployed(t *testing.T) {
 	now := metav1.Now()
-	cr := &api.KieApp{Spec: api.KieAppSpec{Version: constants.CurrentVersion}}
-
+	cr := &api.KieApp{Status: api.KieAppStatus{Applied: api.KieAppSpec{Version: constants.CurrentVersion}}}
 	assert.True(t, SetDeployed(cr))
 
 	assert.NotEmpty(t, cr.Status.Conditions)
@@ -42,7 +40,7 @@ func TestSetDeployedSkipUpdate(t *testing.T) {
 
 func TestSetProvisioning(t *testing.T) {
 	now := metav1.Now()
-	cr := &api.KieApp{Spec: api.KieAppSpec{Version: constants.CurrentVersion}}
+	cr := &api.KieApp{Status: api.KieAppStatus{Applied: api.KieAppSpec{Version: constants.CurrentVersion}}}
 	assert.True(t, SetProvisioning(cr))
 
 	assert.NotEmpty(t, cr.Status.Conditions)
@@ -69,11 +67,11 @@ func TestSetProvisioningSkipUpdate(t *testing.T) {
 
 func TestSetProvisioningAndThenDeployed(t *testing.T) {
 	now := metav1.Now()
-	cr := &api.KieApp{Spec: api.KieAppSpec{Version: constants.PriorVersion1}}
+	cr := &api.KieApp{Status: api.KieAppStatus{Applied: api.KieAppSpec{Version: constants.PriorVersion1}}}
 
 	assert.True(t, SetProvisioning(cr))
 	assert.True(t, SetDeployed(cr))
-	defaults.SetVersion(cr, constants.CurrentVersion)
+	cr.Status.Applied.Version = constants.CurrentVersion
 	assert.True(t, SetProvisioning(cr))
 	assert.True(t, SetDeployed(cr))
 
@@ -105,7 +103,7 @@ func TestSetProvisioningAndThenDeployed(t *testing.T) {
 }
 
 func TestBuffer(t *testing.T) {
-	cr := &api.KieApp{Spec: api.KieAppSpec{Version: constants.CurrentVersion}}
+	cr := &api.KieApp{Status: api.KieAppStatus{Applied: api.KieAppSpec{Version: constants.CurrentVersion}}}
 	for i := 0; i < maxBuffer+2; i++ {
 		SetFailed(cr, api.UnknownReason, fmt.Errorf("Error %d", i))
 	}


### PR DESCRIPTION
new `applied` status approach results in the following reconciled KieApp -
```yaml
apiVersion: app.kiegroup.org/v2
kind: KieApp
metadata:
  annotations:
    app.kiegroup.org: 7.8.0
  creationTimestamp: '2020-04-29T15:09:50Z'
  generation: 23
  name: prod
  namespace: testtom
  resourceVersion: '814170'
  selfLink: /apis/app.kiegroup.org/v2/namespaces/testtom/kieapps/prod
  uid: 00153694-dec9-4cf6-a3fe-8806de8afc83
spec:
  commonConfig:
    adminUser: testing
    amqClusterPassword: this
  environment: rhpam-production
  objects:
    console: {}
    servers:
      - deployments: 2
        name: tom
      - deployments: 1
  upgrades:
    enabled: true
status:
  applied:
    commonConfig:
      adminPassword: r57mYMdn
      adminUser: testing
      amqClusterPassword: this
      amqPassword: TdrrU816
      applicationName: prod
      dbPassword: xoJx7AFe
      keyStorePassword: mgo4OQ7j
    environment: rhpam-production
    objects:
      console:
        replicas: 3
      servers:
        - deployments: 2
          name: tom
          replicas: 3
        - deployments: 1
          name: prod-kieserver
          replicas: 3
    upgrades:
      enabled: true
    version: 7.8.0
  conditions:
    - lastTransitionTime: '2020-04-29T15:09:54Z'
      status: 'True'
      type: Provisioning
      version: 7.8.0
    - lastTransitionTime: '2020-04-29T15:10:19Z'
      status: 'True'
      type: Deployed
      version: 7.8.0
  consoleHost: 'https://prod-rhpamcentrmon-testtom.apps-crc.testing'
  deployments:
    ready:
      - tom-postgresql
      - tom-2-postgresql
      - prod-kieserver-postgresql
    starting:
      - prod-rhpamcentrmon
      - tom
      - tom-2
      - prod-kieserver
  phase: Deployed
  version: 7.8.0
```

Signed-off-by: tchughesiv <tchughesiv@gmail.com>