### PR TITLE
[KIECLOUD-392] bypass sha for BC imagestreams

### DIFF
--- a/deploy/catalog_resources/community/7.8/kiecloud-operator.7.8.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/community/7.8/kiecloud-operator.7.8.0.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Integration & Delivery
     certified: "false"
     containerImage: quay.io/kiegroup/kie-cloud-operator:7.8.0
-    createdAt: "2020-05-01 11:17:24"
+    createdAt: "2020-05-13 10:23:46"
     description: Deploys and manages Red Hat Process Automation Manager and Red Hat
       Decision Manager environments.
     repository: https://github.com/kiegroup/kie-cloud-operator
@@ -188,15 +188,15 @@ spec:
                 - name: PAM_PROCESS_MIGRATION_IMAGE_7.8.0
                   value: registry.redhat.io/rhpam-7/rhpam-process-migration-rhel8:7.8.0
                 - name: OSE_CLI_IMAGE_7.8.0
-                  value: registry.redhat.io/openshift3/ose-cli:v3.11
+                  value: registry.redhat.io/openshift3/ose-cli@sha256:eda798d5c0f026b2221716f5df33fd97cd25bfb565f969e76e62815f1bd3a924
                 - name: MYSQL_PROXY_IMAGE_7.8.0
-                  value: registry.redhat.io/rhscl/mysql-57-rhel7:latest
+                  value: registry.redhat.io/rhscl/mysql-57-rhel7@sha256:9a781abe7581cc141e14a7e404ec34125b3e89c008b14f4e7b41e094fd3049fe
                 - name: POSTGRESQL_PROXY_IMAGE_7.8.0
-                  value: registry.redhat.io/rhscl/postgresql-10-rhel7:latest
+                  value: registry.redhat.io/rhscl/postgresql-10-rhel7@sha256:8c459a1c790cb81503b16a1bfb296dc2306cbb9e51f24194e8a730416296b006
                 - name: DATAGRID_IMAGE_7.8.0
-                  value: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.5
+                  value: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift@sha256:3375ec169d274278da56d1401c5c1285f7d2812ea0bde2ac9ad9652b69f80893
                 - name: BROKER_IMAGE_7.8.0
-                  value: registry.redhat.io/amq7/amq-broker:7.6
+                  value: registry.redhat.io/amq7/amq-broker@sha256:7e81fec6e8fcb760829ab73512d1abf4da93e6e3bca42a12f517f793b34d6709
                 - name: DM_KIESERVER_IMAGE_7.7.1
                   value: registry.redhat.io/rhdm-7/rhdm-kieserver-rhel8:7.7.1
                 - name: DM_CONTROLLER_IMAGE_7.7.1
@@ -214,53 +214,53 @@ spec:
                 - name: PAM_SMARTROUTER_IMAGE_7.7.1
                   value: registry.redhat.io/rhpam-7/rhpam-smartrouter-rhel8:7.7.1
                 - name: OSE_CLI_IMAGE_7.7.1
-                  value: registry.redhat.io/openshift3/ose-cli:v3.11
+                  value: registry.redhat.io/openshift3/ose-cli@sha256:eda798d5c0f026b2221716f5df33fd97cd25bfb565f969e76e62815f1bd3a924
                 - name: MYSQL_PROXY_IMAGE_7.7.1
-                  value: registry.redhat.io/rhscl/mysql-57-rhel7:latest
+                  value: registry.redhat.io/rhscl/mysql-57-rhel7@sha256:9a781abe7581cc141e14a7e404ec34125b3e89c008b14f4e7b41e094fd3049fe
                 - name: POSTGRESQL_PROXY_IMAGE_7.7.1
-                  value: registry.redhat.io/rhscl/postgresql-10-rhel7:latest
+                  value: registry.redhat.io/rhscl/postgresql-10-rhel7@sha256:8c459a1c790cb81503b16a1bfb296dc2306cbb9e51f24194e8a730416296b006
                 - name: DATAGRID_IMAGE_7.7.1
-                  value: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.5
+                  value: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift@sha256:3375ec169d274278da56d1401c5c1285f7d2812ea0bde2ac9ad9652b69f80893
                 - name: BROKER_IMAGE_7.7.1
-                  value: registry.redhat.io/amq7/amq-broker:7.5
+                  value: registry.redhat.io/amq7/amq-broker@sha256:ba5273b390a4762c21f005fdc92a837680417250dcd5e6d9d3c8f776e9cc372e
                 - name: DM_KIESERVER_IMAGE_7.7.0
-                  value: registry.redhat.io/rhdm-7/rhdm-kieserver-rhel8:7.7.0
+                  value: registry.redhat.io/rhdm-7/rhdm-kieserver-rhel8@sha256:debf4f45f36509e608c2d8754539aa5697aa4255ac85ab4a521915ef88841660
                 - name: DM_CONTROLLER_IMAGE_7.7.0
-                  value: registry.redhat.io/rhdm-7/rhdm-controller-rhel8:7.7.0
+                  value: registry.redhat.io/rhdm-7/rhdm-controller-rhel8@sha256:92542ad2b83f42eb0f245daa1e732c752d9c164f31fb963f42ac876aeba42c98
                 - name: DM_DC_IMAGE_7.7.0
-                  value: registry.redhat.io/rhdm-7/rhdm-decisioncentral-rhel8:7.7.0
+                  value: registry.redhat.io/rhdm-7/rhdm-decisioncentral-rhel8@sha256:be1c8fca841bffd7d63bb8522bb7a7b35d18acd36e1cd8e576ea111d9f9e48f1
                 - name: PAM_KIESERVER_IMAGE_7.7.0
-                  value: registry.redhat.io/rhpam-7/rhpam-kieserver-rhel8:7.7.0
+                  value: registry.redhat.io/rhpam-7/rhpam-kieserver-rhel8@sha256:75372031305a597171895641edf46f19664d08bea19d9c41e6d8d43042a3c97d
                 - name: PAM_CONTROLLER_IMAGE_7.7.0
-                  value: registry.redhat.io/rhpam-7/rhpam-controller-rhel8:7.7.0
+                  value: registry.redhat.io/rhpam-7/rhpam-controller-rhel8@sha256:05f7956bcae5acd10e89ecbbc5a12b9bd737cf696c276bb10f52bd93b8080ebd
                 - name: PAM_BC_IMAGE_7.7.0
-                  value: registry.redhat.io/rhpam-7/rhpam-businesscentral-rhel8:7.7.0
+                  value: registry.redhat.io/rhpam-7/rhpam-businesscentral-rhel8@sha256:43674501114fe87ad692b3dcc00e0c3c8a98cef0876c0b70051904c0330d5152
                 - name: PAM_BC_MONITORING_IMAGE_7.7.0
-                  value: registry.redhat.io/rhpam-7/rhpam-businesscentral-monitoring-rhel8:7.7.0
+                  value: registry.redhat.io/rhpam-7/rhpam-businesscentral-monitoring-rhel8@sha256:f236fb93165f83b88a9edda70f05fe9eaab2f6f3838f18eead2c1cd8318c03d9
                 - name: PAM_SMARTROUTER_IMAGE_7.7.0
-                  value: registry.redhat.io/rhpam-7/rhpam-smartrouter-rhel8:7.7.0
+                  value: registry.redhat.io/rhpam-7/rhpam-smartrouter-rhel8@sha256:4fbfe67e9b7d8411ef963815d2c2bbbd8071025741f8f0184d48b5bd769dc9e3
                 - name: OSE_CLI_IMAGE_7.7.0
-                  value: registry.redhat.io/openshift3/ose-cli:v3.11
+                  value: registry.redhat.io/openshift3/ose-cli@sha256:eda798d5c0f026b2221716f5df33fd97cd25bfb565f969e76e62815f1bd3a924
                 - name: MYSQL_PROXY_IMAGE_7.7.0
-                  value: registry.redhat.io/rhscl/mysql-57-rhel7:latest
+                  value: registry.redhat.io/rhscl/mysql-57-rhel7@sha256:9a781abe7581cc141e14a7e404ec34125b3e89c008b14f4e7b41e094fd3049fe
                 - name: POSTGRESQL_PROXY_IMAGE_7.7.0
-                  value: registry.redhat.io/rhscl/postgresql-10-rhel7:latest
+                  value: registry.redhat.io/rhscl/postgresql-10-rhel7@sha256:8c459a1c790cb81503b16a1bfb296dc2306cbb9e51f24194e8a730416296b006
                 - name: DATAGRID_IMAGE_7.7.0
-                  value: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.3
+                  value: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift@sha256:cfd8c4ac1c495b766dd3ff1a85c35afe092858f8f65b52a5b044811719482236
                 - name: BROKER_IMAGE_7.7.0
-                  value: registry.redhat.io/amq7/amq-broker:7.5
+                  value: registry.redhat.io/amq7/amq-broker@sha256:ba5273b390a4762c21f005fdc92a837680417250dcd5e6d9d3c8f776e9cc372e
                 - name: OAUTH_PROXY_IMAGE_LATEST
-                  value: registry.redhat.io/openshift4/ose-oauth-proxy:latest
+                  value: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:1d5825577014d40e186d14a477d556f2a8a407e699efaad006be21eae93eb1f6
                 - name: OAUTH_PROXY_IMAGE_4.4
-                  value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.4
+                  value: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:1d5825577014d40e186d14a477d556f2a8a407e699efaad006be21eae93eb1f6
                 - name: OAUTH_PROXY_IMAGE_4.3
-                  value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3
+                  value: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:d9edec46bb747242a87845e85b2eafdce8e3bf985de2ae21aeb88192cc316e33
                 - name: OAUTH_PROXY_IMAGE_4.2
-                  value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.2
+                  value: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:a3192cc7fc8dab17ea602165bd7c2ae2263e69ef878d1ba9f8de47c2468934a5
                 - name: OAUTH_PROXY_IMAGE_4.1
-                  value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.1
+                  value: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:43fde141b6670727a1771fa52cd125b366275786b4be0a0a0c57005fd6e0c912
                 - name: OAUTH_PROXY_IMAGE_3
-                  value: registry.redhat.io/openshift3/oauth-proxy:latest
+                  value: registry.redhat.io/openshift3/oauth-proxy@sha256:4a5d0a92b80ab0738c0a3e3c975a7c59a4242d4337def418bec7f9ec77785ada
                 image: quay.io/kiegroup/kie-cloud-operator:7.8.0
                 imagePullPolicy: Always
                 name: kie-cloud-operator
@@ -472,47 +472,47 @@ spec:
     name: rhpam-businesscentral-monitoring-rhel8
   - image: registry.redhat.io/rhpam-7/rhpam-smartrouter-rhel8:7.7.1
     name: rhpam-smartrouter-rhel8
-  - image: registry.redhat.io/rhdm-7/rhdm-kieserver-rhel8:7.7.0
+  - image: registry.redhat.io/rhdm-7/rhdm-kieserver-rhel8@sha256:debf4f45f36509e608c2d8754539aa5697aa4255ac85ab4a521915ef88841660
     name: rhdm-kieserver-rhel8
-  - image: registry.redhat.io/rhdm-7/rhdm-controller-rhel8:7.7.0
+  - image: registry.redhat.io/rhdm-7/rhdm-controller-rhel8@sha256:92542ad2b83f42eb0f245daa1e732c752d9c164f31fb963f42ac876aeba42c98
     name: rhdm-controller-rhel8
-  - image: registry.redhat.io/rhdm-7/rhdm-decisioncentral-rhel8:7.7.0
+  - image: registry.redhat.io/rhdm-7/rhdm-decisioncentral-rhel8@sha256:be1c8fca841bffd7d63bb8522bb7a7b35d18acd36e1cd8e576ea111d9f9e48f1
     name: rhdm-decisioncentral-rhel8
-  - image: registry.redhat.io/rhpam-7/rhpam-kieserver-rhel8:7.7.0
+  - image: registry.redhat.io/rhpam-7/rhpam-kieserver-rhel8@sha256:75372031305a597171895641edf46f19664d08bea19d9c41e6d8d43042a3c97d
     name: rhpam-kieserver-rhel8
-  - image: registry.redhat.io/rhpam-7/rhpam-controller-rhel8:7.7.0
+  - image: registry.redhat.io/rhpam-7/rhpam-controller-rhel8@sha256:05f7956bcae5acd10e89ecbbc5a12b9bd737cf696c276bb10f52bd93b8080ebd
     name: rhpam-controller-rhel8
-  - image: registry.redhat.io/rhpam-7/rhpam-businesscentral-rhel8:7.7.0
+  - image: registry.redhat.io/rhpam-7/rhpam-businesscentral-rhel8@sha256:43674501114fe87ad692b3dcc00e0c3c8a98cef0876c0b70051904c0330d5152
     name: rhpam-businesscentral-rhel8
-  - image: registry.redhat.io/rhpam-7/rhpam-businesscentral-monitoring-rhel8:7.7.0
+  - image: registry.redhat.io/rhpam-7/rhpam-businesscentral-monitoring-rhel8@sha256:f236fb93165f83b88a9edda70f05fe9eaab2f6f3838f18eead2c1cd8318c03d9
     name: rhpam-businesscentral-monitoring-rhel8
-  - image: registry.redhat.io/rhpam-7/rhpam-smartrouter-rhel8:7.7.0
+  - image: registry.redhat.io/rhpam-7/rhpam-smartrouter-rhel8@sha256:4fbfe67e9b7d8411ef963815d2c2bbbd8071025741f8f0184d48b5bd769dc9e3
     name: rhpam-smartrouter-rhel8
-  - image: registry.redhat.io/openshift4/ose-oauth-proxy:latest
+  - image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:1d5825577014d40e186d14a477d556f2a8a407e699efaad006be21eae93eb1f6
     name: ose-oauth-proxy
-  - image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.4
+  - image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:1d5825577014d40e186d14a477d556f2a8a407e699efaad006be21eae93eb1f6
     name: ose-oauth-proxy
-  - image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3
+  - image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:d9edec46bb747242a87845e85b2eafdce8e3bf985de2ae21aeb88192cc316e33
     name: ose-oauth-proxy
-  - image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.2
+  - image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:a3192cc7fc8dab17ea602165bd7c2ae2263e69ef878d1ba9f8de47c2468934a5
     name: ose-oauth-proxy
-  - image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.1
+  - image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:43fde141b6670727a1771fa52cd125b366275786b4be0a0a0c57005fd6e0c912
     name: ose-oauth-proxy
-  - image: registry.redhat.io/openshift3/oauth-proxy:latest
+  - image: registry.redhat.io/openshift3/oauth-proxy@sha256:4a5d0a92b80ab0738c0a3e3c975a7c59a4242d4337def418bec7f9ec77785ada
     name: oauth-proxy
-  - image: registry.redhat.io/openshift3/ose-cli:v3.11
+  - image: registry.redhat.io/openshift3/ose-cli@sha256:eda798d5c0f026b2221716f5df33fd97cd25bfb565f969e76e62815f1bd3a924
     name: ose-cli
-  - image: registry.redhat.io/rhscl/mysql-57-rhel7:latest
+  - image: registry.redhat.io/rhscl/mysql-57-rhel7@sha256:9a781abe7581cc141e14a7e404ec34125b3e89c008b14f4e7b41e094fd3049fe
     name: mysql-57-rhel7
-  - image: registry.redhat.io/rhscl/postgresql-10-rhel7:latest
+  - image: registry.redhat.io/rhscl/postgresql-10-rhel7@sha256:8c459a1c790cb81503b16a1bfb296dc2306cbb9e51f24194e8a730416296b006
     name: postgresql-10-rhel7
-  - image: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.3
+  - image: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift@sha256:cfd8c4ac1c495b766dd3ff1a85c35afe092858f8f65b52a5b044811719482236
     name: datagrid73-openshift
-  - image: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.5
+  - image: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift@sha256:3375ec169d274278da56d1401c5c1285f7d2812ea0bde2ac9ad9652b69f80893
     name: datagrid73-openshift
-  - image: registry.redhat.io/amq7/amq-broker:7.5
+  - image: registry.redhat.io/amq7/amq-broker@sha256:ba5273b390a4762c21f005fdc92a837680417250dcd5e6d9d3c8f776e9cc372e
     name: amq-broker
-  - image: registry.redhat.io/amq7/amq-broker:7.6
+  - image: registry.redhat.io/amq7/amq-broker@sha256:7e81fec6e8fcb760829ab73512d1abf4da93e6e3bca42a12f517f793b34d6709
     name: amq-broker
   replaces: kiecloud-operator.1.4.1
   selector:

--- a/deploy/catalog_resources/redhat/7.8/businessautomation-operator.7.8.0.clusterserviceversion.yaml
+++ b/deploy/catalog_resources/redhat/7.8/businessautomation-operator.7.8.0.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Integration & Delivery
     certified: "true"
     containerImage: registry.redhat.io/rhpam-7/rhpam-rhel8-operator:7.8.0
-    createdAt: "2020-05-01 11:17:24"
+    createdAt: "2020-05-13 10:25:14"
     description: Deploys and manages Red Hat Process Automation Manager and Red Hat
       Decision Manager environments.
     repository: https://github.com/kiegroup/kie-cloud-operator
@@ -188,15 +188,15 @@ spec:
                 - name: PAM_PROCESS_MIGRATION_IMAGE_7.8.0
                   value: registry.redhat.io/rhpam-7/rhpam-process-migration-rhel8:7.8.0
                 - name: OSE_CLI_IMAGE_7.8.0
-                  value: registry.redhat.io/openshift3/ose-cli:v3.11
+                  value: registry.redhat.io/openshift3/ose-cli@sha256:eda798d5c0f026b2221716f5df33fd97cd25bfb565f969e76e62815f1bd3a924
                 - name: MYSQL_PROXY_IMAGE_7.8.0
-                  value: registry.redhat.io/rhscl/mysql-57-rhel7:latest
+                  value: registry.redhat.io/rhscl/mysql-57-rhel7@sha256:9a781abe7581cc141e14a7e404ec34125b3e89c008b14f4e7b41e094fd3049fe
                 - name: POSTGRESQL_PROXY_IMAGE_7.8.0
-                  value: registry.redhat.io/rhscl/postgresql-10-rhel7:latest
+                  value: registry.redhat.io/rhscl/postgresql-10-rhel7@sha256:8c459a1c790cb81503b16a1bfb296dc2306cbb9e51f24194e8a730416296b006
                 - name: DATAGRID_IMAGE_7.8.0
-                  value: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.5
+                  value: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift@sha256:3375ec169d274278da56d1401c5c1285f7d2812ea0bde2ac9ad9652b69f80893
                 - name: BROKER_IMAGE_7.8.0
-                  value: registry.redhat.io/amq7/amq-broker:7.6
+                  value: registry.redhat.io/amq7/amq-broker@sha256:7e81fec6e8fcb760829ab73512d1abf4da93e6e3bca42a12f517f793b34d6709
                 - name: DM_KIESERVER_IMAGE_7.7.1
                   value: registry.redhat.io/rhdm-7/rhdm-kieserver-rhel8:7.7.1
                 - name: DM_CONTROLLER_IMAGE_7.7.1
@@ -214,53 +214,53 @@ spec:
                 - name: PAM_SMARTROUTER_IMAGE_7.7.1
                   value: registry.redhat.io/rhpam-7/rhpam-smartrouter-rhel8:7.7.1
                 - name: OSE_CLI_IMAGE_7.7.1
-                  value: registry.redhat.io/openshift3/ose-cli:v3.11
+                  value: registry.redhat.io/openshift3/ose-cli@sha256:eda798d5c0f026b2221716f5df33fd97cd25bfb565f969e76e62815f1bd3a924
                 - name: MYSQL_PROXY_IMAGE_7.7.1
-                  value: registry.redhat.io/rhscl/mysql-57-rhel7:latest
+                  value: registry.redhat.io/rhscl/mysql-57-rhel7@sha256:9a781abe7581cc141e14a7e404ec34125b3e89c008b14f4e7b41e094fd3049fe
                 - name: POSTGRESQL_PROXY_IMAGE_7.7.1
-                  value: registry.redhat.io/rhscl/postgresql-10-rhel7:latest
+                  value: registry.redhat.io/rhscl/postgresql-10-rhel7@sha256:8c459a1c790cb81503b16a1bfb296dc2306cbb9e51f24194e8a730416296b006
                 - name: DATAGRID_IMAGE_7.7.1
-                  value: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.5
+                  value: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift@sha256:3375ec169d274278da56d1401c5c1285f7d2812ea0bde2ac9ad9652b69f80893
                 - name: BROKER_IMAGE_7.7.1
-                  value: registry.redhat.io/amq7/amq-broker:7.5
+                  value: registry.redhat.io/amq7/amq-broker@sha256:ba5273b390a4762c21f005fdc92a837680417250dcd5e6d9d3c8f776e9cc372e
                 - name: DM_KIESERVER_IMAGE_7.7.0
-                  value: registry.redhat.io/rhdm-7/rhdm-kieserver-rhel8:7.7.0
+                  value: registry.redhat.io/rhdm-7/rhdm-kieserver-rhel8@sha256:debf4f45f36509e608c2d8754539aa5697aa4255ac85ab4a521915ef88841660
                 - name: DM_CONTROLLER_IMAGE_7.7.0
-                  value: registry.redhat.io/rhdm-7/rhdm-controller-rhel8:7.7.0
+                  value: registry.redhat.io/rhdm-7/rhdm-controller-rhel8@sha256:92542ad2b83f42eb0f245daa1e732c752d9c164f31fb963f42ac876aeba42c98
                 - name: DM_DC_IMAGE_7.7.0
-                  value: registry.redhat.io/rhdm-7/rhdm-decisioncentral-rhel8:7.7.0
+                  value: registry.redhat.io/rhdm-7/rhdm-decisioncentral-rhel8@sha256:be1c8fca841bffd7d63bb8522bb7a7b35d18acd36e1cd8e576ea111d9f9e48f1
                 - name: PAM_KIESERVER_IMAGE_7.7.0
-                  value: registry.redhat.io/rhpam-7/rhpam-kieserver-rhel8:7.7.0
+                  value: registry.redhat.io/rhpam-7/rhpam-kieserver-rhel8@sha256:75372031305a597171895641edf46f19664d08bea19d9c41e6d8d43042a3c97d
                 - name: PAM_CONTROLLER_IMAGE_7.7.0
-                  value: registry.redhat.io/rhpam-7/rhpam-controller-rhel8:7.7.0
+                  value: registry.redhat.io/rhpam-7/rhpam-controller-rhel8@sha256:05f7956bcae5acd10e89ecbbc5a12b9bd737cf696c276bb10f52bd93b8080ebd
                 - name: PAM_BC_IMAGE_7.7.0
-                  value: registry.redhat.io/rhpam-7/rhpam-businesscentral-rhel8:7.7.0
+                  value: registry.redhat.io/rhpam-7/rhpam-businesscentral-rhel8@sha256:43674501114fe87ad692b3dcc00e0c3c8a98cef0876c0b70051904c0330d5152
                 - name: PAM_BC_MONITORING_IMAGE_7.7.0
-                  value: registry.redhat.io/rhpam-7/rhpam-businesscentral-monitoring-rhel8:7.7.0
+                  value: registry.redhat.io/rhpam-7/rhpam-businesscentral-monitoring-rhel8@sha256:f236fb93165f83b88a9edda70f05fe9eaab2f6f3838f18eead2c1cd8318c03d9
                 - name: PAM_SMARTROUTER_IMAGE_7.7.0
-                  value: registry.redhat.io/rhpam-7/rhpam-smartrouter-rhel8:7.7.0
+                  value: registry.redhat.io/rhpam-7/rhpam-smartrouter-rhel8@sha256:4fbfe67e9b7d8411ef963815d2c2bbbd8071025741f8f0184d48b5bd769dc9e3
                 - name: OSE_CLI_IMAGE_7.7.0
-                  value: registry.redhat.io/openshift3/ose-cli:v3.11
+                  value: registry.redhat.io/openshift3/ose-cli@sha256:eda798d5c0f026b2221716f5df33fd97cd25bfb565f969e76e62815f1bd3a924
                 - name: MYSQL_PROXY_IMAGE_7.7.0
-                  value: registry.redhat.io/rhscl/mysql-57-rhel7:latest
+                  value: registry.redhat.io/rhscl/mysql-57-rhel7@sha256:9a781abe7581cc141e14a7e404ec34125b3e89c008b14f4e7b41e094fd3049fe
                 - name: POSTGRESQL_PROXY_IMAGE_7.7.0
-                  value: registry.redhat.io/rhscl/postgresql-10-rhel7:latest
+                  value: registry.redhat.io/rhscl/postgresql-10-rhel7@sha256:8c459a1c790cb81503b16a1bfb296dc2306cbb9e51f24194e8a730416296b006
                 - name: DATAGRID_IMAGE_7.7.0
-                  value: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.3
+                  value: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift@sha256:cfd8c4ac1c495b766dd3ff1a85c35afe092858f8f65b52a5b044811719482236
                 - name: BROKER_IMAGE_7.7.0
-                  value: registry.redhat.io/amq7/amq-broker:7.5
+                  value: registry.redhat.io/amq7/amq-broker@sha256:ba5273b390a4762c21f005fdc92a837680417250dcd5e6d9d3c8f776e9cc372e
                 - name: OAUTH_PROXY_IMAGE_LATEST
-                  value: registry.redhat.io/openshift4/ose-oauth-proxy:latest
+                  value: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:1d5825577014d40e186d14a477d556f2a8a407e699efaad006be21eae93eb1f6
                 - name: OAUTH_PROXY_IMAGE_4.4
-                  value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.4
+                  value: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:1d5825577014d40e186d14a477d556f2a8a407e699efaad006be21eae93eb1f6
                 - name: OAUTH_PROXY_IMAGE_4.3
-                  value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3
+                  value: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:d9edec46bb747242a87845e85b2eafdce8e3bf985de2ae21aeb88192cc316e33
                 - name: OAUTH_PROXY_IMAGE_4.2
-                  value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.2
+                  value: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:a3192cc7fc8dab17ea602165bd7c2ae2263e69ef878d1ba9f8de47c2468934a5
                 - name: OAUTH_PROXY_IMAGE_4.1
-                  value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.1
+                  value: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:43fde141b6670727a1771fa52cd125b366275786b4be0a0a0c57005fd6e0c912
                 - name: OAUTH_PROXY_IMAGE_3
-                  value: registry.redhat.io/openshift3/oauth-proxy:latest
+                  value: registry.redhat.io/openshift3/oauth-proxy@sha256:4a5d0a92b80ab0738c0a3e3c975a7c59a4242d4337def418bec7f9ec77785ada
                 image: registry.redhat.io/rhpam-7/rhpam-rhel8-operator:7.8.0
                 imagePullPolicy: Always
                 name: business-automation-operator
@@ -472,47 +472,47 @@ spec:
     name: rhpam-businesscentral-monitoring-rhel8
   - image: registry.redhat.io/rhpam-7/rhpam-smartrouter-rhel8:7.7.1
     name: rhpam-smartrouter-rhel8
-  - image: registry.redhat.io/rhdm-7/rhdm-kieserver-rhel8:7.7.0
+  - image: registry.redhat.io/rhdm-7/rhdm-kieserver-rhel8@sha256:debf4f45f36509e608c2d8754539aa5697aa4255ac85ab4a521915ef88841660
     name: rhdm-kieserver-rhel8
-  - image: registry.redhat.io/rhdm-7/rhdm-controller-rhel8:7.7.0
+  - image: registry.redhat.io/rhdm-7/rhdm-controller-rhel8@sha256:92542ad2b83f42eb0f245daa1e732c752d9c164f31fb963f42ac876aeba42c98
     name: rhdm-controller-rhel8
-  - image: registry.redhat.io/rhdm-7/rhdm-decisioncentral-rhel8:7.7.0
+  - image: registry.redhat.io/rhdm-7/rhdm-decisioncentral-rhel8@sha256:be1c8fca841bffd7d63bb8522bb7a7b35d18acd36e1cd8e576ea111d9f9e48f1
     name: rhdm-decisioncentral-rhel8
-  - image: registry.redhat.io/rhpam-7/rhpam-kieserver-rhel8:7.7.0
+  - image: registry.redhat.io/rhpam-7/rhpam-kieserver-rhel8@sha256:75372031305a597171895641edf46f19664d08bea19d9c41e6d8d43042a3c97d
     name: rhpam-kieserver-rhel8
-  - image: registry.redhat.io/rhpam-7/rhpam-controller-rhel8:7.7.0
+  - image: registry.redhat.io/rhpam-7/rhpam-controller-rhel8@sha256:05f7956bcae5acd10e89ecbbc5a12b9bd737cf696c276bb10f52bd93b8080ebd
     name: rhpam-controller-rhel8
-  - image: registry.redhat.io/rhpam-7/rhpam-businesscentral-rhel8:7.7.0
+  - image: registry.redhat.io/rhpam-7/rhpam-businesscentral-rhel8@sha256:43674501114fe87ad692b3dcc00e0c3c8a98cef0876c0b70051904c0330d5152
     name: rhpam-businesscentral-rhel8
-  - image: registry.redhat.io/rhpam-7/rhpam-businesscentral-monitoring-rhel8:7.7.0
+  - image: registry.redhat.io/rhpam-7/rhpam-businesscentral-monitoring-rhel8@sha256:f236fb93165f83b88a9edda70f05fe9eaab2f6f3838f18eead2c1cd8318c03d9
     name: rhpam-businesscentral-monitoring-rhel8
-  - image: registry.redhat.io/rhpam-7/rhpam-smartrouter-rhel8:7.7.0
+  - image: registry.redhat.io/rhpam-7/rhpam-smartrouter-rhel8@sha256:4fbfe67e9b7d8411ef963815d2c2bbbd8071025741f8f0184d48b5bd769dc9e3
     name: rhpam-smartrouter-rhel8
-  - image: registry.redhat.io/openshift4/ose-oauth-proxy:latest
+  - image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:1d5825577014d40e186d14a477d556f2a8a407e699efaad006be21eae93eb1f6
     name: ose-oauth-proxy
-  - image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.4
+  - image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:1d5825577014d40e186d14a477d556f2a8a407e699efaad006be21eae93eb1f6
     name: ose-oauth-proxy
-  - image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.3
+  - image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:d9edec46bb747242a87845e85b2eafdce8e3bf985de2ae21aeb88192cc316e33
     name: ose-oauth-proxy
-  - image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.2
+  - image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:a3192cc7fc8dab17ea602165bd7c2ae2263e69ef878d1ba9f8de47c2468934a5
     name: ose-oauth-proxy
-  - image: registry.redhat.io/openshift4/ose-oauth-proxy:v4.1
+  - image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:43fde141b6670727a1771fa52cd125b366275786b4be0a0a0c57005fd6e0c912
     name: ose-oauth-proxy
-  - image: registry.redhat.io/openshift3/oauth-proxy:latest
+  - image: registry.redhat.io/openshift3/oauth-proxy@sha256:4a5d0a92b80ab0738c0a3e3c975a7c59a4242d4337def418bec7f9ec77785ada
     name: oauth-proxy
-  - image: registry.redhat.io/openshift3/ose-cli:v3.11
+  - image: registry.redhat.io/openshift3/ose-cli@sha256:eda798d5c0f026b2221716f5df33fd97cd25bfb565f969e76e62815f1bd3a924
     name: ose-cli
-  - image: registry.redhat.io/rhscl/mysql-57-rhel7:latest
+  - image: registry.redhat.io/rhscl/mysql-57-rhel7@sha256:9a781abe7581cc141e14a7e404ec34125b3e89c008b14f4e7b41e094fd3049fe
     name: mysql-57-rhel7
-  - image: registry.redhat.io/rhscl/postgresql-10-rhel7:latest
+  - image: registry.redhat.io/rhscl/postgresql-10-rhel7@sha256:8c459a1c790cb81503b16a1bfb296dc2306cbb9e51f24194e8a730416296b006
     name: postgresql-10-rhel7
-  - image: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.3
+  - image: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift@sha256:cfd8c4ac1c495b766dd3ff1a85c35afe092858f8f65b52a5b044811719482236
     name: datagrid73-openshift
-  - image: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift:1.5
+  - image: registry.redhat.io/jboss-datagrid-7/datagrid73-openshift@sha256:3375ec169d274278da56d1401c5c1285f7d2812ea0bde2ac9ad9652b69f80893
     name: datagrid73-openshift
-  - image: registry.redhat.io/amq7/amq-broker:7.5
+  - image: registry.redhat.io/amq7/amq-broker@sha256:ba5273b390a4762c21f005fdc92a837680417250dcd5e6d9d3c8f776e9cc372e
     name: amq-broker
-  - image: registry.redhat.io/amq7/amq-broker:7.6
+  - image: registry.redhat.io/amq7/amq-broker@sha256:7e81fec6e8fcb760829ab73512d1abf4da93e6e3bca42a12f517f793b34d6709
     name: amq-broker
   replaces: businessautomation-operator.1.4.1
   selector:


### PR DESCRIPTION
- ensure image tag used instead of sha when builds are involved
- ensure each serverset properly points to its own build/image
- fix issue where webhook passwds not being retained when multiple builds specified
- refactor server defaults & retention logic

Signed-off-by: tchughesiv <tchughesiv@gmail.com>