### PR TITLE
[KIECLOUD-395] Enabling the new Simplified mode for Business Central Monitoring console for operator

### DIFF
--- a/config/7.8.0/common.yaml
+++ b/config/7.8.0/common.yaml
@@ -254,8 +254,10 @@ console:
                   - name: "[[.ApplicationName]]-[[.Console.Name]]-[[.Constants.KeystoreVolumeSuffix]]"
                     mountPath: "/etc/businesscentral-secret-volume"
                     readOnly: true
+                  #[[if not .Console.Simplified]]
                   - name: "[[.ApplicationName]]-[[.Console.Name]]-pvol"
                     mountPath: "/opt/kie/data"
+                  #[[end]]
                   #[[if .Auth.RoleMapper.From]]
                   - name: "[[.Constants.RoleMapperVolume]]"
                     mountPath: "[[.Auth.RoleMapper.MountPath]]"
@@ -270,9 +272,11 @@ console:
               - name: "[[.ApplicationName]]-[[.Console.Name]]-[[.Constants.KeystoreVolumeSuffix]]"
                 secret:
                   secretName: "[[.Console.KeystoreSecret]]"
+              #[[if not .Console.Simplified]]
               - name: "[[.ApplicationName]]-[[.Console.Name]]-pvol"
                 persistentVolumeClaim:
                   claimName: "[[.ApplicationName]]-[[.Console.Name]]-claim"
+              #[[end]]
               #[[if .Auth.RoleMapper.From]]
               - name: "[[.Constants.RoleMapperVolume]]"
               #[[if eq .Auth.RoleMapper.From.Kind "ConfigMap"]]
@@ -305,6 +309,7 @@ console:
                   claimName: "[[.Console.GitHooks.From.Name]]"
               #[[end]]
               #[[end]]
+  #[[if not .Console.Simplified]]
   persistentVolumeClaims:
     - metadata:
         name: "[[.ApplicationName]]-[[.Console.Name]]-claim"
@@ -317,6 +322,7 @@ console:
         resources:
           requests:
             storage: "64Mi"
+  #[[end]]
   services:
     - spec:
         ports:

--- a/pkg/apis/app/v2/kieapp_types.go
+++ b/pkg/apis/app/v2/kieapp_types.go
@@ -440,6 +440,7 @@ type ConsoleTemplate struct {
 	GitHooks         GitHooksVolume `json:"gitHooks,omitempty"`
 	Jvm              JvmObject      `json:"jvm,omitempty"`
 	StorageClassName string         `json:"storageClassName,omitempty"`
+	Simplified       bool           `json:"simplifed"`
 }
 
 // ServerTemplate contains all the variables used in the yaml templates

--- a/pkg/controller/kieapp/defaults/defaults.go
+++ b/pkg/controller/kieapp/defaults/defaults.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"text/template"
 
@@ -293,7 +294,20 @@ func getConsoleTemplate(cr *api.KieApp) api.ConsoleTemplate {
 	if cr.Status.Applied.Objects.Console.Jvm != nil {
 		template.Jvm = *cr.Status.Applied.Objects.Console.Jvm.DeepCopy()
 	}
+	// Simplified mode configuration
+	if enabled, err := strconv.ParseBool(getSpecEnv(cr.Spec.Objects.Console.Env, "ORG_APPFORMER_SIMPLIFIED_MONITORING_ENABLED")); err == nil {
+		template.Simplified = enabled
+	}
 	return template
+}
+
+func getSpecEnv(envs []corev1.EnvVar, name string) string {
+	for _, env := range envs {
+		if env.Name == name {
+			return env.Value
+		}
+	}
+	return ""
 }
 
 func getSmartRouterTemplate(cr *api.KieApp) api.SmartRouterTemplate {


### PR DESCRIPTION
To follow up on KIECLOUD-394, KieApp Operator needs to suppress the creation and related configurations for persistent volume initially required by Business Central Monitoring Console.

Related JIRA:
https://issues.redhat.com/projects/KIECLOUD/issues/KIECLOUD-394

Related PR:
https://github.com/jboss-container-images/jboss-kie-modules/pull/370

Signed-off-by: Evan Zhang <evan.zhang@redhat.com>