### PR TITLE
[RHPAM-2996] add ssh secret option to console object for githooks

### DIFF
--- a/config/7.8.0/common.yaml
+++ b/config/7.8.0/common.yaml
@@ -268,6 +268,10 @@ console:
                     mountPath: "[[.Console.GitHooks.MountPath]]"
                     readOnly: true
                   #[[end]]
+                  #[[if ne .Console.GitHooks.SSHSecret ""]]
+                  - name: "[[.Constants.GitHooksSSHSecret]]"
+                    mountPath: "/home/jboss/.ssh"
+                  #[[end]]
             volumes:
               - name: "[[.ApplicationName]]-[[.Console.Name]]-[[.Constants.KeystoreVolumeSuffix]]"
                 secret:
@@ -298,15 +302,28 @@ console:
               #[[if eq .Console.GitHooks.From.Kind "ConfigMap"]]
                 configMap:
                   name: "[[.Console.GitHooks.From.Name]]"
-                  defaultMode: 420
+                  defaultMode: 0770
               #[[end]]
               #[[if eq .Console.GitHooks.From.Kind "Secret"]]
                 secret:
                   secretName: "[[.Console.GitHooks.From.Name]]"
+                  defaultMode: 0770
               #[[end]]
               #[[if eq .Console.GitHooks.From.Kind "PersistentVolumeClaim"]]
                 persistentVolumeClaim:
                   claimName: "[[.Console.GitHooks.From.Name]]"
+              #[[end]]
+              #[[if ne .Console.GitHooks.SSHSecret ""]]
+              - name: "[[.Constants.GitHooksSSHSecret]]"
+                secret:
+                  secretName: "[[.Console.GitHooks.SSHSecret]]"
+                  items:
+                  - key: id_rsa
+                    path: id_rsa
+                    mode: 0440
+                  - key: known_hosts
+                    path: known_hosts
+                    mode: 0660
               #[[end]]
               #[[end]]
   #[[if not .Console.Simplified]]

--- a/deploy/crds/kieapp.crd.yaml
+++ b/deploy/crds/kieapp.crd.yaml
@@ -182,6 +182,9 @@ spec:
                           type: object
                           description: GitHooks configuration object
                           properties:
+                            sshSecret:
+                              type: string
+                              description: Secret to use for ssh key and known hosts file.
                             mountPath:
                               type: string
                               description: Absolute path where the gitHooks folder will be mounted.

--- a/deploy/crs/v2/snippets/githooks.yaml
+++ b/deploy/crs/v2/snippets/githooks.yaml
@@ -15,3 +15,4 @@ spec:
         from:
           kind: PersistentVolumeClaim
           name: githooks-pvc
+        sshSecret: ssh-secret

--- a/deploy/ui/form.json
+++ b/deploy/ui/form.json
@@ -516,6 +516,13 @@
                       "description": "Reference object Name for the GitHooks."
                     }
                   ]
+                },
+                {
+                  "label": "SSH Secret",
+                  "type": "text",
+                  "required": false,
+                  "jsonPath": "$.spec.objects.console.gitHooks.sshSecret",
+                  "description": "Secret to use for ssh key and known hosts file."
                 }
               ]
             },

--- a/pkg/apis/app/v2/kieapp_types.go
+++ b/pkg/apis/app/v2/kieapp_types.go
@@ -259,6 +259,7 @@ type WebhookSecret struct {
 type GitHooksVolume struct {
 	MountPath string                  `json:"mountPath,omitempty"`
 	From      *corev1.ObjectReference `json:"from,omitempty"`
+	SSHSecret string                  `json:"sshSecret,omitempty"`
 }
 
 // KieAppAuthObject Authentication specification to be used by the KieApp
@@ -425,6 +426,7 @@ type TemplateConstants struct {
 	DatagridImageURL     string `json:"datagridImageURL,omitempty"`
 	RoleMapperVolume     string `json:"roleMapperVolume"`
 	GitHooksVolume       string `json:"gitHooksVolume,omitempty"`
+	GitHooksSSHSecret    string `json:"gitHooksSSHSecret,omitempty"`
 }
 
 // ConsoleTemplate contains all the variables used in the yaml templates

--- a/pkg/controller/kieapp/constants/constants.go
+++ b/pkg/controller/kieapp/constants/constants.go
@@ -90,6 +90,8 @@ const (
 	GitHooksDefaultDir = "/opt/kie/data/git/hooks"
 	// GitHooksVolume Name of the mounted volume name when GitHooks reference is set
 	GitHooksVolume = "githooks-volume"
+	// GitHooksSSHSecret Name of the mounted volume name when GitHooks SSH Secret reference is set
+	GitHooksSSHSecret = "githooks-ssh-volume"
 	// RoleMapperVolume Name of the mounted volume name when RoleMapper reference is set
 	RoleMapperVolume = "rolemapper-volume"
 	// RoleMapperDefaultDir Default path for the rolemapping properties file
@@ -326,6 +328,7 @@ var TemplateConstants = api.TemplateConstants{
 	DatabaseVolumeSuffix: DatabaseVolumeSuffix,
 	RoleMapperVolume:     RoleMapperVolume,
 	GitHooksVolume:       GitHooksVolume,
+	GitHooksSSHSecret:    GitHooksSSHSecret,
 }
 
 // DebugTrue - used to enable debug logs in objects


### PR DESCRIPTION
mounts a secret in BC at `/home/jboss/.ssh` with the following required files -
 - id_rsa
 - known_hosts

Signed-off-by: tchughesiv <tchughesiv@gmail.com>