### PR TITLE
keystore patch

### DIFF
--- a/pkg/controller/kieapp/constants/constants.go
+++ b/pkg/controller/kieapp/constants/constants.go
@@ -74,6 +74,10 @@ const (
 	KeystoreSecret = "%s-app-secret"
 	// KeystoreVolumeSuffix Suffix for the keystore volumes and volumeMounts name
 	KeystoreVolumeSuffix = "keystore-volume"
+	// KeystoreAlias used when creating entry in Keystore
+	KeystoreAlias = "jboss"
+	// KeystoreName used when creating Secret
+	KeystoreName = "keystore.jks"
 	// DatabaseVolumeSuffix Suffix to use for any database volume and volumeMounts
 	DatabaseVolumeSuffix = "pvol"
 	// DefaultDatabaseSize Default Database Persistence size

--- a/pkg/controller/kieapp/shared/utils.go
+++ b/pkg/controller/kieapp/shared/utils.go
@@ -11,6 +11,7 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/constants"
 	"github.com/pavel-v-chernykh/keystore-go"
 	"github.com/prometheus/common/log"
 	corev1 "k8s.io/api/core/v1"
@@ -19,7 +20,7 @@ import (
 )
 
 // GenerateKeystore returns a Java Keystore with a self-signed certificate
-func GenerateKeystore(commonName, alias string, password []byte) []byte {
+func GenerateKeystore(commonName string, password []byte) []byte {
 	cert, derPK, err := genCert(commonName)
 	if err != nil {
 		log.Error("Error generating certificate. ", err)
@@ -27,7 +28,7 @@ func GenerateKeystore(commonName, alias string, password []byte) []byte {
 
 	var chain []keystore.Certificate
 	keyStore := keystore.KeyStore{
-		alias: &keystore.PrivateKeyEntry{
+		constants.KeystoreAlias: &keystore.PrivateKeyEntry{
 			Entry: keystore.Entry{
 				CreationDate: time.Now(),
 			},

--- a/pkg/controller/kieapp/shared/utils_test.go
+++ b/pkg/controller/kieapp/shared/utils_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"testing"
 
+	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/constants"
 	keystore "github.com/pavel-v-chernykh/keystore-go"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -57,20 +58,19 @@ func TestGetEnvVar(t *testing.T) {
 }
 
 func TestGenerateKeystore(t *testing.T) {
-	alias := "test"
 	password := GeneratePassword(8)
 	assert.EqualValues(t, 8, len(password))
 
 	commonName := "test-https"
-	keyBytes := GenerateKeystore(commonName, alias, password)
+	keyBytes := GenerateKeystore(commonName, password)
 	keyStore, err := keystore.Decode(bytes.NewReader(keyBytes), password)
 	assert.Nil(t, err)
 
-	derKey := keyStore[alias].(*keystore.PrivateKeyEntry).PrivKey
+	derKey := keyStore[constants.KeystoreAlias].(*keystore.PrivateKeyEntry).PrivKey
 	_, err = x509.ParsePKCS8PrivateKey(derKey)
 	assert.Nil(t, err)
 
-	cert := keyStore[alias].(*keystore.PrivateKeyEntry).CertChain[0].Content
+	cert := keyStore[constants.KeystoreAlias].(*keystore.PrivateKeyEntry).CertChain[0].Content
 	certificate, err := x509.ParseCertificate(cert)
 	assert.Nil(t, err)
 	assert.Equal(t, commonName, certificate.Subject.CommonName)


### PR DESCRIPTION
This resolves an issue where when a generated keystore password changes, the keystore secret was not regenerated using the new password.

Without this change, affected kieserver and bc pods never successfully start due to an incorrect keystore pwd.

Signed-off-by: tchughesiv <tchughesiv@gmail.com>