### PR TITLE
[RHPAM-3055] Use CR name in the console links

### DIFF
--- a/pkg/controller/kieapp/kieapp_controller.go
+++ b/pkg/controller/kieapp/kieapp_controller.go
@@ -1046,7 +1046,7 @@ func (reconciler *Reconciler) getConsoleLinkResource(cr *api.KieApp) resource.Ku
 		Spec: consolev1.ConsoleLinkSpec{
 			Link: consolev1.Link{
 				Href: cr.Status.ConsoleHost,
-				Text: constants.EnvironmentConstants[cr.Status.Applied.Environment].App.FriendlyName,
+				Text: getConsoleLinkFriendlyName(cr),
 			},
 			Location: consolev1.NamespaceDashboard,
 			NamespaceDashboard: &consolev1.NamespaceDashboardSpec{
@@ -1059,4 +1059,8 @@ func (reconciler *Reconciler) getConsoleLinkResource(cr *api.KieApp) resource.Ku
 
 func getConsoleLinkName(cr *api.KieApp) string {
 	return fmt.Sprintf("%s-link-%s", cr.Namespace, cr.Name)
+}
+
+func getConsoleLinkFriendlyName(cr *api.KieApp) string {
+	return fmt.Sprintf("%s: %s", cr.Name, constants.EnvironmentConstants[cr.Status.Applied.Environment].App.FriendlyName)
 }

--- a/pkg/controller/kieapp/kieapp_controller_test.go
+++ b/pkg/controller/kieapp/kieapp_controller_test.go
@@ -787,7 +787,7 @@ func TestConsoleLinkCreation(t *testing.T) {
 
 	consoleLink := &consolev1.ConsoleLink{}
 	reconciler.Service.Get(context.TODO(), getNamespacedName("", getConsoleLinkName(cr)), consoleLink)
-	assert.Equal(t, "Business Central", consoleLink.Spec.Text)
+	assert.Equal(t, "cr: Business Central", consoleLink.Spec.Text)
 	assert.Equal(t, "https://example", consoleLink.Spec.Href)
 	assert.Equal(t, "testns-link-cr", consoleLink.GetName())
 	assert.Len(t, consoleLink.Spec.NamespaceDashboard.Namespaces, 1)


### PR DESCRIPTION
Signed-off-by: ruromero <rromerom@redhat.com>

Fix https://issues.redhat.com/browse/RHPAM-3055