### PR TITLE
[KIECLOUD-422] display admin user & pwd in Operator Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,15 @@ If pushing to another quay repository, replace _kiegroup_ with your username or 
 **Create your own index image**
 ```bash
 $ make bundle-dev
+USERNAME=tchughesiv
 VERSION=$(go run getversion.go)
-IMAGE=quay.io/tchughesiv/rhpam-operator-bundle
+IMAGE=quay.io/${USERNAME}/rhpam-operator-bundle
 BUNDLE=${IMAGE}:${VERSION}
 
 $ docker push ${BUNDLE}
 BUNDLE_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ${BUNDLE})
 INDEX_VERSION=v4.5 # v4.6
-INDEX_IMAGE=quay.io/tchughesiv/ba-operator-index:${INDEX_VERSION}
+INDEX_IMAGE=quay.io/${USERNAME}/ba-operator-index:${INDEX_VERSION}
 INDEX_FROM=${INDEX_IMAGE}_$(go run getversion.go --prior)
 INDEX_TO=${INDEX_IMAGE}_${VERSION}
 

--- a/deploy/crds/kieapp.crd.yaml
+++ b/deploy/crds/kieapp.crd.yaml
@@ -272,24 +272,29 @@ spec:
                 properties:
                   adminPassword:
                     description: The password to use for the adminUser.
+                    format: password
                     type: string
                   adminUser:
                     description: The user to use for the admin.
                     type: string
                   amqClusterPassword:
                     description: The password to use for amq cluster user.
+                    format: password
                     type: string
                   amqPassword:
                     description: The password to use for amq user.
+                    format: password
                     type: string
                   applicationName:
                     description: The name of the application deployment.
                     type: string
                   dbPassword:
                     description: The password to use for databases.
+                    format: password
                     type: string
                   keyStorePassword:
                     description: The password to use for keystore generation.
+                    format: password
                     type: string
                 type: object
               environment:
@@ -713,6 +718,7 @@ spec:
                                 type: string
                               password:
                                 description: External database password
+                                format: password
                                 type: string
                               username:
                                 description: External database username
@@ -940,6 +946,7 @@ spec:
                                   type: string
                                 password:
                                   description: External database password
+                                  format: password
                                   type: string
                                 port:
                                   description: Database Port. For example, 3306
@@ -1161,6 +1168,7 @@ spec:
                               type: string
                             amqKeystorePassword:
                               description: The password for the AMQ keystore and certificate.
+                              format: password
                               type: string
                             amqQueues:
                               description: AMQ broker broker comma separated queues,
@@ -1175,6 +1183,7 @@ spec:
                               type: string
                             amqTruststorePassword:
                               description: The password for the AMQ Trust Store.
+                              format: password
                               type: string
                             auditTransacted:
                               description: Determines if JMS session is transacted
@@ -1204,6 +1213,7 @@ spec:
                             password:
                               description: AMQ broker password to connect do the AMQ,
                                 generated if empty.
+                              format: password
                               type: string
                             queueAudit:
                               description: JNDI name of audit logging queue for JMS,
@@ -1835,24 +1845,29 @@ spec:
                     properties:
                       adminPassword:
                         description: The password to use for the adminUser.
+                        format: password
                         type: string
                       adminUser:
                         description: The user to use for the admin.
                         type: string
                       amqClusterPassword:
                         description: The password to use for amq cluster user.
+                        format: password
                         type: string
                       amqPassword:
                         description: The password to use for amq user.
+                        format: password
                         type: string
                       applicationName:
                         description: The name of the application deployment.
                         type: string
                       dbPassword:
                         description: The password to use for databases.
+                        format: password
                         type: string
                       keyStorePassword:
                         description: The password to use for keystore generation.
+                        format: password
                         type: string
                     type: object
                   environment:
@@ -2284,6 +2299,7 @@ spec:
                                     type: string
                                   password:
                                     description: External database password
+                                    format: password
                                     type: string
                                   username:
                                     description: External database username
@@ -2521,6 +2537,7 @@ spec:
                                       type: string
                                     password:
                                       description: External database password
+                                      format: password
                                       type: string
                                     port:
                                       description: Database Port. For example, 3306
@@ -2749,6 +2766,7 @@ spec:
                                 amqKeystorePassword:
                                   description: The password for the AMQ keystore and
                                     certificate.
+                                  format: password
                                   type: string
                                 amqQueues:
                                   description: AMQ broker broker comma separated queues,
@@ -2765,6 +2783,7 @@ spec:
                                   type: string
                                 amqTruststorePassword:
                                   description: The password for the AMQ Trust Store.
+                                  format: password
                                   type: string
                                 auditTransacted:
                                   description: Determines if JMS session is transacted
@@ -2794,6 +2813,7 @@ spec:
                                 password:
                                   description: AMQ broker password to connect do the
                                     AMQ, generated if empty.
+                                  format: password
                                   type: string
                                 queueAudit:
                                   description: JNDI name of audit logging queue for

--- a/deploy/olm-catalog/dev/7.9.0/manifests/businessautomation-operator.7.9.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/dev/7.9.0/manifests/businessautomation-operator.7.9.0.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Integration & Delivery
     certified: "false"
     containerImage: quay.io/kiegroup/kie-cloud-operator:7.9.0
-    createdAt: "2020-09-17 14:51:02"
+    createdAt: "2020-09-18 13:58:00"
     description: Deploys and manages Red Hat Process Automation Manager and Red Hat Decision Manager environments.
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     repository: https://github.com/kiegroup/kie-cloud-operator
@@ -17,7 +17,7 @@ metadata:
     operator-businessautomation: "true"
     operatorframework.io/arch.amd64: supported
     operatorframework.io/os.linux: supported
-  name: businessautomation-operator.7.9.0-dev-x9vcsqg4w8
+  name: businessautomation-operator.7.9.0-dev-zgt7h8cxlm
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -62,6 +62,16 @@ spec:
         name: ""
         version: v1
       specDescriptors:
+      - description: The admin user for BC console.
+        displayName: Business/Decision Central Admin User (defaults to 'adminUser')
+        path: commonConfig.adminUser
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:password
+      - description: The admin password for BC console.
+        displayName: Business/Decision Central Admin Password (defaults to 'RedHat')
+        path: commonConfig.adminPassword
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:password
       - description: Set true to enable automatic micro version product upgrades, it is disabled by default.
         displayName: Enable Upgrades
         path: upgrades.enabled
@@ -433,7 +443,7 @@ spec:
   - operator
   labels:
     alm-owner-businessautomation: businessautomation-operator
-    operated-by: businessautomation-operator.7.9.0-dev-x9vcsqg4w8
+    operated-by: businessautomation-operator.7.9.0-dev-zgt7h8cxlm
   links:
   - name: Product Page
     url: https://access.redhat.com/products/red-hat-process-automation-manager
@@ -536,5 +546,5 @@ spec:
   selector:
     matchLabels:
       alm-owner-businessautomation: businessautomation-operator
-      operated-by: businessautomation-operator.7.9.0-dev-x9vcsqg4w8
-  version: 7.9.0+x9vcsqg4w8
+      operated-by: businessautomation-operator.7.9.0-dev-zgt7h8cxlm
+  version: 7.9.0+zgt7h8cxlm

--- a/deploy/olm-catalog/prod/7.9.0/manifests/businessautomation-operator.7.9.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/prod/7.9.0/manifests/businessautomation-operator.7.9.0.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Integration & Delivery
     certified: "true"
     containerImage: registry.redhat.io/rhpam-7/rhpam-rhel8-operator:7.9.0
-    createdAt: "2020-09-17 14:51:02"
+    createdAt: "2020-09-18 13:58:00"
     description: Deploys and manages Red Hat Process Automation Manager and Red Hat Decision Manager environments.
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     repository: https://github.com/kiegroup/kie-cloud-operator
@@ -62,6 +62,16 @@ spec:
         name: ""
         version: v1
       specDescriptors:
+      - description: The admin user for BC console.
+        displayName: Business/Decision Central Admin User (defaults to 'adminUser')
+        path: commonConfig.adminUser
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:password
+      - description: The admin password for BC console.
+        displayName: Business/Decision Central Admin Password (defaults to 'RedHat')
+        path: commonConfig.adminPassword
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:password
       - description: Set true to enable automatic micro version product upgrades, it is disabled by default.
         displayName: Enable Upgrades
         path: upgrades.enabled

--- a/pkg/apis/app/v2/kieapp_types.go
+++ b/pkg/apis/app/v2/kieapp_types.go
@@ -173,6 +173,7 @@ type KieAppJmsObject struct {
 	AuditTransacted *bool `json:"auditTransacted,omitempty"`
 	// AMQ broker username to connect do the AMQ, generated if empty.
 	Username string `json:"username,omitempty"`
+	// +kubebuilder:validation:Format:=password
 	// AMQ broker password to connect do the AMQ, generated if empty.
 	Password string `json:"password,omitempty"`
 	// AMQ broker broker comma separated queues, if empty the values from default queues will be used.
@@ -181,10 +182,12 @@ type KieAppJmsObject struct {
 	AMQSecretName string `json:"amqSecretName,omitempty"` // AMQ SSL parameters
 	// The name of the AMQ SSL Trust Store file.
 	AMQTruststoreName string `json:"amqTruststoreName,omitempty"`
+	// +kubebuilder:validation:Format:=password
 	// The password for the AMQ Trust Store.
 	AMQTruststorePassword string `json:"amqTruststorePassword,omitempty"`
 	// The name of the AMQ keystore file.
 	AMQKeystoreName string `json:"amqKeystoreName,omitempty"`
+	// +kubebuilder:validation:Format:=password
 	// The password for the AMQ keystore and certificate.
 	AMQKeystorePassword string `json:"amqKeystorePassword,omitempty"`
 	// Not intended to be set by the user, if will be set to true if all required SSL parameters are set.
@@ -472,6 +475,7 @@ type CommonExternalDatabaseObject struct {
 	// External database username
 	Username string `json:"username"`
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Format:=password
 	// External database password
 	Password string `json:"password"`
 	// Sets xa-pool/min-pool-size for the configured datasource.
@@ -678,16 +682,21 @@ type BuildTemplate struct {
 type CommonConfig struct {
 	// The name of the application deployment.
 	ApplicationName string `json:"applicationName,omitempty"`
+	// +kubebuilder:validation:Format:=password
 	// The password to use for keystore generation.
 	KeyStorePassword string `json:"keyStorePassword,omitempty"`
 	// The user to use for the admin.
 	AdminUser string `json:"adminUser,omitempty"`
+	// +kubebuilder:validation:Format:=password
 	// The password to use for the adminUser.
 	AdminPassword string `json:"adminPassword,omitempty"`
+	// +kubebuilder:validation:Format:=password
 	// The password to use for databases.
 	DBPassword string `json:"dbPassword,omitempty"`
+	// +kubebuilder:validation:Format:=password
 	// The password to use for amq user.
 	AMQPassword string `json:"amqPassword,omitempty"`
+	// +kubebuilder:validation:Format:=password
 	// The password to use for amq cluster user.
 	AMQClusterPassword string `json:"amqClusterPassword,omitempty"`
 }

--- a/tools/csv-gen/csv-gen.go
+++ b/tools/csv-gen/csv-gen.go
@@ -234,6 +234,18 @@ func main() {
 				},
 				SpecDescriptors: []csvv1.SpecDescriptor{
 					{
+						Description:  "The admin user for BC console.",
+						DisplayName:  "Business/Decision Central Admin User (defaults to '" + constants.DefaultAdminUser + "')",
+						Path:         "commonConfig.adminUser",
+						XDescriptors: []string{"urn:alm:descriptor:com.tectonic.ui:password"},
+					},
+					{
+						Description:  "The admin password for BC console.",
+						DisplayName:  "Business/Decision Central Admin Password (defaults to '" + constants.DefaultPassword + "')",
+						Path:         "commonConfig.adminPassword",
+						XDescriptors: []string{"urn:alm:descriptor:com.tectonic.ui:password"},
+					},
+					{
 						Description:  "Set true to enable automatic micro version product upgrades, it is disabled by default.",
 						DisplayName:  "Enable Upgrades",
 						Path:         "upgrades.enabled",


### PR DESCRIPTION
Leverage `urn:alm:descriptor:com.tectonic.ui:password` specDescriptor.
https://github.com/openshift/console/blob/master/frontend/packages/operator-lifecycle-manager/src/components/descriptors/reference/reference.md#8-password

![Screen Shot 2020-09-18 at 2 04 41 PM](https://user-images.githubusercontent.com/11095048/93636197-1c764380-f9b9-11ea-82bc-e197275102dd.png)

Signed-off-by: tchughesiv <tchughesiv@gmail.com>