### PR TITLE
[KIECLOUD-422] move admin user/pwd to statusDescriptors

### DIFF
--- a/deploy/olm-catalog/dev/7.9.0/manifests/businessautomation-operator.7.9.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/dev/7.9.0/manifests/businessautomation-operator.7.9.0.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Integration & Delivery
     certified: "false"
     containerImage: quay.io/kiegroup/kie-cloud-operator:7.9.0
-    createdAt: "2020-09-22 11:50:50"
+    createdAt: "2020-09-25 15:05:21"
     description: Deploys and manages Red Hat Process Automation Manager and Red Hat Decision Manager environments.
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     repository: https://github.com/kiegroup/kie-cloud-operator
@@ -17,7 +17,7 @@ metadata:
     operator-businessautomation: "true"
     operatorframework.io/arch.amd64: supported
     operatorframework.io/os.linux: supported
-  name: businessautomation-operator.7.9.0-dev-x7zlgfdt6r
+  name: businessautomation-operator.7.9.0-dev-p9f5jmzdd2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -83,6 +83,16 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:label
       statusDescriptors:
+      - description: The admin user for BC console.
+        displayName: Business/Decision Central Admin User
+        path: applied.commonConfig.adminUser
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:password
+      - description: The admin password for BC console.
+        displayName: Business/Decision Central Admin Password
+        path: applied.commonConfig.adminPassword
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:password
       - description: Product version installed.
         displayName: Version
         path: version
@@ -444,7 +454,7 @@ spec:
   - operator
   labels:
     alm-owner-businessautomation: businessautomation-operator
-    operated-by: businessautomation-operator.7.9.0-dev-x7zlgfdt6r
+    operated-by: businessautomation-operator.7.9.0-dev-p9f5jmzdd2
   links:
   - name: Product Page
     url: https://access.redhat.com/products/red-hat-process-automation-manager
@@ -547,5 +557,5 @@ spec:
   selector:
     matchLabels:
       alm-owner-businessautomation: businessautomation-operator
-      operated-by: businessautomation-operator.7.9.0-dev-x7zlgfdt6r
-  version: 7.9.0+x7zlgfdt6r
+      operated-by: businessautomation-operator.7.9.0-dev-p9f5jmzdd2
+  version: 7.9.0+p9f5jmzdd2

--- a/deploy/olm-catalog/prod/7.9.0/manifests/businessautomation-operator.7.9.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/prod/7.9.0/manifests/businessautomation-operator.7.9.0.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Integration & Delivery
     certified: "true"
     containerImage: registry.redhat.io/rhpam-7/rhpam-rhel8-operator:7.9.0
-    createdAt: "2020-09-22 11:50:50"
+    createdAt: "2020-09-25 15:05:21"
     description: Deploys and manages Red Hat Process Automation Manager and Red Hat Decision Manager environments.
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     repository: https://github.com/kiegroup/kie-cloud-operator
@@ -83,6 +83,16 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:label
       statusDescriptors:
+      - description: The admin user for BC console.
+        displayName: Business/Decision Central Admin User
+        path: applied.commonConfig.adminUser
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:password
+      - description: The admin password for BC console.
+        displayName: Business/Decision Central Admin Password
+        path: applied.commonConfig.adminPassword
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:password
       - description: Product version installed.
         displayName: Version
         path: version

--- a/image-bundle.yaml
+++ b/image-bundle.yaml
@@ -35,8 +35,7 @@ labels:
   - name: com.redhat.delivery.operator.bundle
     value: "true"
   - name: com.redhat.openshift.versions
-    # change to this label for 7.9.1+ releases ?? # value: v4.6
-    value: v4.5,v4.6
+    value: v4.7
 modules:
   repositories:
     - path: deploy/olm-catalog/prod

--- a/tools/csv-gen/csv-gen.go
+++ b/tools/csv-gen/csv-gen.go
@@ -260,6 +260,18 @@ func main() {
 				},
 				StatusDescriptors: []csvv1.StatusDescriptor{
 					{
+						Description:  "The admin user for BC console.",
+						DisplayName:  "Business/Decision Central Admin User",
+						Path:         "applied.commonConfig.adminUser",
+						XDescriptors: []string{"urn:alm:descriptor:com.tectonic.ui:password"},
+					},
+					{
+						Description:  "The admin password for BC console.",
+						DisplayName:  "Business/Decision Central Admin Password",
+						Path:         "applied.commonConfig.adminPassword",
+						XDescriptors: []string{"urn:alm:descriptor:com.tectonic.ui:password"},
+					},
+					{
 						Description:  "Product version installed.",
 						DisplayName:  "Version",
 						Path:         "version",


### PR DESCRIPTION
Dependant on https://github.com/openshift/console/pull/6697

We'll need to wait for a later operator release. Once the above is merged. Then, we'll need to target the operator version that aligns with whatever OCP version these console password type enhancements are released with. Which appears to be 4.7.

![Screen Shot 2020-09-21 at 11 06 42 AM](https://user-images.githubusercontent.com/11095048/93804538-0f9d5e00-fc0c-11ea-9b82-538db6406b07.png)

Signed-off-by: tchughesiv <tchughesiv@gmail.com>