### PR TITLE
upgrade fix: retain version from applied status

### DIFF
--- a/pkg/controller/kieapp/defaults/defaults.go
+++ b/pkg/controller/kieapp/defaults/defaults.go
@@ -1002,11 +1002,14 @@ func SetDefaults(cr *api.KieApp) {
 			api.SchemeGroupVersion.Group: version.Version,
 		})
 	}
-	// retain ONLY generated passwords / usernames from status...
+	// retain certain items from status... e.g. version, usernames, passwords, etc
 	// everything else in status should be recreated with each reconcile.
 	specApply := cr.Spec.DeepCopy()
 	if len(specApply.Version) == 0 {
 		specApply.Version = constants.CurrentVersion
+		if len(cr.Status.Applied.Version) != 0 {
+			specApply.Version = cr.Status.Applied.Version
+		}
 	}
 	if err := mergo.Merge(&specApply.CommonConfig, cr.Status.Applied.CommonConfig); err != nil {
 		log.Error(err)

--- a/pkg/controller/kieapp/defaults/upgrade_test.go
+++ b/pkg/controller/kieapp/defaults/upgrade_test.go
@@ -117,6 +117,21 @@ func TestCheckProductUpgrade(t *testing.T) {
 	assert.NotEmpty(t, diffs)
 	// assert.Empty(t, diffs)
 
+	// check upgrade against version in status section
+	cr.Status.Applied.Version = constants.PriorVersion2
+	cr.Spec.Version = ""
+	minor, micro, err = checkProductUpgrade(cr)
+	assert.Empty(t, cr.Spec.Version)
+	assert.Nil(t, err)
+	assert.True(t, minor)
+	assert.True(t, micro)
+	cr.Status.Applied.Version = constants.CurrentVersion
+	minor, micro, err = checkProductUpgrade(cr)
+	assert.Empty(t, cr.Spec.Version)
+	assert.Nil(t, err)
+	assert.False(t, minor)
+	assert.False(t, micro)
+
 	// Current version, no upgrades
 	cr = &api.KieApp{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
this is required now that we switched to status subresource.

/assign @bmozaffa 

Signed-off-by: tchughesiv <tchughesiv@gmail.com>