### PR TITLE
[RHPAM-3056] Business Central remains "Container Creating" if missing known_hosts file in the githooks configuration

### DIFF
--- a/config/7.9.0/common.yaml
+++ b/config/7.9.0/common.yaml
@@ -321,9 +321,6 @@ console:
                   - key: id_rsa
                     path: id_rsa
                     mode: 0440
-                  - key: known_hosts
-                    path: known_hosts
-                    mode: 0660
               #[[end]]
               #[[end]]
   #[[if not .Console.Simplified]]

--- a/pkg/controller/kieapp/defaults/defaults_test.go
+++ b/pkg/controller/kieapp/defaults/defaults_test.go
@@ -3179,7 +3179,6 @@ func TestStorageClassName(t *testing.T) {
 
 func TestGitHooks(t *testing.T) {
 	var defaultMode int32 = 0770
-	var knownHosts int32 = 0660
 	var idRsa int32 = 0440
 	tests := []struct {
 		name                string
@@ -3311,11 +3310,6 @@ func TestGitHooks(t *testing.T) {
 							Key:  "id_rsa",
 							Path: "id_rsa",
 							Mode: &idRsa,
-						},
-						{
-							Key:  "known_hosts",
-							Path: "known_hosts",
-							Mode: &knownHosts,
 						},
 					},
 				},


### PR DESCRIPTION
https://issues.redhat.com/browse/RHPAM-3056