### PR TITLE
[RHPAM-3245] - Change resource requirements for BC and KIE Server

### DIFF
--- a/deploy/crds/kieapp.crd.yaml
+++ b/deploy/crds/kieapp.crd.yaml
@@ -537,8 +537,7 @@ spec:
                           gcMaxMetaspaceSize:
                             description: The maximum metaspace size unit, unit could
                               be g (Giga) m (Mega) or k (kilo)  e.g. '400m'
-                            format: int32
-                            type: integer
+                            type: string
                           gcMinHeapFreeRatio:
                             description: Minimum percentage of heap free after GC
                               to avoid expansion. e.g. '20'
@@ -1269,8 +1268,7 @@ spec:
                             gcMaxMetaspaceSize:
                               description: The maximum metaspace size unit, unit could
                                 be g (Giga) m (Mega) or k (kilo)  e.g. '400m'
-                              format: int32
-                              type: integer
+                              type: string
                             gcMinHeapFreeRatio:
                               description: Minimum percentage of heap free after GC
                                 to avoid expansion. e.g. '20'
@@ -2119,8 +2117,7 @@ spec:
                               gcMaxMetaspaceSize:
                                 description: The maximum metaspace size unit, unit
                                   could be g (Giga) m (Mega) or k (kilo)  e.g. '400m'
-                                format: int32
-                                type: integer
+                                type: string
                               gcMinHeapFreeRatio:
                                 description: Minimum percentage of heap free after
                                   GC to avoid expansion. e.g. '20'
@@ -2876,8 +2873,7 @@ spec:
                                 gcMaxMetaspaceSize:
                                   description: The maximum metaspace size unit, unit
                                     could be g (Giga) m (Mega) or k (kilo)  e.g. '400m'
-                                  format: int32
-                                  type: integer
+                                  type: string
                                 gcMinHeapFreeRatio:
                                   description: Minimum percentage of heap free after
                                     GC to avoid expansion. e.g. '20'

--- a/deploy/ui/form.json
+++ b/deploy/ui/form.json
@@ -709,7 +709,7 @@
                     },
                     {
                       "label": "GC max metaspace size",
-                      "type": "integer",
+                      "type": "text",
                       "required": false,
                       "description": "The maximum metaspace size, unit could be g (Giga) m (Mega) or k (kilo)  e.g. '400m'",
                       "jsonPath": "$.spec.objects.console.jvm.gcMaxMetaspaceSize",
@@ -1363,7 +1363,7 @@
                         },
                         {
                           "label": "GC max metaspace size",
-                          "type": "integer",
+                          "type": "text",
                           "required": false,
                           "description": "The maximum metaspace size, unit could be g (Giga) m (Mega) or k (Kilo)  e.g. '400m'.",
                           "jsonPath": "$.spec.objects.servers[*].jvm.gcMaxMetaspaceSize",

--- a/pkg/apis/app/v2/kieapp_types.go
+++ b/pkg/apis/app/v2/kieapp_types.go
@@ -219,7 +219,7 @@ type JvmObject struct {
 	// The weighting given to the current GC time versus previous GC times  when determining the new heap size. e.g. '90'
 	GcAdaptiveSizePolicyWeight *int32 `json:"gcAdaptiveSizePolicyWeight,omitempty"`
 	// The maximum metaspace size unit, unit could be g (Giga) m (Mega) or k (kilo)  e.g. '400m'
-	GcMaxMetaspaceSize *int32 `json:"gcMaxMetaspaceSize,omitempty"`
+	GcMaxMetaspaceSize string `json:"gcMaxMetaspaceSize,omitempty"`
 	// Specify Java GC to use. The value of this variable should contain the necessary JRE command-line options to specify the required GC, which will override the default of '-XX:+UseParallelOldGC'. e.g. '-XX:+UseG1GC'
 	GcContainerOptions string `json:"gcContainerOptions,omitempty"`
 }

--- a/pkg/apis/app/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/app/v2/zz_generated.deepcopy.go
@@ -587,11 +587,6 @@ func (in *JvmObject) DeepCopyInto(out *JvmObject) {
 		*out = new(int32)
 		**out = **in
 	}
-	if in.GcMaxMetaspaceSize != nil {
-		in, out := &in.GcMaxMetaspaceSize, &out.GcMaxMetaspaceSize
-		*out = new(int32)
-		**out = **in
-	}
 	return
 }
 

--- a/pkg/controller/kieapp/constants/constants.go
+++ b/pkg/controller/kieapp/constants/constants.go
@@ -165,14 +165,72 @@ const (
 	PamContext  = ImageRegistry + "/rhpam-7/rhpam-"
 	RhelVersion = "-rhel8"
 
-	//Resources Limits
-	ConsoleCPULimit        = "2"
-	ConsoleCPURequests     = "1"
-	ServersCPULimit        = "1"
-	ServersCPURequests     = "500m"
-	SmartRouterCPULimit    = "500m"
-	SmartRouterCPURequests = "250m"
+	//Resources Limits and Requests
+	ConsoleProdCPULimit         = "1"
+	ConsoleProdMemLimit         = "2Gi"
+	ConsoleAuthoringCPULimit    = "2"
+	ConsoleAuthoringMemLimit    = "4Gi"
+	ConsoleAuthoringCPURequests = "1500m"
+	ConsoleAuthoringMemRequests = "3Gi"
+	ConsoleProdCPURequests      = "500m"
+	ConsoleProdMemRequests      = "1.5Gi"
+	ServersCPULimit             = "1"
+	ServersMemLimit             = "2Gi"
+	ServersCPURequests          = "750m"
+	ServersMemRequests          = "1Gi"
+	SmartRouterCPULimit         = "500m"
+	SmartRouterMemLimit         = "1Gi"
+	SmartRouterCPURequests      = "250m"
+	SmartRouterMemRequests      = "1Gi"
 )
+
+// Console Resource Limits for BC Monitoring in Prod Env
+var ConsoleProdLimits = map[string]string{
+	"CPU": ConsoleProdCPULimit,
+	"MEM": ConsoleProdMemLimit,
+}
+
+// Console Resource Limits for BC in Authoring Env
+var ConsoleAuthoringLimits = map[string]string{
+	"CPU": ConsoleAuthoringCPULimit,
+	"MEM": ConsoleAuthoringMemLimit,
+}
+
+// Server Limits for every Env
+var ServersLimits = map[string]string{
+	"CPU": ServersCPULimit,
+	"MEM": ServersMemLimit,
+}
+
+// SmartRouter Limits for every Env
+var SmartRouterLimits = map[string]string{
+	"CPU": SmartRouterCPULimit,
+	"MEM": SmartRouterMemLimit,
+}
+
+// ConsoleAuthoringRequests defines requests in Authoring environment
+var ConsoleAuthoringRequests = map[string]string{
+	"CPU": ConsoleAuthoringCPURequests,
+	"MEM": ConsoleAuthoringMemRequests,
+}
+
+// ConsoleProdRequests defines requests in Prod or Immutable environment
+var ConsoleProdRequests = map[string]string{
+	"CPU": ConsoleProdCPURequests,
+	"MEM": ConsoleProdMemRequests,
+}
+
+// ServerRequests defines the requests for kieserver deployment
+var ServerRequests = map[string]string{
+	"CPU": ServersCPURequests,
+	"MEM": ServersMemRequests,
+}
+
+// SmartRouterRequests defines the requests for smart router deployment
+var SmartRouterRequests = map[string]string{
+	"CPU": SmartRouterCPURequests,
+	"MEM": SmartRouterMemRequests,
+}
 
 var Images = []ImageEnv{
 	{

--- a/pkg/controller/kieapp/defaults/defaults.go
+++ b/pkg/controller/kieapp/defaults/defaults.go
@@ -1061,16 +1061,20 @@ func SetDefaults(cr *api.KieApp) {
 		}
 		addWebhookPwds(specApply.Objects.Servers[index].Build)
 		checkJvmOnServer(&specApply.Objects.Servers[index])
-		setResourcesDefault(&specApply.Objects.Servers[index].KieAppObject, constants.ServersCPULimit, constants.ServersCPURequests)
+		setResourcesDefault(&specApply.Objects.Servers[index].KieAppObject, constants.ServersLimits, constants.ServerRequests)
 	}
 
 	if specApply.Objects.Console != nil {
 		checkJvmOnConsole(specApply.Objects.Console)
-		setResourcesDefault(&specApply.Objects.Console.KieAppObject, constants.ConsoleCPULimit, constants.ConsoleCPURequests)
+		if strings.Contains(string(specApply.Environment), "authoring") {
+			setResourcesDefault(&specApply.Objects.Console.KieAppObject, constants.ConsoleAuthoringLimits, constants.ConsoleAuthoringRequests)
+		} else if strings.Contains(string(specApply.Environment), "production") {
+			setResourcesDefault(&specApply.Objects.Console.KieAppObject, constants.ConsoleProdLimits, constants.ConsoleProdRequests)
+		}
 	}
 
 	if specApply.Objects.SmartRouter != nil {
-		setResourcesDefault(&specApply.Objects.SmartRouter.KieAppObject, constants.SmartRouterCPULimit, constants.SmartRouterCPURequests)
+		setResourcesDefault(&specApply.Objects.SmartRouter.KieAppObject, constants.SmartRouterLimits, constants.SmartRouterRequests)
 	}
 
 	isTrialEnv := strings.HasSuffix(string(specApply.Environment), constants.TrialEnvSuffix)
@@ -1094,6 +1098,9 @@ func setJvmDefault(jvm *api.JvmObject) {
 		if jvm.JavaInitialMemRatio == nil {
 			jvm.JavaInitialMemRatio = Pint32(25)
 		}
+		if len(jvm.GcMaxMetaspaceSize) == 0 {
+			jvm.GcMaxMetaspaceSize = "512m"
+		}
 	}
 }
 
@@ -1104,21 +1111,27 @@ func checkJvmOnServer(server *api.KieServerSet) {
 	setJvmDefault(server.Jvm)
 }
 
-func setResourcesDefault(kieObject *api.KieAppObject, limits, requests string) {
+func setResourcesDefault(kieObject *api.KieAppObject, limits, requests map[string]string) {
 	if kieObject.Resources == nil {
 		kieObject.Resources = &corev1.ResourceRequirements{}
 	}
 	if kieObject.Resources.Limits == nil {
-		kieObject.Resources.Limits = corev1.ResourceList{corev1.ResourceCPU: createResourceQuantity(limits)}
+		kieObject.Resources.Limits = corev1.ResourceList{corev1.ResourceCPU: createResourceQuantity(limits["CPU"]), corev1.ResourceMemory: createResourceQuantity(limits["MEM"])}
 	}
 	if kieObject.Resources.Requests == nil {
-		kieObject.Resources.Requests = corev1.ResourceList{corev1.ResourceCPU: createResourceQuantity(requests)}
+		kieObject.Resources.Requests = corev1.ResourceList{corev1.ResourceCPU: createResourceQuantity(requests["CPU"]), corev1.ResourceMemory: createResourceQuantity(requests["MEM"])}
 	}
 	if kieObject.Resources.Limits.Cpu() == nil {
-		kieObject.Resources.Limits.Cpu().Add(createResourceQuantity(limits))
+		kieObject.Resources.Limits.Cpu().Add(createResourceQuantity(limits["CPU"]))
+	}
+	if kieObject.Resources.Limits.Memory() == nil {
+		kieObject.Resources.Limits.Memory().Add(createResourceQuantity(limits["MEM"]))
 	}
 	if kieObject.Resources.Requests.Cpu() == nil {
-		kieObject.Resources.Requests.Cpu().Add(createResourceQuantity(requests))
+		kieObject.Resources.Requests.Cpu().Add(createResourceQuantity(requests["CPU"]))
+	}
+	if kieObject.Resources.Requests.Memory() == nil {
+		kieObject.Resources.Requests.Memory().Add(createResourceQuantity(requests["MEM"]))
 	}
 }
 

--- a/pkg/controller/kieapp/test/crd_validation_test.go
+++ b/pkg/controller/kieapp/test/crd_validation_test.go
@@ -178,7 +178,7 @@ func TestJvmCrd(t *testing.T) {
 	testInteger(t, "gcMaxHeapFreeRatio", jvm)
 	testInteger(t, "gcTimeRatio", jvm)
 	testInteger(t, "gcAdaptiveSizePolicyWeight", jvm)
-	testInteger(t, "gcMaxMetaspaceSize", jvm)
+	testString(t, "gcMaxMetaspaceSize", jvm)
 	testString(t, "gcContainerOptions", jvm)
 }
 


### PR DESCRIPTION
Alongside the title JIRA this PR also solves the [BAPL-1766](https://issues.redhat.com/browse/BAPL-1766) as almost both were identical except for setting default value of `MaxMetaspaceSize`. Since that was a small thing I incorporated in this PR only
See: https://issues.redhat.com/browse/RHPAM-3245

Signed-off-by: Tarun Khandelwal <tarkhand@redhat.com>