### PR TITLE
[RHPAM-3296] console ownerRef fix for ocp 4.6.1+

### DIFF
--- a/pkg/controller/kieapp/deploy_ui.go
+++ b/pkg/controller/kieapp/deploy_ui.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 var consoleName = "console-cr-form"
@@ -54,11 +55,12 @@ func deployConsole(reconciler *Reconciler, operator *appsv1.Deployment) {
 	pod := getPod(namespace, image, sa.Name, reconciler.OcpVersion, operator)
 	service := getService(namespace, reconciler.OcpVersion)
 	route := getRoute(namespace)
+	scheme := reconciler.Service.GetScheme()
 	// `inject-trusted-cabundle` ConfigMap only supported in OCP 4.2+
 	if semver.Compare(reconciler.OcpVersion, "v4.2") >= 0 || reconciler.OcpVersion == "" {
 		existing := &corev1.ConfigMap{}
 		new := getCaConfigMap(namespace)
-		new.SetOwnerReferences(operator.GetOwnerReferences())
+		controllerutil.SetOwnerReference(operator, new, scheme)
 		if err := reconciler.Service.Get(context.TODO(), types.NamespacedName{Name: new.Name, Namespace: new.Namespace}, existing); err != nil {
 			if errors.IsNotFound(err) {
 				log.Info("Creating ConfigMap ", new.Name)
@@ -71,7 +73,7 @@ func deployConsole(reconciler *Reconciler, operator *appsv1.Deployment) {
 		} else {
 			if !reflect.DeepEqual(existing.Labels, new.Labels) {
 				existing.Labels = new.Labels
-				existing.SetOwnerReferences(operator.GetOwnerReferences())
+				controllerutil.SetOwnerReference(operator, existing, scheme)
 				log.Info("Updating ConfigMap ", existing.Name)
 				if err := reconciler.Service.Update(context.TODO(), existing); err != nil {
 					log.Error("failed to update configmap", err)
@@ -87,7 +89,7 @@ func deployConsole(reconciler *Reconciler, operator *appsv1.Deployment) {
 	}
 	comparator := compare.NewMapComparator()
 	deltas := comparator.Compare(deployed, requested)
-	writer := write.New(reconciler.Service).WithOwnerReferences(operator.GetOwnerReferences()...)
+	writer := write.New(reconciler.Service).WithOwnerController(operator, scheme)
 	var hasUpdates bool
 	for resourceType, delta := range deltas {
 		if !delta.HasChanges() {


### PR DESCRIPTION
resolves - https://issues.redhat.com/browse/RHPAM-3296

will resolve the infinite reconciliation of console UI objects seen in this operator on 4.6.1 clusters. this is due to a new label that OLM is setting on objects a CSV owns... which is causing the operator to get stuck in a reconcile loop for the console UI deployment.
https://github.com/operator-framework/operator-lifecycle-manager/pull/1607
https://github.com/njhale/operator-lifecycle-manager/blob/162cbc091bdf22153e7c4e2a1b6e57df27407c02/pkg/controller/operators/adoption_controller.go#L196+L217

Operator repeatedly reconciles console objects owned by CSV...
```shell
{"level":"info","ts":"2020-11-06T19:32:09.064455626Z","logger":"kieapp.controller","msg":"No Custom Resource found named businessautomation-operator.7.9.1-dev-66g4svx9hl. Checking for dependent objects to delete."}
{"level":"info","ts":1604691129.065619,"logger":"comparator","msg":"Objects are not equal","deployed":{"operators.coreos.com/businessautomation-operator.test":""},"requested":null}
{"level":"info","ts":1604691129.0657241,"logger":"comparator","msg":"Resources are not equal","deployed":{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"Role","namespace":"test","name":"console-cr-form"},"requested":{"namespace":"test","name":"console-cr-form"}}
{"level":"info","ts":1604691129.0657523,"logger":"comparator","msg":"Objects are not equal","deployed":{"operators.coreos.com/businessautomation-operator.test":""},"requested":null}
{"level":"info","ts":1604691129.0658062,"logger":"comparator","msg":"Resources are not equal","deployed":{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"RoleBinding","namespace":"test","name":"console-cr-form"},"requested":{"namespace":"test","name":"console-cr-form"}}
{"level":"info","ts":1604691129.06583,"logger":"comparator","msg":"Objects are not equal","deployed":{"operators.coreos.com/businessautomation-operator.test":""},"requested":null}
{"level":"info","ts":1604691129.0658462,"logger":"comparator","msg":"Resources are not equal","deployed":{"apiVersion":"v1","kind":"ServiceAccount","namespace":"test","name":"console-cr-form"},"requested":{"namespace":"test","name":"console-cr-form"}}
{"level":"info","ts":1604691129.0658891,"logger":"comparator","msg":"Objects are not equal","deployed":{"operators.coreos.com/businessautomation-operator.test":""},"requested":null}
```

CRC authorization server eventually stops responding -
```
{"error":"server_error","error_description":"The authorization server encountered an unexpected condition that prevented it from fulfilling the request.","state":"1680a864"}
```

Signed-off-by: tchughesiv <tchughesiv@gmail.com>