### PR TITLE
Remove default resource limits from template except for trial envs

### DIFF
--- a/config/7.9.1/common.yaml
+++ b/config/7.9.1/common.yaml
@@ -40,9 +40,6 @@ console:
               - name: "[[.ApplicationName]]-[[.Console.Name]]"
                 image: "[[.Console.ImageURL]]"
                 imagePullPolicy: Always
-                resources:
-                  limits:
-                    memory: 2Gi
                 livenessProbe:
                   httpGet:
                     path: /rest/healthy

--- a/config/7.9.1/common.yaml
+++ b/config/7.9.1/common.yaml
@@ -455,9 +455,6 @@ smartRouter:
               - name: "[[.ApplicationName]]-smartrouter"
                 image: "[[.SmartRouter.ImageURL]]"
                 imagePullPolicy: Always
-                resources:
-                  limits:
-                    memory: "512Mi"
                 ports:
                   - name: http
                     containerPort: 9000
@@ -823,9 +820,6 @@ servers:
                       value: "[[.Jvm.GcContainerOptions]]"
                     #[[end]]
                     ## Jvm config END
-                  resources:
-                    limits:
-                      memory: 1Gi
                   livenessProbe:
                     httpGet:
                       path: /services/rest/server/healthcheck

--- a/config/7.9.1/envs/rhdm-trial.yaml
+++ b/config/7.9.1/envs/rhdm-trial.yaml
@@ -71,6 +71,9 @@ servers:
                       value: "Access-Control-Max-Age"
                     - name: AC_MAX_AGE_FILTER_RESPONSE_HEADER_VALUE
                       value: "1"
+                  resources:
+                    limits:
+                      memory: 2Gi
     ## KIE server deployment config END
     ## KIE server route BEGIN
     routes:

--- a/config/7.9.1/envs/rhdm-trial.yaml
+++ b/config/7.9.1/envs/rhdm-trial.yaml
@@ -9,6 +9,9 @@ console:
               - name: "[[.ApplicationName]]-[[.Console.Name]]"
                 env:
                   - name: KIE_SERVER_HOST
+                resources:
+                  limits:
+                    memory: 2Gi
             volumes:
               - name: "[[.ApplicationName]]-[[.Console.Name]]-pvol"
                 emptyDir: {}
@@ -73,7 +76,7 @@ servers:
                       value: "1"
                   resources:
                     limits:
-                      memory: 2Gi
+                      memory: 1Gi
     ## KIE server deployment config END
     ## KIE server route BEGIN
     routes:

--- a/config/7.9.1/envs/rhpam-trial.yaml
+++ b/config/7.9.1/envs/rhpam-trial.yaml
@@ -9,6 +9,9 @@ console:
               - name: "[[.ApplicationName]]-[[.Console.Name]]"
                 env:
                   - name: KIE_SERVER_HOST
+                resources:
+                  limits:
+                    memory: 2Gi
             volumes:
               - name: "[[.ApplicationName]]-[[.Console.Name]]-pvol"
                 emptyDir: {}

--- a/config/7.9.1/envs/rhpam-trial.yaml
+++ b/config/7.9.1/envs/rhpam-trial.yaml
@@ -75,6 +75,9 @@ servers:
                       value: "Access-Control-Max-Age"
                     - name: AC_MAX_AGE_FILTER_RESPONSE_HEADER_VALUE
                       value: "1"
+                  resources:
+                    limits:
+                      memory: 1Gi
     ## KIE server deployment config END
     ## KIE server route BEGIN
     routes:


### PR DESCRIPTION
Following the #533 the default resource limits set in the templates should be removed except  for the trial envs. In this PR the resource limits are moved from the common config to only for the trial envs
Signed-off-by: Tarun Khandelwal <tarkhand@redhat.com>