### PR TITLE
[RHDM-1499] - Missing Kie Server BuildConfig env configuration in Ope…

### DIFF
--- a/deploy/ui/form.json
+++ b/deploy/ui/form.json
@@ -981,11 +981,33 @@
                           "description": "Secret value for WebHook to configure. Generated if empty"
                         }
                       ]
+                    },
+                    {
+                      "label": "Build Config Environment variable",
+                      "required": false,
+                      "jsonPath": "$.spec.objects.servers[*].build.env",
+                      "type": "object",
+                      "fields": [
+                        {
+                          "label": "Name",
+                          "type": "text",
+                          "required": true,
+                          "jsonPath": "$.spec.objects.servers[*].build.env[*].name",
+                          "description": "Environment variable name for build config"
+                        },
+                        {
+                          "label": "Value",
+                          "type": "text",
+                          "required": true,
+                          "jsonPath": "$.spec.objects.servers[*].build.env[*].value",
+                          "description": "Environment variable value for build config"
+                        }
+                      ]
                     }
                   ]
                 },
                 {
-                  "label": "Environment variable",
+                  "label": "Kie Server Environment variable",
                   "required": false,
                   "jsonPath": "$.spec.objects.servers[*].env",
                   "type": "object",


### PR DESCRIPTION
…rator UI

Just for testing purpose I was able to see the the env being set in the generated yaml from the `console-cr-form` 
```
objects:
    servers:
      - build:
          kieServerContainerDeployment: >-
            rhpam-kieserver-library=org.openshift.quickstarts:rhpam-kieserver-library:1.6.0-SNAPSHOT
          env:
            - name: JAVA_OPTS_APPEND
              value: '-Dmy.custom.property=prop-test'
```

See: https://issues.redhat.com/browse/RHDM-1499

Signed-off-by: Tarun Khandelwal <tarkhand@redhat.com>