### PR TITLE
Revert GcMaxMetaspaceSize CRD to accept the int

### DIFF
--- a/deploy/crds/kieapp.crd.yaml
+++ b/deploy/crds/kieapp.crd.yaml
@@ -535,9 +535,10 @@ spec:
                             format: int32
                             type: integer
                           gcMaxMetaspaceSize:
-                            description: The maximum metaspace size unit, unit could
-                              be g (Giga) m (Mega) or k (kilo)  e.g. '400m'
-                            type: string
+                            description: The maximum metaspace size in Mega bytes
+                              unit e.g. 400
+                            format: int32
+                            type: integer
                           gcMinHeapFreeRatio:
                             description: Minimum percentage of heap free after GC
                               to avoid expansion. e.g. '20'
@@ -1382,9 +1383,10 @@ spec:
                               format: int32
                               type: integer
                             gcMaxMetaspaceSize:
-                              description: The maximum metaspace size unit, unit could
-                                be g (Giga) m (Mega) or k (kilo)  e.g. '400m'
-                              type: string
+                              description: The maximum metaspace size in Mega bytes
+                                unit e.g. 400
+                              format: int32
+                              type: integer
                             gcMinHeapFreeRatio:
                               description: Minimum percentage of heap free after GC
                                 to avoid expansion. e.g. '20'
@@ -2231,9 +2233,10 @@ spec:
                                 format: int32
                                 type: integer
                               gcMaxMetaspaceSize:
-                                description: The maximum metaspace size unit, unit
-                                  could be g (Giga) m (Mega) or k (kilo)  e.g. '400m'
-                                type: string
+                                description: The maximum metaspace size in Mega bytes
+                                  unit e.g. 400
+                                format: int32
+                                type: integer
                               gcMinHeapFreeRatio:
                                 description: Minimum percentage of heap free after
                                   GC to avoid expansion. e.g. '20'
@@ -3107,9 +3110,10 @@ spec:
                                   format: int32
                                   type: integer
                                 gcMaxMetaspaceSize:
-                                  description: The maximum metaspace size unit, unit
-                                    could be g (Giga) m (Mega) or k (kilo)  e.g. '400m'
-                                  type: string
+                                  description: The maximum metaspace size in Mega
+                                    bytes unit e.g. 400
+                                  format: int32
+                                  type: integer
                                 gcMinHeapFreeRatio:
                                   description: Minimum percentage of heap free after
                                     GC to avoid expansion. e.g. '20'

--- a/deploy/ui/form.json
+++ b/deploy/ui/form.json
@@ -709,7 +709,7 @@
                     },
                     {
                       "label": "GC max metaspace size",
-                      "type": "text",
+                      "type": "integer",
                       "required": false,
                       "description": "The maximum metaspace size, unit could be g (Giga) m (Mega) or k (kilo)  e.g. '400m'",
                       "jsonPath": "$.spec.objects.console.jvm.gcMaxMetaspaceSize",
@@ -1363,7 +1363,7 @@
                         },
                         {
                           "label": "GC max metaspace size",
-                          "type": "text",
+                          "type": "integer",
                           "required": false,
                           "description": "The maximum metaspace size, unit could be g (Giga) m (Mega) or k (Kilo)  e.g. '400m'.",
                           "jsonPath": "$.spec.objects.servers[*].jvm.gcMaxMetaspaceSize",

--- a/deploy/ui/form.json
+++ b/deploy/ui/form.json
@@ -711,7 +711,7 @@
                       "label": "GC max metaspace size",
                       "type": "integer",
                       "required": false,
-                      "description": "The maximum metaspace size, unit could be g (Giga) m (Mega) or k (kilo)  e.g. '400m'",
+                      "description": "The maximum metaspace size in Mega bytes unit e.g. 400",
                       "jsonPath": "$.spec.objects.console.jvm.gcMaxMetaspaceSize",
                       "originalJsonPath": "$.spec.objects.console.jvm.gcMaxMetaspaceSize"
                     },
@@ -1365,7 +1365,7 @@
                           "label": "GC max metaspace size",
                           "type": "integer",
                           "required": false,
-                          "description": "The maximum metaspace size, unit could be g (Giga) m (Mega) or k (Kilo)  e.g. '400m'.",
+                          "description": "The maximum metaspace size in Mega bytes unit e.g. 400",
                           "jsonPath": "$.spec.objects.servers[*].jvm.gcMaxMetaspaceSize",
                           "originalJsonPath": "$.spec.objects.servers[*].jvm.gcMaxMetaspaceSize"
                         },

--- a/pkg/apis/app/v2/kieapp_types.go
+++ b/pkg/apis/app/v2/kieapp_types.go
@@ -218,8 +218,8 @@ type JvmObject struct {
 	GcTimeRatio *int32 `json:"gcTimeRatio,omitempty"`
 	// The weighting given to the current GC time versus previous GC times  when determining the new heap size. e.g. '90'
 	GcAdaptiveSizePolicyWeight *int32 `json:"gcAdaptiveSizePolicyWeight,omitempty"`
-	// The maximum metaspace size unit, unit could be g (Giga) m (Mega) or k (kilo)  e.g. '400m'
-	GcMaxMetaspaceSize string `json:"gcMaxMetaspaceSize,omitempty"`
+	// The maximum metaspace size in Mega bytes unit e.g. 400
+	GcMaxMetaspaceSize *int32 `json:"gcMaxMetaspaceSize,omitempty"`
 	// Specify Java GC to use. The value of this variable should contain the necessary JRE command-line options to specify the required GC, which will override the default of '-XX:+UseParallelOldGC'. e.g. '-XX:+UseG1GC'
 	GcContainerOptions string `json:"gcContainerOptions,omitempty"`
 }

--- a/pkg/apis/app/v2/zz_generated.deepcopy.go
+++ b/pkg/apis/app/v2/zz_generated.deepcopy.go
@@ -587,6 +587,11 @@ func (in *JvmObject) DeepCopyInto(out *JvmObject) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.GcMaxMetaspaceSize != nil {
+		in, out := &in.GcMaxMetaspaceSize, &out.GcMaxMetaspaceSize
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/kieapp/defaults/defaults.go
+++ b/pkg/controller/kieapp/defaults/defaults.go
@@ -1107,8 +1107,8 @@ func setJvmDefault(jvm *api.JvmObject) {
 		if jvm.JavaInitialMemRatio == nil {
 			jvm.JavaInitialMemRatio = Pint32(25)
 		}
-		if len(jvm.GcMaxMetaspaceSize) == 0 {
-			jvm.GcMaxMetaspaceSize = "512m"
+		if jvm.GcMaxMetaspaceSize == nil {
+			jvm.GcMaxMetaspaceSize = Pint32(512)
 		}
 	}
 }

--- a/pkg/controller/kieapp/defaults/defaults_test.go
+++ b/pkg/controller/kieapp/defaults/defaults_test.go
@@ -799,7 +799,7 @@ func createJvmTestObject() *api.JvmObject {
 		GcMaxHeapFreeRatio:         Pint32(40),
 		GcTimeRatio:                Pint32(4),
 		GcAdaptiveSizePolicyWeight: Pint32(90),
-		GcMaxMetaspaceSize:         "100m",
+		GcMaxMetaspaceSize:         Pint32(100),
 		GcContainerOptions:         "-XX:+UseG1GC",
 	}
 	return &jvmObject
@@ -842,7 +842,7 @@ func testJvmEnv(t *testing.T, envs []corev1.EnvVar) {
 			assert.Equal(t, "90", env.Value)
 
 		case "GC_MAX_METASPACE_SIZE":
-			assert.Equal(t, "100m", env.Value)
+			assert.Equal(t, "100", env.Value)
 
 		case "GC_CONTAINER_OPTIONS":
 			assert.Equal(t, "-XX:+UseG1GC", env.Value)
@@ -4664,7 +4664,7 @@ func createJvmTestObjectWithoutJavaMaxMemRatio() *api.JvmObject {
 		GcMaxHeapFreeRatio:         Pint32(40),
 		GcTimeRatio:                Pint32(4),
 		GcAdaptiveSizePolicyWeight: Pint32(90),
-		GcMaxMetaspaceSize:         "100m",
+		GcMaxMetaspaceSize:         Pint32(100),
 		GcContainerOptions:         "-XX:+UseG1GC",
 	}
 	return &jvmObject

--- a/pkg/controller/kieapp/test/crd_validation_test.go
+++ b/pkg/controller/kieapp/test/crd_validation_test.go
@@ -178,7 +178,7 @@ func TestJvmCrd(t *testing.T) {
 	testInteger(t, "gcMaxHeapFreeRatio", jvm)
 	testInteger(t, "gcTimeRatio", jvm)
 	testInteger(t, "gcAdaptiveSizePolicyWeight", jvm)
-	testString(t, "gcMaxMetaspaceSize", jvm)
+	testInteger(t, "gcMaxMetaspaceSize", jvm)
 	testString(t, "gcContainerOptions", jvm)
 }
 


### PR DESCRIPTION
Reverting as the cct_modules append a `m` in the env
For more info See: https://github.com/jboss-openshift/cct_module/blob/0.39.0/jboss/container/java/jvm/bash/artifacts/opt/jboss/container/java/jvm/java-default-options#L157
Signed-off-by: Tarun Khandelwal <tarkhand@redhat.com>