### PR TITLE
[KIECLOUD-438] - DeploymentConfig probes for BusinessCentral too shor…

### DIFF
--- a/config/7.9.1/common.yaml
+++ b/config/7.9.1/common.yaml
@@ -45,15 +45,25 @@ console:
                     path: /rest/healthy
                     port: 8080
                     scheme: HTTP
+                  initialDelaySeconds: 90
+                  timeoutSeconds: 2
+                  periodSeconds: 15
+                  failureThreshold: 10
+                startupProbe:
+                  httpGet:
+                    path: /rest/healthy
+                    port: 8080
+                    scheme: HTTP
                   initialDelaySeconds: 180
                   timeoutSeconds: 2
                   periodSeconds: 15
+                  failureThreshold: 36
                 readinessProbe:
                   httpGet:
                     path: /rest/ready
                     port: 8080
                     scheme: HTTP
-                  initialDelaySeconds: 30
+                  initialDelaySeconds: 60
                   timeoutSeconds: 2
                   periodSeconds: 5
                   failureThreshold: 36


### PR DESCRIPTION
…t causing POD Termination

See: https://issues.redhat.com/browse/KIECLOUD-438

Signed-off-by: Tarun Khandelwal <tarkhand@redhat.com>