### PR TITLE
[RHPAM-3326] - Defaul value for MaxMetaspaceSize in Operator overried…

### DIFF
--- a/pkg/controller/kieapp/defaults/defaults.go
+++ b/pkg/controller/kieapp/defaults/defaults.go
@@ -1122,9 +1122,6 @@ func setJvmDefault(jvm *api.JvmObject) {
 		if jvm.JavaInitialMemRatio == nil {
 			jvm.JavaInitialMemRatio = Pint32(25)
 		}
-		if jvm.GcMaxMetaspaceSize == nil {
-			jvm.GcMaxMetaspaceSize = Pint32(512)
-		}
 	}
 }
 


### PR DESCRIPTION
…s default values set by image scripts
Default values added in the respective images and remove from the operator
See: https://issues.redhat.com/browse/RHPAM-3326

Signed-off-by: Tarun Khandelwal <tarkhand@redhat.com>