### PR TITLE
fix reconcile errors due to RHPAM-3181 PR

### DIFF
--- a/config/7.11.0/common.yaml
+++ b/config/7.11.0/common.yaml
@@ -123,6 +123,7 @@ console:
                   - name: KUBERNETES_NAMESPACE
                     valueFrom:
                       fieldRef:
+                        apiVersion: v1
                         fieldPath: metadata.namespace
                   - name: KUBERNETES_LABELS
                     value: "cluster=jgrp.k8s.[[.ApplicationName]].[[.Console.Name]]"
@@ -673,6 +674,7 @@ servers:
                     - name: KUBERNETES_NAMESPACE
                       valueFrom:
                         fieldRef:
+                          apiVersion: v1
                           fieldPath: metadata.namespace
                     - name: KUBERNETES_LABELS
                       value: "cluster=jgrp.k8s.[[.KieName]]"


### PR DESCRIPTION
https://github.com/kiegroup/kie-cloud-operator/pull/567 changes were causing an infinite reconcile loop in the operator due to missing field in new env vars.

Signed-off-by: Tommy Hughes <tohughes@redhat.com>