### PR TITLE
change csv file name to bypass cekit issue

### DIFF
--- a/deploy/olm-catalog/dev/7.11.0-1/manifests/businessautomation-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/dev/7.11.0-1/manifests/businessautomation-operator.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Integration & Delivery
     certified: "false"
     containerImage: quay.io/kiegroup/kie-cloud-operator:7.11.0
-    createdAt: "2021-03-08 18:26:05"
+    createdAt: "2021-03-23 08:38:44"
     description: Deploys and manages Red Hat Process Automation Manager and Red Hat Decision Manager environments.
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     repository: https://github.com/kiegroup/kie-cloud-operator
@@ -17,7 +17,7 @@ metadata:
     operator-businessautomation: "true"
     operatorframework.io/arch.amd64: supported
     operatorframework.io/os.linux: supported
-  name: businessautomation-operator.7.11.0-1-dev-kkdtwpph6r
+  name: businessautomation-operator.7.11.0-1-dev-kzxkmx7l28
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -413,7 +413,7 @@ spec:
   - operator
   labels:
     alm-owner-businessautomation: businessautomation-operator
-    operated-by: businessautomation-operator.7.11.0-1-dev-kkdtwpph6r
+    operated-by: businessautomation-operator.7.11.0-1-dev-kzxkmx7l28
   links:
   - name: Product Page
     url: https://access.redhat.com/products/red-hat-process-automation-manager
@@ -429,5 +429,5 @@ spec:
   selector:
     matchLabels:
       alm-owner-businessautomation: businessautomation-operator
-      operated-by: businessautomation-operator.7.11.0-1-dev-kkdtwpph6r
-  version: 7.11.0-1+kkdtwpph6r
+      operated-by: businessautomation-operator.7.11.0-1-dev-kzxkmx7l28
+  version: 7.11.0-1+kzxkmx7l28

--- a/deploy/olm-catalog/prod/7.11.0-1/manifests/businessautomation-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/prod/7.11.0-1/manifests/businessautomation-operator.clusterserviceversion.yaml
@@ -6,8 +6,8 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Integration & Delivery
     certified: "true"
-    containerImage: registry-proxy.engineering.redhat.com/rh-osbs/rhpam-7-rhpam-rhel8-operator:7.11.0
-    createdAt: "2021-03-08 18:26:05"
+    containerImage: registry.stage.redhat.io/rhpam-7/rhpam-rhel8-operator:7.11.0
+    createdAt: "2021-03-23 08:38:45"
     description: Deploys and manages Red Hat Process Automation Manager and Red Hat Decision Manager environments.
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     repository: https://github.com/kiegroup/kie-cloud-operator
@@ -17,7 +17,7 @@ metadata:
     operator-businessautomation: "true"
     operatorframework.io/arch.amd64: supported
     operatorframework.io/os.linux: supported
-  name: businessautomation-operator.7.11.0-1-dev-vp6bcxndsb
+  name: businessautomation-operator.7.11.0-1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -169,25 +169,25 @@ spec:
                 - name: DEBUG
                   value: "false"
                 - name: RELATED_IMAGE_DM_KIESERVER_IMAGE_7.11.0
-                  value: registry-proxy.engineering.redhat.com/rhdm-7/rhdm-kieserver-rhel8:7.11.0
+                  value: registry.stage.redhat.io/rhdm-7/rhdm-kieserver-rhel8:7.11.0
                 - name: RELATED_IMAGE_DM_CONTROLLER_IMAGE_7.11.0
-                  value: registry-proxy.engineering.redhat.com/rhdm-7/rhdm-controller-rhel8:7.11.0
+                  value: registry.stage.redhat.io/rhdm-7/rhdm-controller-rhel8:7.11.0
                 - name: RELATED_IMAGE_DM_DC_IMAGE_7.11.0
-                  value: registry-proxy.engineering.redhat.com/rhdm-7/rhdm-decisioncentral-rhel8:7.11.0
+                  value: registry.stage.redhat.io/rhdm-7/rhdm-decisioncentral-rhel8:7.11.0
                 - name: RELATED_IMAGE_PAM_KIESERVER_IMAGE_7.11.0
-                  value: registry-proxy.engineering.redhat.com/rhpam-7/rhpam-kieserver-rhel8:7.11.0
+                  value: registry.stage.redhat.io/rhpam-7/rhpam-kieserver-rhel8:7.11.0
                 - name: RELATED_IMAGE_PAM_CONTROLLER_IMAGE_7.11.0
-                  value: registry-proxy.engineering.redhat.com/rhpam-7/rhpam-controller-rhel8:7.11.0
+                  value: registry.stage.redhat.io/rhpam-7/rhpam-controller-rhel8:7.11.0
                 - name: RELATED_IMAGE_PAM_BC_IMAGE_7.11.0
-                  value: registry-proxy.engineering.redhat.com/rhpam-7/rhpam-businesscentral-rhel8:7.11.0
+                  value: registry.stage.redhat.io/rhpam-7/rhpam-businesscentral-rhel8:7.11.0
                 - name: RELATED_IMAGE_PAM_BC_MONITORING_IMAGE_7.11.0
-                  value: registry-proxy.engineering.redhat.com/rhpam-7/rhpam-businesscentral-monitoring-rhel8:7.11.0
+                  value: registry.stage.redhat.io/rhpam-7/rhpam-businesscentral-monitoring-rhel8:7.11.0
                 - name: RELATED_IMAGE_PAM_SMARTROUTER_IMAGE_7.11.0
-                  value: registry-proxy.engineering.redhat.com/rhpam-7/rhpam-smartrouter-rhel8:7.11.0
+                  value: registry.stage.redhat.io/rhpam-7/rhpam-smartrouter-rhel8:7.11.0
                 - name: RELATED_IMAGE_PAM_PROCESS_MIGRATION_IMAGE_7.11.0
-                  value: registry-proxy.engineering.redhat.com/rhpam-7/rhpam-process-migration-rhel8:7.11.0
+                  value: registry.stage.redhat.io/rhpam-7/rhpam-process-migration-rhel8:7.11.0
                 - name: RELATED_IMAGE_PAM_DASHBUILDER_IMAGE_7.11.0
-                  value: registry-proxy.engineering.redhat.com/rhpam-7/rhpam-dashbuilder-rhel8:7.11.0
+                  value: registry.stage.redhat.io/rhpam-7/rhpam-dashbuilder-rhel8:7.11.0
                 - name: RELATED_IMAGE_OSE_CLI_IMAGE_7.11.0
                   value: registry.redhat.io/openshift3/ose-cli:v3.11
                 - name: RELATED_IMAGE_MYSQL_PROXY_IMAGE_7.11.0
@@ -246,7 +246,7 @@ spec:
                   value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.1
                 - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_3
                   value: registry.redhat.io/openshift3/oauth-proxy:latest
-                image: registry-proxy.engineering.redhat.com/rh-osbs/rhpam-7-rhpam-rhel8-operator:7.11.0
+                image: registry.stage.redhat.io/rhpam-7/rhpam-rhel8-operator:7.11.0
                 imagePullPolicy: Always
                 name: business-automation-operator
                 resources: {}
@@ -413,7 +413,7 @@ spec:
   - operator
   labels:
     alm-owner-businessautomation: businessautomation-operator
-    operated-by: businessautomation-operator.7.11.0-1-dev-vp6bcxndsb
+    operated-by: businessautomation-operator.7.11.0-1
   links:
   - name: Product Page
     url: https://access.redhat.com/products/red-hat-process-automation-manager
@@ -422,12 +422,12 @@ spec:
   maintainers:
   - email: bsig-cloud@redhat.com
     name: Red Hat
-  maturity: test
+  maturity: stable
   provider:
     name: Red Hat
   replaces: businessautomation-operator.7.10.1-1
   selector:
     matchLabels:
       alm-owner-businessautomation: businessautomation-operator
-      operated-by: businessautomation-operator.7.11.0-1-dev-vp6bcxndsb
-  version: 7.11.0-1+vp6bcxndsb
+      operated-by: businessautomation-operator.7.11.0-1
+  version: 7.11.0-1

--- a/deploy/olm-catalog/test/7.11.0-1/manifests/businessautomation-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/test/7.11.0-1/manifests/businessautomation-operator.clusterserviceversion.yaml
@@ -6,8 +6,8 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Integration & Delivery
     certified: "true"
-    containerImage: registry.stage.redhat.io/rhpam-7/rhpam-rhel8-operator:7.11.0
-    createdAt: "2021-03-08 18:26:05"
+    containerImage: registry-proxy.engineering.redhat.com/rh-osbs/rhpam-7-rhpam-rhel8-operator:7.11.0
+    createdAt: "2021-03-23 08:38:44"
     description: Deploys and manages Red Hat Process Automation Manager and Red Hat Decision Manager environments.
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     repository: https://github.com/kiegroup/kie-cloud-operator
@@ -17,7 +17,7 @@ metadata:
     operator-businessautomation: "true"
     operatorframework.io/arch.amd64: supported
     operatorframework.io/os.linux: supported
-  name: businessautomation-operator.7.11.0-1
+  name: businessautomation-operator.7.11.0-1-dev-krdrjj5f5h
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -169,25 +169,25 @@ spec:
                 - name: DEBUG
                   value: "false"
                 - name: RELATED_IMAGE_DM_KIESERVER_IMAGE_7.11.0
-                  value: registry.stage.redhat.io/rhdm-7/rhdm-kieserver-rhel8:7.11.0
+                  value: registry-proxy.engineering.redhat.com/rhdm-7/rhdm-kieserver-rhel8:7.11.0
                 - name: RELATED_IMAGE_DM_CONTROLLER_IMAGE_7.11.0
-                  value: registry.stage.redhat.io/rhdm-7/rhdm-controller-rhel8:7.11.0
+                  value: registry-proxy.engineering.redhat.com/rhdm-7/rhdm-controller-rhel8:7.11.0
                 - name: RELATED_IMAGE_DM_DC_IMAGE_7.11.0
-                  value: registry.stage.redhat.io/rhdm-7/rhdm-decisioncentral-rhel8:7.11.0
+                  value: registry-proxy.engineering.redhat.com/rhdm-7/rhdm-decisioncentral-rhel8:7.11.0
                 - name: RELATED_IMAGE_PAM_KIESERVER_IMAGE_7.11.0
-                  value: registry.stage.redhat.io/rhpam-7/rhpam-kieserver-rhel8:7.11.0
+                  value: registry-proxy.engineering.redhat.com/rhpam-7/rhpam-kieserver-rhel8:7.11.0
                 - name: RELATED_IMAGE_PAM_CONTROLLER_IMAGE_7.11.0
-                  value: registry.stage.redhat.io/rhpam-7/rhpam-controller-rhel8:7.11.0
+                  value: registry-proxy.engineering.redhat.com/rhpam-7/rhpam-controller-rhel8:7.11.0
                 - name: RELATED_IMAGE_PAM_BC_IMAGE_7.11.0
-                  value: registry.stage.redhat.io/rhpam-7/rhpam-businesscentral-rhel8:7.11.0
+                  value: registry-proxy.engineering.redhat.com/rhpam-7/rhpam-businesscentral-rhel8:7.11.0
                 - name: RELATED_IMAGE_PAM_BC_MONITORING_IMAGE_7.11.0
-                  value: registry.stage.redhat.io/rhpam-7/rhpam-businesscentral-monitoring-rhel8:7.11.0
+                  value: registry-proxy.engineering.redhat.com/rhpam-7/rhpam-businesscentral-monitoring-rhel8:7.11.0
                 - name: RELATED_IMAGE_PAM_SMARTROUTER_IMAGE_7.11.0
-                  value: registry.stage.redhat.io/rhpam-7/rhpam-smartrouter-rhel8:7.11.0
+                  value: registry-proxy.engineering.redhat.com/rhpam-7/rhpam-smartrouter-rhel8:7.11.0
                 - name: RELATED_IMAGE_PAM_PROCESS_MIGRATION_IMAGE_7.11.0
-                  value: registry.stage.redhat.io/rhpam-7/rhpam-process-migration-rhel8:7.11.0
+                  value: registry-proxy.engineering.redhat.com/rhpam-7/rhpam-process-migration-rhel8:7.11.0
                 - name: RELATED_IMAGE_PAM_DASHBUILDER_IMAGE_7.11.0
-                  value: registry.stage.redhat.io/rhpam-7/rhpam-dashbuilder-rhel8:7.11.0
+                  value: registry-proxy.engineering.redhat.com/rhpam-7/rhpam-dashbuilder-rhel8:7.11.0
                 - name: RELATED_IMAGE_OSE_CLI_IMAGE_7.11.0
                   value: registry.redhat.io/openshift3/ose-cli:v3.11
                 - name: RELATED_IMAGE_MYSQL_PROXY_IMAGE_7.11.0
@@ -246,7 +246,7 @@ spec:
                   value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.1
                 - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_3
                   value: registry.redhat.io/openshift3/oauth-proxy:latest
-                image: registry.stage.redhat.io/rhpam-7/rhpam-rhel8-operator:7.11.0
+                image: registry-proxy.engineering.redhat.com/rh-osbs/rhpam-7-rhpam-rhel8-operator:7.11.0
                 imagePullPolicy: Always
                 name: business-automation-operator
                 resources: {}
@@ -413,7 +413,7 @@ spec:
   - operator
   labels:
     alm-owner-businessautomation: businessautomation-operator
-    operated-by: businessautomation-operator.7.11.0-1
+    operated-by: businessautomation-operator.7.11.0-1-dev-krdrjj5f5h
   links:
   - name: Product Page
     url: https://access.redhat.com/products/red-hat-process-automation-manager
@@ -422,12 +422,12 @@ spec:
   maintainers:
   - email: bsig-cloud@redhat.com
     name: Red Hat
-  maturity: stable
+  maturity: test
   provider:
     name: Red Hat
   replaces: businessautomation-operator.7.10.1-1
   selector:
     matchLabels:
       alm-owner-businessautomation: businessautomation-operator
-      operated-by: businessautomation-operator.7.11.0-1
-  version: 7.11.0-1
+      operated-by: businessautomation-operator.7.11.0-1-dev-krdrjj5f5h
+  version: 7.11.0-1+krdrjj5f5h

--- a/hack/go-build-bundle.sh
+++ b/hack/go-build-bundle.sh
@@ -22,7 +22,7 @@ fi
 echo ${CFLAGS}
 
 OLMDIR=deploy/olm-catalog/prod
-CSV=businessautomation-operator.${CSVVERSION}.clusterserviceversion.yaml
+CSV=businessautomation-operator.clusterserviceversion.yaml
 if [[ ${DEV} == true ]]; then
     OLMDIR=deploy/olm-catalog/dev
     BUNDLE_NAME=quay.io/tchughesiv/${BUNDLE}
@@ -75,8 +75,8 @@ if [[ ${LOCAL} != true ]]; then
     }' \
         --overrides '{
     artifacts: [
-        {name: '${CRD}', path: '${CRD_PATH}', md5: '${MD5_CRD}', dest: '/manifests'},
-        {name: '${ANNO}', path: '${ANNO_PATH}', md5: '${MD5_ANNO}', dest: '/metadata'}
+        {name: '${CRD}', path: '${CRD_PATH}', md5: '${MD5_CRD}', dest: '/manifests/'},
+        {name: '${ANNO}', path: '${ANNO_PATH}', md5: '${MD5_ANNO}', dest: '/metadata/'}
     ]}' \
         ${CFLAGS}
 else
@@ -85,9 +85,9 @@ else
         --overrides '{version: '${VERSION}'}' \
         --overrides '{
     artifacts: [
-        {name: '${CSV}', path: '${CSV_PATH}', md5: '${MD5_CSV}', dest: '/manifests'},
-        {name: '${CRD}', path: '${CRD_PATH}', md5: '${MD5_CRD}', dest: '/manifests'},
-        {name: '${ANNO}', path: '${ANNO_PATH}', md5: '${MD5_ANNO}', dest: '/metadata'}
+        {name: '${CSV}', path: '${CSV_PATH}', md5: '${MD5_CSV}', dest: '/manifests/'},
+        {name: '${CRD}', path: '${CRD_PATH}', md5: '${MD5_CRD}', dest: '/manifests/'},
+        {name: '${ANNO}', path: '${ANNO_PATH}', md5: '${MD5_ANNO}', dest: '/metadata/'}
     ]}' \
         ${CFLAGS}
 fi

--- a/pkg/controller/kieapp/deploy_ui_test.go
+++ b/pkg/controller/kieapp/deploy_ui_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestUpdateLink(t *testing.T) {
 	box := packr.New("CSV", "../../../deploy/olm-catalog/prod/"+version.CsvVersion+"/manifests")
-	bytes, err := box.Find("businessautomation-operator." + version.CsvVersion + ".clusterserviceversion.yaml")
+	bytes, err := box.Find("businessautomation-operator.clusterserviceversion.yaml")
 	assert.Nil(t, err, "Error reading CSV file")
 	csv := &operators.ClusterServiceVersion{}
 	err = yaml.Unmarshal(bytes, csv)
@@ -38,7 +38,7 @@ func TestUpdateLink(t *testing.T) {
 
 func TestUpdateExistingLink(t *testing.T) {
 	box := packr.New("CSV", "../../../deploy/olm-catalog/prod/"+version.CsvVersion+"/manifests")
-	bytes, err := box.Find("businessautomation-operator." + version.CsvVersion + ".clusterserviceversion.yaml")
+	bytes, err := box.Find("businessautomation-operator.clusterserviceversion.yaml")
 	assert.Nil(t, err, "Error reading CSV file")
 	csv := &operators.ClusterServiceVersion{}
 	err = yaml.Unmarshal(bytes, csv)

--- a/tools/csv-gen/csv-gen.go
+++ b/tools/csv-gen/csv-gen.go
@@ -315,7 +315,7 @@ func main() {
 		if csv.Maturity == "test" {
 			bundleDir = "deploy/olm-catalog/test/" + *ver + "/"
 		}
-		csvFile := bundleDir + "manifests/" + operatorName + "." + *ver + ".clusterserviceversion.yaml"
+		csvFile := bundleDir + "manifests/" + operatorName + ".clusterserviceversion.yaml"
 
 		var templateInterface interface{}
 		templateInterface = templateStruct


### PR DESCRIPTION
until https://github.com/cekit/cekit/issues/700 is resolved, we'll name the csv files the same w/ each release. this will ensure only one cluster service version exists in each bundle built by osbs.

Signed-off-by: Tommy Hughes <tohughes@redhat.com>