### PR TITLE
[RHPAM-3504] remove several ocp3 specific lines and configs

### DIFF
--- a/config/7.10.1/envs/rhdm-authoring-ha.yaml
+++ b/config/7.10.1/envs/rhdm-authoring-ha.yaml
@@ -336,6 +336,6 @@ others:
             application: "[[.ApplicationName]]"
           annotations:
             description: Provides a service for accessing the application over Hot Rod protocol.
-            service.alpha.openshift.io/serving-cert-secret-name: datagrid-service-certs
+            service.beta.openshift.io/serving-cert-secret-name: datagrid-service-certs
   ## ES/AMQ END
 

--- a/config/7.10.1/envs/rhpam-authoring-ha.yaml
+++ b/config/7.10.1/envs/rhpam-authoring-ha.yaml
@@ -337,6 +337,6 @@ others:
             application: "[[.ApplicationName]]"
           annotations:
             description: Provides a service for accessing the application over Hot Rod protocol.
-            service.alpha.openshift.io/serving-cert-secret-name: datagrid-service-certs
+            service.beta.openshift.io/serving-cert-secret-name: datagrid-service-certs
 ## ES/AMQ END
 

--- a/deploy/olm-catalog/dev/7.10.1-1/manifests/businessautomation-operator.7.10.1-1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/dev/7.10.1-1/manifests/businessautomation-operator.7.10.1-1.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Integration & Delivery
     certified: "false"
     containerImage: quay.io/kiegroup/kie-cloud-operator:7.10.1
-    createdAt: "2021-03-08 16:16:40"
+    createdAt: "2021-03-23 11:07:23"
     description: Deploys and manages Red Hat Process Automation Manager and Red Hat Decision Manager environments.
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     repository: https://github.com/kiegroup/kie-cloud-operator
@@ -17,7 +17,7 @@ metadata:
     operator-businessautomation: "true"
     operatorframework.io/arch.amd64: supported
     operatorframework.io/os.linux: supported
-  name: businessautomation-operator.7.10.1-1-dev-96psq2wrq6
+  name: businessautomation-operator.7.10.1-1-dev-zbhl4hwpzp
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -272,8 +272,6 @@ spec:
                   value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.2
                 - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_4.1
                   value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.1
-                - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_3
-                  value: registry.redhat.io/openshift3/oauth-proxy:latest
                 image: quay.io/kiegroup/kie-cloud-operator:7.10.1
                 imagePullPolicy: Always
                 name: business-automation-operator
@@ -441,7 +439,7 @@ spec:
   - operator
   labels:
     alm-owner-businessautomation: businessautomation-operator
-    operated-by: businessautomation-operator.7.10.1-1-dev-96psq2wrq6
+    operated-by: businessautomation-operator.7.10.1-1-dev-zbhl4hwpzp
   links:
   - name: Product Page
     url: https://access.redhat.com/products/red-hat-process-automation-manager
@@ -457,5 +455,5 @@ spec:
   selector:
     matchLabels:
       alm-owner-businessautomation: businessautomation-operator
-      operated-by: businessautomation-operator.7.10.1-1-dev-96psq2wrq6
-  version: 7.10.1-1+96psq2wrq6
+      operated-by: businessautomation-operator.7.10.1-1-dev-zbhl4hwpzp
+  version: 7.10.1-1+zbhl4hwpzp

--- a/deploy/olm-catalog/prod/7.10.1-1/manifests/businessautomation-operator.7.10.1-1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/prod/7.10.1-1/manifests/businessautomation-operator.7.10.1-1.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Integration & Delivery
     certified: "true"
     containerImage: registry.stage.redhat.io/rhpam-7/rhpam-rhel8-operator:7.10.1
-    createdAt: "2021-03-08 16:16:40"
+    createdAt: "2021-03-23 11:07:23"
     description: Deploys and manages Red Hat Process Automation Manager and Red Hat Decision Manager environments.
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     repository: https://github.com/kiegroup/kie-cloud-operator
@@ -272,8 +272,6 @@ spec:
                   value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.2
                 - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_4.1
                   value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.1
-                - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_3
-                  value: registry.redhat.io/openshift3/oauth-proxy:latest
                 image: registry.stage.redhat.io/rhpam-7/rhpam-rhel8-operator:7.10.1
                 imagePullPolicy: Always
                 name: business-automation-operator

--- a/deploy/olm-catalog/test/7.10.1-1/manifests/businessautomation-operator.7.10.1-1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/test/7.10.1-1/manifests/businessautomation-operator.7.10.1-1.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Integration & Delivery
     certified: "true"
     containerImage: registry-proxy.engineering.redhat.com/rh-osbs/rhpam-7-rhpam-rhel8-operator:7.10.1
-    createdAt: "2021-03-08 16:16:40"
+    createdAt: "2021-03-23 11:07:23"
     description: Deploys and manages Red Hat Process Automation Manager and Red Hat Decision Manager environments.
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     repository: https://github.com/kiegroup/kie-cloud-operator
@@ -17,7 +17,7 @@ metadata:
     operator-businessautomation: "true"
     operatorframework.io/arch.amd64: supported
     operatorframework.io/os.linux: supported
-  name: businessautomation-operator.7.10.1-1-dev-mlq4w5dgks
+  name: businessautomation-operator.7.10.1-1-dev-bvv6r6d9fk
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -272,8 +272,6 @@ spec:
                   value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.2
                 - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_4.1
                   value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.1
-                - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_3
-                  value: registry.redhat.io/openshift3/oauth-proxy:latest
                 image: registry-proxy.engineering.redhat.com/rh-osbs/rhpam-7-rhpam-rhel8-operator:7.10.1
                 imagePullPolicy: Always
                 name: business-automation-operator
@@ -441,7 +439,7 @@ spec:
   - operator
   labels:
     alm-owner-businessautomation: businessautomation-operator
-    operated-by: businessautomation-operator.7.10.1-1-dev-mlq4w5dgks
+    operated-by: businessautomation-operator.7.10.1-1-dev-bvv6r6d9fk
   links:
   - name: Product Page
     url: https://access.redhat.com/products/red-hat-process-automation-manager
@@ -457,5 +455,5 @@ spec:
   selector:
     matchLabels:
       alm-owner-businessautomation: businessautomation-operator
-      operated-by: businessautomation-operator.7.10.1-1-dev-mlq4w5dgks
-  version: 7.10.1-1+mlq4w5dgks
+      operated-by: businessautomation-operator.7.10.1-1-dev-bvv6r6d9fk
+  version: 7.10.1-1+bvv6r6d9fk

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -141,8 +141,6 @@ spec:
           value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.2
         - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_4.1
           value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.1
-        - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_3
-          value: registry.redhat.io/openshift3/oauth-proxy:latest
         image: quay.io/kiegroup/kie-cloud-operator:7.10.1
         imagePullPolicy: Always
         name: business-automation-operator

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -169,10 +169,6 @@ func GetDeployment(operatorName, repository, context, imageName, tag, imagePullP
 			Value: constants.Oauth4ImageURL + ":v" + ocpVersion,
 		})
 	}
-	deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
-		Name:  constants.OauthVar + "3",
-		Value: constants.Oauth3ImageLatestURL,
-	})
 
 	return deployment
 }

--- a/pkg/controller/kieapp/constants/constants.go
+++ b/pkg/controller/kieapp/constants/constants.go
@@ -134,7 +134,6 @@ const (
 	PamSmartRouterVar      = relatedImageVar + "PAM_SMARTROUTER_IMAGE_"
 
 	OauthVar             = relatedImageVar + "OAUTH_PROXY_IMAGE_"
-	Oauth3ImageLatestURL = ImageRegistry + "/openshift3/oauth-proxy:latest"
 	Oauth4ImageURL       = ImageRegistry + "/openshift4/ose-oauth-proxy"
 	Oauth4ImageLatestURL = Oauth4ImageURL + ":latest"
 	OauthComponent       = "golang-github-openshift-oauth-proxy-container"

--- a/pkg/controller/kieapp/deploy_ui.go
+++ b/pkg/controller/kieapp/deploy_ui.go
@@ -210,12 +210,6 @@ func getPod(namespace, image, sa, ocpVersion string, operator *appsv1.Deployment
 	} else if val, exists := os.LookupEnv(constants.OauthVar + "LATEST"); exists {
 		oauthImage = val
 	}
-	if ocpMajor == "3" {
-		oauthImage = constants.Oauth3ImageLatestURL
-		if val, exists := os.LookupEnv(constants.OauthVar + "3"); exists {
-			oauthImage = val
-		}
-	}
 	sarString := fmt.Sprintf("--openshift-sar=%s", sar)
 	httpPort := int32(8080)
 	httpsPort := int32(8443)
@@ -328,9 +322,6 @@ func getService(namespace, ocpVersion string) *corev1.Service {
 			},
 			Selector: labels,
 		},
-	}
-	if semver.Major(ocpVersion) == "v3" {
-		svc.Annotations = map[string]string{"service.alpha.openshift.io/serving-cert-secret-name": operatorName + "-proxy-tls"}
 	}
 	return svc
 }


### PR DESCRIPTION
mostly around  signed serving certificates for services. i expect that code during console UI deployment may have been causing leftover token secrets to pile up for certain OSD customers.

this change moves from `service.alpha.openshift.io/serving-cert-secret-name` to `service.beta.openshift.io/serving-cert-secret-name` and removes the code potentially causing duplicate serving secrets.

Signed-off-by: Tommy Hughes <tohughes@redhat.com>