### PR TITLE
[RHPAM-3504] remove several ocp3 specific lines and configs

### DIFF
--- a/deploy/olm-catalog/dev/7.11.0-1/manifests/businessautomation-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/dev/7.11.0-1/manifests/businessautomation-operator.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Integration & Delivery
     certified: "false"
     containerImage: quay.io/kiegroup/kie-cloud-operator:7.11.0
-    createdAt: "2021-03-23 08:38:44"
+    createdAt: "2021-03-24 09:00:45"
     description: Deploys and manages Red Hat Process Automation Manager and Red Hat Decision Manager environments.
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     repository: https://github.com/kiegroup/kie-cloud-operator
@@ -17,7 +17,7 @@ metadata:
     operator-businessautomation: "true"
     operatorframework.io/arch.amd64: supported
     operatorframework.io/os.linux: supported
-  name: businessautomation-operator.7.11.0-1-dev-kzxkmx7l28
+  name: businessautomation-operator.7.11.0-1-dev-fh4w2xn5lv
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -189,7 +189,7 @@ spec:
                 - name: RELATED_IMAGE_PAM_DASHBUILDER_IMAGE_7.11.0
                   value: registry.redhat.io/rhpam-7/rhpam-dashbuilder-rhel8:7.11.0
                 - name: RELATED_IMAGE_OSE_CLI_IMAGE_7.11.0
-                  value: registry.redhat.io/openshift3/ose-cli:v3.11
+                  value: registry.redhat.io/openshift4/ose-cli:v4.7
                 - name: RELATED_IMAGE_MYSQL_PROXY_IMAGE_7.11.0
                   value: registry.redhat.io/rhscl/mysql-80-rhel7:latest
                 - name: RELATED_IMAGE_POSTGRESQL_PROXY_IMAGE_7.11.0
@@ -219,7 +219,7 @@ spec:
                 - name: RELATED_IMAGE_PAM_DASHBUILDER_IMAGE_7.10.1
                   value: registry.redhat.io/rhpam-7/rhpam-dashbuilder-rhel8:7.10.1
                 - name: RELATED_IMAGE_OSE_CLI_IMAGE_7.10.1
-                  value: registry.redhat.io/openshift3/ose-cli:v3.11
+                  value: registry.redhat.io/openshift4/ose-cli:v4.7
                 - name: RELATED_IMAGE_MYSQL_PROXY_IMAGE_7.10.1
                   value: registry.redhat.io/rhscl/mysql-80-rhel7:latest
                 - name: RELATED_IMAGE_POSTGRESQL_PROXY_IMAGE_7.10.1
@@ -244,8 +244,6 @@ spec:
                   value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.2
                 - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_4.1
                   value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.1
-                - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_3
-                  value: registry.redhat.io/openshift3/oauth-proxy:latest
                 image: quay.io/kiegroup/kie-cloud-operator:7.11.0
                 imagePullPolicy: Always
                 name: business-automation-operator
@@ -413,7 +411,7 @@ spec:
   - operator
   labels:
     alm-owner-businessautomation: businessautomation-operator
-    operated-by: businessautomation-operator.7.11.0-1-dev-kzxkmx7l28
+    operated-by: businessautomation-operator.7.11.0-1-dev-fh4w2xn5lv
   links:
   - name: Product Page
     url: https://access.redhat.com/products/red-hat-process-automation-manager
@@ -429,5 +427,5 @@ spec:
   selector:
     matchLabels:
       alm-owner-businessautomation: businessautomation-operator
-      operated-by: businessautomation-operator.7.11.0-1-dev-kzxkmx7l28
-  version: 7.11.0-1+kzxkmx7l28
+      operated-by: businessautomation-operator.7.11.0-1-dev-fh4w2xn5lv
+  version: 7.11.0-1+fh4w2xn5lv

--- a/deploy/olm-catalog/dev/7.11.0-1/manifests/kieapp.crd.yaml
+++ b/deploy/olm-catalog/dev/7.11.0-1/manifests/kieapp.crd.yaml
@@ -1683,6 +1683,11 @@ spec:
                           description: The image tag to use e.g. 7.9.0, this param
                             is optional for custom image.
                           type: string
+                        jbpmCluster:
+                          description: JbpmCluster Enable the KIE Server Jbpm clustering
+                            for processes fail-over, it could increase the number
+                            of kieservers
+                          type: boolean
                         jms:
                           description: KieAppJmsObject messaging specification to
                             be used by the KieApp
@@ -3820,6 +3825,11 @@ spec:
                               description: The image tag to use e.g. 7.9.0, this param
                                 is optional for custom image.
                               type: string
+                            jbpmCluster:
+                              description: JbpmCluster Enable the KIE Server Jbpm
+                                clustering for processes fail-over, it could increase
+                                the number of kieservers
+                              type: boolean
                             jms:
                               description: KieAppJmsObject messaging specification
                                 to be used by the KieApp

--- a/deploy/olm-catalog/prod/7.11.0-1/manifests/businessautomation-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/prod/7.11.0-1/manifests/businessautomation-operator.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Integration & Delivery
     certified: "true"
     containerImage: registry.stage.redhat.io/rhpam-7/rhpam-rhel8-operator:7.11.0
-    createdAt: "2021-03-23 08:38:45"
+    createdAt: "2021-03-24 09:00:46"
     description: Deploys and manages Red Hat Process Automation Manager and Red Hat Decision Manager environments.
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     repository: https://github.com/kiegroup/kie-cloud-operator
@@ -189,7 +189,7 @@ spec:
                 - name: RELATED_IMAGE_PAM_DASHBUILDER_IMAGE_7.11.0
                   value: registry.stage.redhat.io/rhpam-7/rhpam-dashbuilder-rhel8:7.11.0
                 - name: RELATED_IMAGE_OSE_CLI_IMAGE_7.11.0
-                  value: registry.redhat.io/openshift3/ose-cli:v3.11
+                  value: registry.redhat.io/openshift4/ose-cli:v4.7
                 - name: RELATED_IMAGE_MYSQL_PROXY_IMAGE_7.11.0
                   value: registry.redhat.io/rhscl/mysql-80-rhel7:latest
                 - name: RELATED_IMAGE_POSTGRESQL_PROXY_IMAGE_7.11.0
@@ -219,7 +219,7 @@ spec:
                 - name: RELATED_IMAGE_PAM_DASHBUILDER_IMAGE_7.10.1
                   value: registry.redhat.io/rhpam-7/rhpam-dashbuilder-rhel8:7.10.1
                 - name: RELATED_IMAGE_OSE_CLI_IMAGE_7.10.1
-                  value: registry.redhat.io/openshift3/ose-cli:v3.11
+                  value: registry.redhat.io/openshift4/ose-cli:v4.7
                 - name: RELATED_IMAGE_MYSQL_PROXY_IMAGE_7.10.1
                   value: registry.redhat.io/rhscl/mysql-80-rhel7:latest
                 - name: RELATED_IMAGE_POSTGRESQL_PROXY_IMAGE_7.10.1
@@ -244,8 +244,6 @@ spec:
                   value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.2
                 - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_4.1
                   value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.1
-                - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_3
-                  value: registry.redhat.io/openshift3/oauth-proxy:latest
                 image: registry.stage.redhat.io/rhpam-7/rhpam-rhel8-operator:7.11.0
                 imagePullPolicy: Always
                 name: business-automation-operator

--- a/deploy/olm-catalog/prod/7.11.0-1/manifests/kieapp.crd.yaml
+++ b/deploy/olm-catalog/prod/7.11.0-1/manifests/kieapp.crd.yaml
@@ -1683,6 +1683,11 @@ spec:
                           description: The image tag to use e.g. 7.9.0, this param
                             is optional for custom image.
                           type: string
+                        jbpmCluster:
+                          description: JbpmCluster Enable the KIE Server Jbpm clustering
+                            for processes fail-over, it could increase the number
+                            of kieservers
+                          type: boolean
                         jms:
                           description: KieAppJmsObject messaging specification to
                             be used by the KieApp
@@ -3820,6 +3825,11 @@ spec:
                               description: The image tag to use e.g. 7.9.0, this param
                                 is optional for custom image.
                               type: string
+                            jbpmCluster:
+                              description: JbpmCluster Enable the KIE Server Jbpm
+                                clustering for processes fail-over, it could increase
+                                the number of kieservers
+                              type: boolean
                             jms:
                               description: KieAppJmsObject messaging specification
                                 to be used by the KieApp

--- a/deploy/olm-catalog/test/7.11.0-1/manifests/businessautomation-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/test/7.11.0-1/manifests/businessautomation-operator.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Integration & Delivery
     certified: "true"
     containerImage: registry-proxy.engineering.redhat.com/rh-osbs/rhpam-7-rhpam-rhel8-operator:7.11.0
-    createdAt: "2021-03-23 08:38:44"
+    createdAt: "2021-03-24 09:00:46"
     description: Deploys and manages Red Hat Process Automation Manager and Red Hat Decision Manager environments.
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
     repository: https://github.com/kiegroup/kie-cloud-operator
@@ -17,7 +17,7 @@ metadata:
     operator-businessautomation: "true"
     operatorframework.io/arch.amd64: supported
     operatorframework.io/os.linux: supported
-  name: businessautomation-operator.7.11.0-1-dev-krdrjj5f5h
+  name: businessautomation-operator.7.11.0-1-dev-6ngfvn5jss
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -189,7 +189,7 @@ spec:
                 - name: RELATED_IMAGE_PAM_DASHBUILDER_IMAGE_7.11.0
                   value: registry-proxy.engineering.redhat.com/rhpam-7/rhpam-dashbuilder-rhel8:7.11.0
                 - name: RELATED_IMAGE_OSE_CLI_IMAGE_7.11.0
-                  value: registry.redhat.io/openshift3/ose-cli:v3.11
+                  value: registry.redhat.io/openshift4/ose-cli:v4.7
                 - name: RELATED_IMAGE_MYSQL_PROXY_IMAGE_7.11.0
                   value: registry.redhat.io/rhscl/mysql-80-rhel7:latest
                 - name: RELATED_IMAGE_POSTGRESQL_PROXY_IMAGE_7.11.0
@@ -219,7 +219,7 @@ spec:
                 - name: RELATED_IMAGE_PAM_DASHBUILDER_IMAGE_7.10.1
                   value: registry.redhat.io/rhpam-7/rhpam-dashbuilder-rhel8:7.10.1
                 - name: RELATED_IMAGE_OSE_CLI_IMAGE_7.10.1
-                  value: registry.redhat.io/openshift3/ose-cli:v3.11
+                  value: registry.redhat.io/openshift4/ose-cli:v4.7
                 - name: RELATED_IMAGE_MYSQL_PROXY_IMAGE_7.10.1
                   value: registry.redhat.io/rhscl/mysql-80-rhel7:latest
                 - name: RELATED_IMAGE_POSTGRESQL_PROXY_IMAGE_7.10.1
@@ -244,8 +244,6 @@ spec:
                   value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.2
                 - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_4.1
                   value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.1
-                - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_3
-                  value: registry.redhat.io/openshift3/oauth-proxy:latest
                 image: registry-proxy.engineering.redhat.com/rh-osbs/rhpam-7-rhpam-rhel8-operator:7.11.0
                 imagePullPolicy: Always
                 name: business-automation-operator
@@ -413,7 +411,7 @@ spec:
   - operator
   labels:
     alm-owner-businessautomation: businessautomation-operator
-    operated-by: businessautomation-operator.7.11.0-1-dev-krdrjj5f5h
+    operated-by: businessautomation-operator.7.11.0-1-dev-6ngfvn5jss
   links:
   - name: Product Page
     url: https://access.redhat.com/products/red-hat-process-automation-manager
@@ -429,5 +427,5 @@ spec:
   selector:
     matchLabels:
       alm-owner-businessautomation: businessautomation-operator
-      operated-by: businessautomation-operator.7.11.0-1-dev-krdrjj5f5h
-  version: 7.11.0-1+krdrjj5f5h
+      operated-by: businessautomation-operator.7.11.0-1-dev-6ngfvn5jss
+  version: 7.11.0-1+6ngfvn5jss

--- a/deploy/olm-catalog/test/7.11.0-1/manifests/kieapp.crd.yaml
+++ b/deploy/olm-catalog/test/7.11.0-1/manifests/kieapp.crd.yaml
@@ -1683,6 +1683,11 @@ spec:
                           description: The image tag to use e.g. 7.9.0, this param
                             is optional for custom image.
                           type: string
+                        jbpmCluster:
+                          description: JbpmCluster Enable the KIE Server Jbpm clustering
+                            for processes fail-over, it could increase the number
+                            of kieservers
+                          type: boolean
                         jms:
                           description: KieAppJmsObject messaging specification to
                             be used by the KieApp
@@ -3820,6 +3825,11 @@ spec:
                               description: The image tag to use e.g. 7.9.0, this param
                                 is optional for custom image.
                               type: string
+                            jbpmCluster:
+                              description: JbpmCluster Enable the KIE Server Jbpm
+                                clustering for processes fail-over, it could increase
+                                the number of kieservers
+                              type: boolean
                             jms:
                               description: KieAppJmsObject messaging specification
                                 to be used by the KieApp

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -58,7 +58,7 @@ spec:
         - name: RELATED_IMAGE_PAM_DASHBUILDER_IMAGE_7.11.0
           value: registry.redhat.io/rhpam-7/rhpam-dashbuilder-rhel8:7.11.0
         - name: RELATED_IMAGE_OSE_CLI_IMAGE_7.11.0
-          value: registry.redhat.io/openshift3/ose-cli:v3.11
+          value: registry.redhat.io/openshift4/ose-cli:v4.7
         - name: RELATED_IMAGE_MYSQL_PROXY_IMAGE_7.11.0
           value: registry.redhat.io/rhscl/mysql-80-rhel7:latest
         - name: RELATED_IMAGE_POSTGRESQL_PROXY_IMAGE_7.11.0
@@ -88,7 +88,7 @@ spec:
         - name: RELATED_IMAGE_PAM_DASHBUILDER_IMAGE_7.10.1
           value: registry.redhat.io/rhpam-7/rhpam-dashbuilder-rhel8:7.10.1
         - name: RELATED_IMAGE_OSE_CLI_IMAGE_7.10.1
-          value: registry.redhat.io/openshift3/ose-cli:v3.11
+          value: registry.redhat.io/openshift4/ose-cli:v4.7
         - name: RELATED_IMAGE_MYSQL_PROXY_IMAGE_7.10.1
           value: registry.redhat.io/rhscl/mysql-80-rhel7:latest
         - name: RELATED_IMAGE_POSTGRESQL_PROXY_IMAGE_7.10.1
@@ -113,8 +113,6 @@ spec:
           value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.2
         - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_4.1
           value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.1
-        - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_3
-          value: registry.redhat.io/openshift3/oauth-proxy:latest
         image: quay.io/kiegroup/kie-cloud-operator:7.11.0
         imagePullPolicy: Always
         name: business-automation-operator

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -169,10 +169,6 @@ func GetDeployment(operatorName, repository, context, imageName, tag, imagePullP
 			Value: constants.Oauth4ImageURL + ":v" + ocpVersion,
 		})
 	}
-	deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{
-		Name:  constants.OauthVar + "3",
-		Value: constants.Oauth3ImageLatestURL,
-	})
 
 	return deployment
 }

--- a/pkg/controller/kieapp/constants/constants.go
+++ b/pkg/controller/kieapp/constants/constants.go
@@ -2,6 +2,7 @@ package constants
 
 import (
 	api "github.com/kiegroup/kie-cloud-operator/pkg/apis/app/v2"
+	"golang.org/x/mod/semver"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -23,8 +24,8 @@ var SupportedVersions = []string{CurrentVersion, PriorVersion}
 var VersionConstants = map[string]*api.VersionConfigs{
 	CurrentVersion: {
 		APIVersion:          api.SchemeGroupVersion.Version,
-		OseCliImageURL:      OseCli311ImageURL,
-		OseCliComponent:     OseCli311Component,
+		OseCliImageURL:      OseCli4ImageURL,
+		OseCliComponent:     OseCli4Component,
 		BrokerImage:         BrokerImage,
 		BrokerImageTag:      Broker78ImageTag,
 		BrokerImageURL:      Broker78ImageURL,
@@ -39,8 +40,8 @@ var VersionConstants = map[string]*api.VersionConfigs{
 	},
 	PriorVersion: {
 		APIVersion:          api.SchemeGroupVersion.Version,
-		OseCliImageURL:      OseCli311ImageURL,
-		OseCliComponent:     OseCli311Component,
+		OseCliImageURL:      OseCli4ImageURL,
+		OseCliComponent:     OseCli4Component,
 		BrokerImage:         BrokerImage,
 		BrokerImageTag:      Broker78ImageTag,
 		BrokerImageURL:      Broker78ImageURL,
@@ -168,7 +169,6 @@ const (
 	PamSmartRouterVar      = relatedImageVar + "PAM_SMARTROUTER_IMAGE_"
 
 	OauthVar             = relatedImageVar + "OAUTH_PROXY_IMAGE_"
-	Oauth3ImageLatestURL = ImageRegistry + "/openshift3/oauth-proxy:latest"
 	Oauth4ImageURL       = ImageRegistry + "/openshift4/ose-oauth-proxy"
 	Oauth4ImageLatestURL = Oauth4ImageURL + ":latest"
 	OauthComponent       = "golang-github-openshift-oauth-proxy-container"
@@ -183,9 +183,8 @@ const (
 	MySQL80ImageURL  = ImageRegistry + "/rhscl/mysql-80-rhel7:latest"
 	MySQL80Component = "rh-mysql80-container"
 
-	OseCliVar          = relatedImageVar + "OSE_CLI_IMAGE_"
-	OseCli311ImageURL  = ImageRegistry + "/openshift3/ose-cli:v3.11"
-	OseCli311Component = "openshift-enterprise-cli-container"
+	OseCliVar        = relatedImageVar + "OSE_CLI_IMAGE_"
+	OseCli4Component = "openshift-enterprise-cli-container"
 
 	BrokerComponent = "amq-broker-openshift-container"
 	BrokerVar       = relatedImageVar + "BROKER_IMAGE_"
@@ -261,6 +260,8 @@ const (
 	KubeNS     = "KUBERNETES_NAMESPACE"
 	KubeLabels = "KUBERNETES_LABELS"
 )
+
+var OseCli4ImageURL = ImageRegistry + "/openshift4/ose-cli:" + highestOcpVersion(Ocp4Versions)
 
 // Console Resource Limits for BC Monitoring in Prod Env
 var ConsoleProdLimits = map[string]string{
@@ -473,4 +474,15 @@ var DebugTrue = corev1.EnvVar{
 var DebugFalse = corev1.EnvVar{
 	Name:  "DEBUG",
 	Value: "false",
+}
+
+func highestOcpVersion(versions []string) string {
+	highest := ""
+	for _, ver := range versions {
+		ver = "v" + ver
+		if semver.IsValid(ver) && semver.Compare(ver, highest) > 0 {
+			highest = ver
+		}
+	}
+	return highest
 }

--- a/pkg/controller/kieapp/deploy_ui.go
+++ b/pkg/controller/kieapp/deploy_ui.go
@@ -210,12 +210,6 @@ func getPod(namespace, image, sa, ocpVersion string, operator *appsv1.Deployment
 	} else if val, exists := os.LookupEnv(constants.OauthVar + "LATEST"); exists {
 		oauthImage = val
 	}
-	if ocpMajor == "3" {
-		oauthImage = constants.Oauth3ImageLatestURL
-		if val, exists := os.LookupEnv(constants.OauthVar + "3"); exists {
-			oauthImage = val
-		}
-	}
 	sarString := fmt.Sprintf("--openshift-sar=%s", sar)
 	httpPort := int32(8080)
 	httpsPort := int32(8443)
@@ -328,9 +322,6 @@ func getService(namespace, ocpVersion string) *corev1.Service {
 			},
 			Selector: labels,
 		},
-	}
-	if semver.Major(ocpVersion) == "v3" {
-		svc.Annotations = map[string]string{"service.alpha.openshift.io/serving-cert-secret-name": operatorName + "-proxy-tls"}
 	}
 	return svc
 }


### PR DESCRIPTION
changes:
 - this change moves from `service.alpha.openshift.io/serving-cert-secret-name` to `service.beta.openshift.io/serving-cert-secret-name`
 - switch to openshift4 `ose-cli` image
 - remove old openshift3 `oath-proxy` image

Signed-off-by: Tommy Hughes <tohughes@redhat.com>