### PR TITLE
[RHPAM-4075] - Kie repository persistence is disabled in rhpam-trial

### DIFF
--- a/deploy/ui/form.json
+++ b/deploy/ui/form.json
@@ -1498,7 +1498,7 @@
                   "required": false,
                   "jsonPath": "$.spec.objects.servers[*].persistRepos",
                   "originalJsonPath": "$.spec.objects.servers[*].persistRepos",
-                  "description": "Persist the Maven and KIE repositories on ~/.m2/repository and ~/.kie/repository respectively.",
+                  "description": "Persist the Maven and KIE repositories on ~/.m2/repository and ~/.kie/repository respectively. persistRepos option can't be set to true when the trial environment is chosen",
                   "fields": [
                     {
                       "label": "Enable Persistent Storage for kie and maven repositories",

--- a/deploy/ui/form.json
+++ b/deploy/ui/form.json
@@ -1498,7 +1498,7 @@
                   "required": false,
                   "jsonPath": "$.spec.objects.servers[*].persistRepos",
                   "originalJsonPath": "$.spec.objects.servers[*].persistRepos",
-                  "description": "Persist the Maven and KIE repositories on ~/.m2/repository and ~/.kie/repository respectively. persistRepos option can't be set to true when the trial environment is chosen",
+                  "description": "Persist the Maven and KIE repositories on ~/.m2/repository and ~/.kie/repository respectively. The option persistRepos will be automatically set to false when the Trial environment is set.",
                   "fields": [
                     {
                       "label": "Enable Persistent Storage for kie and maven repositories",

--- a/pkg/controller/kieapp/defaults/defaults.go
+++ b/pkg/controller/kieapp/defaults/defaults.go
@@ -808,6 +808,7 @@ func getServersConfig(cr *api.KieApp) ([]api.ServerTemplate, error) {
 			// Apply PV default size
 			if isTrial(cr) {
 				template.PersistRepos = false
+				serverSet.PersistRepos = false
 			} else {
 				if len(template.ServersM2PvSize) <= 0 {
 					template.ServersM2PvSize = constants.ServersM2PvSize

--- a/pkg/controller/kieapp/defaults/defaults_test.go
+++ b/pkg/controller/kieapp/defaults/defaults_test.go
@@ -764,7 +764,6 @@ func TestRhpamTrialWithReposPersistedWithStorageClass(t *testing.T) {
 
 	// there shouldn't be any pvc on trial env
 	assert.Len(t, env.Servers[0].PersistentVolumeClaims, 0)
-	assert.Equal(t, "false", getEnvVariable(env.Servers[0].DeploymentConfigs[0].Spec.Template.Spec.Containers[0], "KIE_SERVER_PERSIST_REPOS"))
 	assert.Equal(t, false, cr.Status.Applied.Objects.Servers[0].PersistRepos)
 }
 

--- a/pkg/controller/kieapp/defaults/defaults_test.go
+++ b/pkg/controller/kieapp/defaults/defaults_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/gobuffalo/packr/v2"
 	api "github.com/kiegroup/kie-cloud-operator/pkg/apis/app/v2"
 	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/constants"
-	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/test"f
+	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/test"
 	appsv1 "github.com/openshift/api/apps/v1"
 	buildv1 "github.com/openshift/api/build/v1"
 	"github.com/stretchr/testify/assert"

--- a/pkg/controller/kieapp/defaults/defaults_test.go
+++ b/pkg/controller/kieapp/defaults/defaults_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/gobuffalo/packr/v2"
 	api "github.com/kiegroup/kie-cloud-operator/pkg/apis/app/v2"
 	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/constants"
-	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/test"
+	"github.com/kiegroup/kie-cloud-operator/pkg/controller/kieapp/test"f
 	appsv1 "github.com/openshift/api/apps/v1"
 	buildv1 "github.com/openshift/api/build/v1"
 	"github.com/stretchr/testify/assert"
@@ -746,6 +746,37 @@ func TestRhpamTrialWithReposPersistedWithStorageClass(t *testing.T) {
 				Servers: []api.KieServerSet{
 					{
 						PersistRepos:     true,
+						ServersM2PvSize:  "2Gi",
+						ServersKiePvSize: "150Mi",
+					},
+				},
+			},
+		},
+	}
+
+	env, err := GetEnvironment(&cr, test.MockService())
+	assert.Nil(t, err, "Error getting prod environment")
+	m2RepoVM, kieRepoVM, m2Vol, kieVol := kieServerPersistentStorageCommonConfig(&cr)
+	assert.NotContains(t, env.Servers[0].DeploymentConfigs[0].Spec.Template.Spec.Containers[0].VolumeMounts, m2RepoVM)
+	assert.NotContains(t, env.Servers[0].DeploymentConfigs[0].Spec.Template.Spec.Containers[0].VolumeMounts, kieRepoVM)
+	assert.NotContains(t, env.Servers[0].DeploymentConfigs[0].Spec.Template.Spec.Volumes, m2Vol)
+	assert.NotContains(t, env.Servers[0].DeploymentConfigs[0].Spec.Template.Spec.Volumes, kieVol)
+
+	// there shouldn't be any pvc on trial env
+	assert.Len(t, env.Servers[0].PersistentVolumeClaims, 0)
+}
+
+func TestRhpamTrialWithoutSpecifyingReposPersistedWithStorageClass(t *testing.T) {
+
+	cr := api.KieApp{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: api.KieAppSpec{
+			Environment: api.RhpamTrial,
+			Objects: api.KieAppObjects{
+				Servers: []api.KieServerSet{
+					{
 						ServersM2PvSize:  "2Gi",
 						ServersKiePvSize: "150Mi",
 					},

--- a/pkg/controller/kieapp/defaults/defaults_test.go
+++ b/pkg/controller/kieapp/defaults/defaults_test.go
@@ -764,37 +764,8 @@ func TestRhpamTrialWithReposPersistedWithStorageClass(t *testing.T) {
 
 	// there shouldn't be any pvc on trial env
 	assert.Len(t, env.Servers[0].PersistentVolumeClaims, 0)
-}
-
-func TestRhpamTrialWithoutSpecifyingReposPersistedWithStorageClass(t *testing.T) {
-
-	cr := api.KieApp{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test",
-		},
-		Spec: api.KieAppSpec{
-			Environment: api.RhpamTrial,
-			Objects: api.KieAppObjects{
-				Servers: []api.KieServerSet{
-					{
-						ServersM2PvSize:  "2Gi",
-						ServersKiePvSize: "150Mi",
-					},
-				},
-			},
-		},
-	}
-
-	env, err := GetEnvironment(&cr, test.MockService())
-	assert.Nil(t, err, "Error getting prod environment")
-	m2RepoVM, kieRepoVM, m2Vol, kieVol := kieServerPersistentStorageCommonConfig(&cr)
-	assert.NotContains(t, env.Servers[0].DeploymentConfigs[0].Spec.Template.Spec.Containers[0].VolumeMounts, m2RepoVM)
-	assert.NotContains(t, env.Servers[0].DeploymentConfigs[0].Spec.Template.Spec.Containers[0].VolumeMounts, kieRepoVM)
-	assert.NotContains(t, env.Servers[0].DeploymentConfigs[0].Spec.Template.Spec.Volumes, m2Vol)
-	assert.NotContains(t, env.Servers[0].DeploymentConfigs[0].Spec.Template.Spec.Volumes, kieVol)
-
-	// there shouldn't be any pvc on trial env
-	assert.Len(t, env.Servers[0].PersistentVolumeClaims, 0)
+	assert.Equal(t, "false", getEnvVariable(env.Servers[0].DeploymentConfigs[0].Spec.Template.Spec.Containers[0], "KIE_SERVER_PERSIST_REPOS"), "Variable should exist and be false")
+	assert.Equal(t, false, cr.Status.Applied.Objects.Servers[0].PersistRepos)
 }
 
 func runCommonAssertsForKieServerPersistentStorageVolumeMounts(t *testing.T, cr api.KieApp, env api.Environment) {

--- a/pkg/controller/kieapp/defaults/defaults_test.go
+++ b/pkg/controller/kieapp/defaults/defaults_test.go
@@ -764,7 +764,7 @@ func TestRhpamTrialWithReposPersistedWithStorageClass(t *testing.T) {
 
 	// there shouldn't be any pvc on trial env
 	assert.Len(t, env.Servers[0].PersistentVolumeClaims, 0)
-	assert.Equal(t, "false", getEnvVariable(env.Servers[0].DeploymentConfigs[0].Spec.Template.Spec.Containers[0], "KIE_SERVER_PERSIST_REPOS"), "Variable should exist and be false")
+	assert.Equal(t, "false", getEnvVariable(env.Servers[0].DeploymentConfigs[0].Spec.Template.Spec.Containers[0], "KIE_SERVER_PERSIST_REPOS"))
 	assert.Equal(t, false, cr.Status.Applied.Objects.Servers[0].PersistRepos)
 }
 


### PR DESCRIPTION
[RHPAM-4075] - Kie repository persistence is disabled in rhpam-trial and the UI form re-instates the same.
https://issues.redhat.com/browse/RHPAM-4075

Signed-off-by: Achyut Madhusudan <amadhusu@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [X] Pull Request title is properly formatted: [KIECLOUD-XYZ] Subject, [RHDM-XYZ] Subject or [RHPAM-XYZ] Subject
- [X]  Pull Request contains link to the JIRA issue
- [X]  Pull Request contains description of the issue
- [X]  Pull Request does not include fixes for issues other than the main ticket
- [X]  Attached commits represent units of work and are properly formatted
- [X]  You have read and agreed to the Developer Certificate of Origin (DCO) (see CONTRIBUTING.md)
- [X]  Every commit contains Signed-off-by: Your Name <yourname@example.com> - use git commit -s