### PR TITLE
[RHPAM-4075] - Kie repository persistence is disabled in rhpam-trial

### DIFF
--- a/deploy/ui/form.json
+++ b/deploy/ui/form.json
@@ -1497,7 +1497,7 @@
                   "required": false,
                   "jsonPath": "$.spec.objects.servers[*].persistRepos",
                   "originalJsonPath": "$.spec.objects.servers[*].persistRepos",
-                  "description": "Persist the Maven and KIE repositories on ~/.m2/repository and ~/.kie/repository respectively.",
+                  "description": "Persist the Maven and KIE repositories on ~/.m2/repository and ~/.kie/repository respectively. persistRepos option can't be set to true when the trial environment is chosen",
                   "fields": [
                     {
                       "label": "Enable Persistent Storage for kie and maven repositories",

--- a/pkg/controller/kieapp/defaults/defaults.go
+++ b/pkg/controller/kieapp/defaults/defaults.go
@@ -807,6 +807,7 @@ func getServersConfig(cr *api.KieApp) ([]api.ServerTemplate, error) {
 			// Apply PV default size
 			if isTrial(cr) {
 				template.PersistRepos = false
+				serverSet.PersistRepos = false
 			} else {
 				if len(template.ServersM2PvSize) <= 0 {
 					template.ServersM2PvSize = constants.ServersM2PvSize


### PR DESCRIPTION
[RHPAM-4075] - Kie repository persistence is disabled in rhpam-trial and the UI form re-instates the same.
https://issues.redhat.com/browse/RHPAM-4075

Signed-off-by: Achyut Madhusudan <amadhusu@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [X] Pull Request title is properly formatted: [KIECLOUD-XYZ] Subject, [RHDM-XYZ] Subject or [RHPAM-XYZ] Subject
- [X]  Pull Request contains link to the JIRA issue
- [X]  Pull Request contains description of the issue
- [X]  Pull Request does not include fixes for issues other than the main ticket
- [X]  Attached commits represent units of work and are properly formatted
- [X]  You have read and agreed to the Developer Certificate of Origin (DCO) (see CONTRIBUTING.md)
- [X]  Every commit contains Signed-off-by: Your Name [yourname@example.com](mailto:yourname@example.com) - use git commit -s