### PR TITLE
[RHPAM-4239] KieExecutorMDB property in Operator UI use wrong name

### DIFF
--- a/deploy/ui/form.json
+++ b/deploy/ui/form.json
@@ -1745,7 +1745,7 @@
                       "label": "Max Number of Session",
                       "type": "integer",
                       "required": false,
-                      "jsonPath": "$.spec.objects.servers[*].MDBMaxSession",
+                      "jsonPath": "$.spec.objects.servers[*].kieExecutorMDBMaxSession",
                       "originalJsonPath": "$.spec.objects.servers[*].kieExecutorMDBMaxSession",
                       "description": "Number of max session used by the JMS Executor, it must be lower than the value of max-pool-size passed as jboss.mdb.strict.max.pool.size, if leaved empty the max.pool.size will be set to 60."
                     }


### PR DESCRIPTION
See:https://issues.redhat.com/browse/RHPAM-4239
Signed-off-by: desmax74 <mdessi@redhat.com>