### PR TITLE
[RHPAM-4224] - Installer generates wrong Min/Max connection pool size

### DIFF
--- a/deploy/ui/form.json
+++ b/deploy/ui/form.json
@@ -2176,7 +2176,7 @@
                             {
                               "label": "Maximum connection pool size",
                               "type": "text",
-                              "jsonPath": "$.spec.objects.servers[*].database.externalConfig.minPoolSize",
+                              "jsonPath": "$.spec.objects.servers[*].database.externalConfig.maxPoolSize",
                               "description": "Sets xa-pool/max-pool-size for the configured datasource."
                             },
                             {


### PR DESCRIPTION
[RHPAM-4224] - Installer generates wrong Min/Max connection pool size in external DB configuration of CR.
https://issues.redhat.com/browse/RHPAM-4224

Signed-off-by: Achyut Madhusudan <amadhusu@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [X]  Pull Request title is properly formatted: [KIECLOUD-XYZ] Subject, [RHDM-XYZ] Subject or [RHPAM-XYZ] Subject
- [X]  Pull Request contains link to the JIRA issue
- [X]  Pull Request contains description of the issue
- [X]  Pull Request does not include fixes for issues other than the main ticket
- [X]  Attached commits represent units of work and are properly formatted
- [X]  You have read and agreed to the Developer Certificate of Origin (DCO) (see CONTRIBUTING.md)
- [X]  Every commit contains Signed-off-by: Your Name [yourname@example.com](mailto:yourname@example.com) - use git commit -s