### PR TITLE
[RHPAM-4167] Name of the property is wrongly set from console cr form

### DIFF
--- a/deploy/ui/form.json
+++ b/deploy/ui/form.json
@@ -58,8 +58,8 @@
             {
               "label": "Image Tags enabled",
               "type": "fieldGroup",
-              "jsonPath": "$.spec.useImageTags",
-              "originalJsonPath": "$.spec.useImageTags",
+              "jsonPath": "$.spec",
+              "originalJsonPath": "$.spec",
               "displayWhen": "true",
               "visible": false,
               "fields": [


### PR DESCRIPTION
Signed-off-by: Davide Salerno <dsalerno@redhat.com>

Cherry-pick: https://github.com/kiegroup/kie-cloud-operator/pull/795

See: [RHPAM-4167](https://issues.redhat.com/browse/RHPAM-4167?focusedCommentId=20453745&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-20453745)

The change is following what suggested in [this example](https://github.com/RHsyseng/console-cr-form/blob/be2aa15abde0792dfb00cd4427a9f64fe6095f2f/test/examples/full-form.json#L137) of the Custom Resource Form Generation module.
