### PR TITLE
[KIECLOUD-640] - Fix naming of deploy yaml files

### DIFF
--- a/deploy/cluster_role_binding.yaml
+++ b/deploy/cluster_role_binding.yaml
@@ -7,7 +7,6 @@ roleRef:
   kind: ClusterRole
   name: business-automation-operator
 subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: ServiceAccount
+- kind: ServiceAccount
   name: business-automation-operator
   namespace: placeholder

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -7,6 +7,5 @@ roleRef:
   kind: Role
   name: business-automation-operator
 subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: ServiceAccount
+- kind: ServiceAccount
   name: business-automation-operator


### PR DESCRIPTION
remove apiGroup from subjects on cluster role bind and role binding
subject definition

Signed-off-by: spolti <fspolti@redhat.com>