### PR TITLE
remove OCP 4.1.5 version from image curation list

### DIFF
--- a/deploy/olm-catalog/dev/7.13.5-1/manifests/businessautomation-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/dev/7.13.5-1/manifests/businessautomation-operator.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Integration & Delivery
     certified: "false"
     containerImage: quay.io/kiegroup/kie-cloud-operator:7.13.5
-    createdAt: "2024-02-28 14:32:08"
+    createdAt: "2024-02-29 11:37:35"
     description: Deploys and manages Red Hat Process Automation Manager and Red Hat
       Decision Manager environments.
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
@@ -20,7 +20,7 @@ metadata:
     operator-businessautomation: "true"
     operatorframework.io/arch.amd64: supported
     operatorframework.io/os.linux: supported
-  name: businessautomation-operator.7.13.5-1-dev-wgzql99gn9
+  name: businessautomation-operator.7.13.5-1-dev-vlbwcmgjjd
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -187,7 +187,7 @@ spec:
                 - name: RELATED_IMAGE_PAM_DASHBUILDER_IMAGE_7.13.5
                   value: registry.redhat.io/rhpam-7/rhpam-dashbuilder-rhel8:7.13.5
                 - name: RELATED_IMAGE_OSE_CLI_IMAGE_7.13.5
-                  value: registry.redhat.io/openshift4/ose-cli:v4.15
+                  value: registry.redhat.io/openshift4/ose-cli:v4.14
                 - name: RELATED_IMAGE_MYSQL_PROXY_IMAGE_7.13.5
                   value: registry.redhat.io/rhscl/mysql-80-rhel7:latest
                 - name: RELATED_IMAGE_POSTGRESQL_PROXY_IMAGE_7.13.5
@@ -211,7 +211,7 @@ spec:
                 - name: RELATED_IMAGE_PAM_DASHBUILDER_IMAGE_7.13.4
                   value: registry.redhat.io/rhpam-7/rhpam-dashbuilder-rhel8:7.13.4
                 - name: RELATED_IMAGE_OSE_CLI_IMAGE_7.13.4
-                  value: registry.redhat.io/openshift4/ose-cli:v4.15
+                  value: registry.redhat.io/openshift4/ose-cli:v4.14
                 - name: RELATED_IMAGE_MYSQL_PROXY_IMAGE_7.13.4
                   value: registry.redhat.io/rhscl/mysql-80-rhel7:latest
                 - name: RELATED_IMAGE_POSTGRESQL_PROXY_IMAGE_7.13.4
@@ -222,8 +222,6 @@ spec:
                   value: registry.redhat.io/amq7/amq-broker-rhel8:7.9
                 - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_LATEST
                   value: registry.redhat.io/openshift4/ose-oauth-proxy:latest
-                - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_4.15
-                  value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.15
                 - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_4.14
                   value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.14
                 - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_4.13
@@ -405,7 +403,7 @@ spec:
   - operator
   labels:
     alm-owner-businessautomation: businessautomation-operator
-    operated-by: businessautomation-operator.7.13.5-1-dev-wgzql99gn9
+    operated-by: businessautomation-operator.7.13.5-1-dev-vlbwcmgjjd
   links:
   - name: Product Page
     url: https://access.redhat.com/products/red-hat-process-automation-manager
@@ -421,5 +419,5 @@ spec:
   selector:
     matchLabels:
       alm-owner-businessautomation: businessautomation-operator
-      operated-by: businessautomation-operator.7.13.5-1-dev-wgzql99gn9
-  version: 7.13.5-1+wgzql99gn9
+      operated-by: businessautomation-operator.7.13.5-1-dev-vlbwcmgjjd
+  version: 7.13.5-1+vlbwcmgjjd

--- a/deploy/olm-catalog/prod/7.13.5-1/manifests/businessautomation-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/prod/7.13.5-1/manifests/businessautomation-operator.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Integration & Delivery
     certified: "true"
     containerImage: registry.stage.redhat.io/rhpam-7/rhpam-rhel8-operator:7.13.5
-    createdAt: "2024-02-28 14:32:08"
+    createdAt: "2024-02-29 11:37:35"
     description: Deploys and manages Red Hat Process Automation Manager and Red Hat
       Decision Manager environments.
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
@@ -187,7 +187,7 @@ spec:
                 - name: RELATED_IMAGE_PAM_DASHBUILDER_IMAGE_7.13.5
                   value: registry.stage.redhat.io/rhpam-7/rhpam-dashbuilder-rhel8:7.13.5
                 - name: RELATED_IMAGE_OSE_CLI_IMAGE_7.13.5
-                  value: registry.redhat.io/openshift4/ose-cli:v4.15
+                  value: registry.redhat.io/openshift4/ose-cli:v4.14
                 - name: RELATED_IMAGE_MYSQL_PROXY_IMAGE_7.13.5
                   value: registry.redhat.io/rhscl/mysql-80-rhel7:latest
                 - name: RELATED_IMAGE_POSTGRESQL_PROXY_IMAGE_7.13.5
@@ -211,7 +211,7 @@ spec:
                 - name: RELATED_IMAGE_PAM_DASHBUILDER_IMAGE_7.13.4
                   value: registry.redhat.io/rhpam-7/rhpam-dashbuilder-rhel8:7.13.4
                 - name: RELATED_IMAGE_OSE_CLI_IMAGE_7.13.4
-                  value: registry.redhat.io/openshift4/ose-cli:v4.15
+                  value: registry.redhat.io/openshift4/ose-cli:v4.14
                 - name: RELATED_IMAGE_MYSQL_PROXY_IMAGE_7.13.4
                   value: registry.redhat.io/rhscl/mysql-80-rhel7:latest
                 - name: RELATED_IMAGE_POSTGRESQL_PROXY_IMAGE_7.13.4
@@ -222,8 +222,6 @@ spec:
                   value: registry.redhat.io/amq7/amq-broker-rhel8:7.9
                 - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_LATEST
                   value: registry.redhat.io/openshift4/ose-oauth-proxy:latest
-                - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_4.15
-                  value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.15
                 - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_4.14
                   value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.14
                 - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_4.13

--- a/deploy/olm-catalog/test/7.13.5-1/manifests/businessautomation-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/test/7.13.5-1/manifests/businessautomation-operator.clusterserviceversion.yaml
@@ -7,7 +7,7 @@ metadata:
     categories: Integration & Delivery
     certified: "true"
     containerImage: registry-proxy.engineering.redhat.com/rh-osbs/rhpam-7-rhpam-rhel8-operator:7.13.5
-    createdAt: "2024-02-28 14:32:08"
+    createdAt: "2024-02-29 11:37:35"
     description: Deploys and manages Red Hat Process Automation Manager and Red Hat
       Decision Manager environments.
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
@@ -20,7 +20,7 @@ metadata:
     operator-businessautomation: "true"
     operatorframework.io/arch.amd64: supported
     operatorframework.io/os.linux: supported
-  name: businessautomation-operator.7.13.5-1-dev-nm2xx78wq8
+  name: businessautomation-operator.7.13.5-1-dev-p7t7h62z57
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -187,7 +187,7 @@ spec:
                 - name: RELATED_IMAGE_PAM_DASHBUILDER_IMAGE_7.13.5
                   value: registry-proxy.engineering.redhat.com/rhpam-7/rhpam-dashbuilder-rhel8:7.13.5
                 - name: RELATED_IMAGE_OSE_CLI_IMAGE_7.13.5
-                  value: registry.redhat.io/openshift4/ose-cli:v4.15
+                  value: registry.redhat.io/openshift4/ose-cli:v4.14
                 - name: RELATED_IMAGE_MYSQL_PROXY_IMAGE_7.13.5
                   value: registry.redhat.io/rhscl/mysql-80-rhel7:latest
                 - name: RELATED_IMAGE_POSTGRESQL_PROXY_IMAGE_7.13.5
@@ -211,7 +211,7 @@ spec:
                 - name: RELATED_IMAGE_PAM_DASHBUILDER_IMAGE_7.13.4
                   value: registry.redhat.io/rhpam-7/rhpam-dashbuilder-rhel8:7.13.4
                 - name: RELATED_IMAGE_OSE_CLI_IMAGE_7.13.4
-                  value: registry.redhat.io/openshift4/ose-cli:v4.15
+                  value: registry.redhat.io/openshift4/ose-cli:v4.14
                 - name: RELATED_IMAGE_MYSQL_PROXY_IMAGE_7.13.4
                   value: registry.redhat.io/rhscl/mysql-80-rhel7:latest
                 - name: RELATED_IMAGE_POSTGRESQL_PROXY_IMAGE_7.13.4
@@ -222,8 +222,6 @@ spec:
                   value: registry.redhat.io/amq7/amq-broker-rhel8:7.9
                 - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_LATEST
                   value: registry.redhat.io/openshift4/ose-oauth-proxy:latest
-                - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_4.15
-                  value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.15
                 - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_4.14
                   value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.14
                 - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_4.13
@@ -405,7 +403,7 @@ spec:
   - operator
   labels:
     alm-owner-businessautomation: businessautomation-operator
-    operated-by: businessautomation-operator.7.13.5-1-dev-nm2xx78wq8
+    operated-by: businessautomation-operator.7.13.5-1-dev-p7t7h62z57
   links:
   - name: Product Page
     url: https://access.redhat.com/products/red-hat-process-automation-manager
@@ -421,5 +419,5 @@ spec:
   selector:
     matchLabels:
       alm-owner-businessautomation: businessautomation-operator
-      operated-by: businessautomation-operator.7.13.5-1-dev-nm2xx78wq8
-  version: 7.13.5-1+nm2xx78wq8
+      operated-by: businessautomation-operator.7.13.5-1-dev-p7t7h62z57
+  version: 7.13.5-1+p7t7h62z57

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -52,7 +52,7 @@ spec:
         - name: RELATED_IMAGE_PAM_DASHBUILDER_IMAGE_7.13.5
           value: registry.redhat.io/rhpam-7/rhpam-dashbuilder-rhel8:7.13.5
         - name: RELATED_IMAGE_OSE_CLI_IMAGE_7.13.5
-          value: registry.redhat.io/openshift4/ose-cli:v4.15
+          value: registry.redhat.io/openshift4/ose-cli:v4.14
         - name: RELATED_IMAGE_MYSQL_PROXY_IMAGE_7.13.5
           value: registry.redhat.io/rhscl/mysql-80-rhel7:latest
         - name: RELATED_IMAGE_POSTGRESQL_PROXY_IMAGE_7.13.5
@@ -76,7 +76,7 @@ spec:
         - name: RELATED_IMAGE_PAM_DASHBUILDER_IMAGE_7.13.4
           value: registry.redhat.io/rhpam-7/rhpam-dashbuilder-rhel8:7.13.4
         - name: RELATED_IMAGE_OSE_CLI_IMAGE_7.13.4
-          value: registry.redhat.io/openshift4/ose-cli:v4.15
+          value: registry.redhat.io/openshift4/ose-cli:v4.14
         - name: RELATED_IMAGE_MYSQL_PROXY_IMAGE_7.13.4
           value: registry.redhat.io/rhscl/mysql-80-rhel7:latest
         - name: RELATED_IMAGE_POSTGRESQL_PROXY_IMAGE_7.13.4
@@ -87,8 +87,6 @@ spec:
           value: registry.redhat.io/amq7/amq-broker-rhel8:7.9
         - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_LATEST
           value: registry.redhat.io/openshift4/ose-oauth-proxy:latest
-        - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_4.15
-          value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.15
         - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_4.14
           value: registry.redhat.io/openshift4/ose-oauth-proxy:v4.14
         - name: RELATED_IMAGE_OAUTH_PROXY_IMAGE_4.13

--- a/pkg/controller/kieapp/constants/constants.go
+++ b/pkg/controller/kieapp/constants/constants.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Ocp4Versions - OpenShift minor versions used for image curation
-var Ocp4Versions = []string{"4.15", "4.14", "4.13", "4.12"}
+var Ocp4Versions = []string{"4.14", "4.13", "4.12"}
 
 const (
 	// CurrentVersion product version supported


### PR DESCRIPTION
Currently the build fails with error:

`Unable to fetch v2.manifest_list for [registry.redhat.io/openshift4/ose-oauth-proxy:v4.15](http://registry.redhat.io/openshift4/ose-oauth-proxy:v4.15);`

It seems this image is only on rhel-9, so as it is just for "image curation" remove it from now.