### PR TITLE
Bump go-toolset image to 1.19.9

### DIFF
--- a/image-prod.yaml
+++ b/image-prod.yaml
@@ -2,7 +2,7 @@
   name: "builder"
   description: "Golang builder image"
   version: ""
-  from: "registry.redhat.io/ubi8/go-toolset:1.17.7"
+  from: "registry.redhat.io/ubi8/go-toolset:1.19.9"
   modules:
     repositories:
       - path: modules/builder-prod

--- a/image.yaml
+++ b/image.yaml
@@ -2,7 +2,7 @@
   name: "builder"
   description: "Golang builder image"
   version: ""
-  from: "registry.redhat.io/ubi8/go-toolset:1.17.7"
+  from: "registry.redhat.io/ubi8/go-toolset:1.19.9"
   modules:
     repositories:
       - name: builder


### PR DESCRIPTION
Bumping the go-toolset image tag to resolve CVE-2023-24540 html/template.