### PR TITLE
Bump go-toolset image to 1.20.12

### DIFF
--- a/image-prod.yaml
+++ b/image-prod.yaml
@@ -2,7 +2,7 @@
   name: "builder"
   description: "Golang builder image"
   version: ""
-  from: "registry.redhat.io/ubi8/go-toolset:1.19.9"
+  from: "registry.redhat.io/ubi8/go-toolset:1.20.12"
   modules:
     repositories:
       - path: modules/builder-prod

--- a/image.yaml
+++ b/image.yaml
@@ -2,7 +2,7 @@
   name: "builder"
   description: "Golang builder image"
   version: ""
-  from: "registry.redhat.io/ubi8/go-toolset:1.19.9"
+  from: "registry.redhat.io/ubi8/go-toolset:1.20.12"
   modules:
     repositories:
       - name: builder


### PR DESCRIPTION
Another bump after #985 , 1.19.9 is vulnerable with
CVE-2023-39319
CVE-2023-39318
Both are fixed in 1.20.8, and here I am bumping to most recent 1.20 tag of go-toolset image.

























































