### PR TITLE
[DBACLD-168351] KIE app operators remain in the provisioning state

### DIFF
--- a/pkg/controller/kieapp/deploy_ui.go
+++ b/pkg/controller/kieapp/deploy_ui.go
@@ -438,7 +438,7 @@ func getServiceAccount(namespace string) *corev1.ServiceAccount {
 			Namespace: namespace,
 			Labels:    labels,
 			Annotations: map[string]string{
-				"serviceaccounts.openshift.io/oauth-redirectreference.primary": string(annotation),
+				"serviceaccounts.openshift.io/internal-registry-pull-secret-ref:console-cr-form-dockercfg-serviceaccounts.openshift.io/oauth-redirectreference.primary": string(annotation),
 			},
 		},
 	}


### PR DESCRIPTION
Kieapp continuously remain in 'provisioning' state  after making any changes. They are not able to make any changes to applications due to this but their existing deployments seem to be working fine.
